### PR TITLE
Initialize Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
   "contributors": [],
   "license": "MIT",
   "scripts": {
-    "build": "shx rm -rf dist && webpack && pkg dist/spk.js && shx mv spk-* dist",
+    "build": "shx rm -rf dist && webpack && pkg dist/spk.js && shx mv spk-{linux,macos,win.exe} dist",
     "test": "jest",
     "test-watch": "jest --watchAll"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/js-yaml": "^3.12.1",
     "@types/node": "^12.7.4",
     "@types/shelljs": "^0.8.5",
+    "@types/uuid": "^3.4.5",
     "husky": ">=1",
     "jest": "^24.9.0",
     "lint-staged": ">=8",
@@ -44,7 +46,9 @@
   },
   "dependencies": {
     "commander": "^3.0.1",
+    "js-yaml": "^3.13.1",
     "shelljs": "^0.8.3",
+    "uuid": "^3.3.3",
     "winston": "^3.2.1"
   }
 }

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,0 +1,67 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import shell from "shelljs";
+import uuid from "uuid/v4";
+import { disableVerboseLogging, enableVerboseLogging } from "../logger";
+import { initialize } from "./init";
+
+beforeAll(() => {
+  enableVerboseLogging();
+});
+
+afterAll(() => {
+  disableVerboseLogging();
+});
+
+test("bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml gets generated on init for non mono-repo", async () => {
+  // Create random directory to initialize
+  const randomTmpDir = path.join(os.tmpdir(), uuid());
+  fs.mkdirSync(randomTmpDir);
+
+  // init
+  await initialize(randomTmpDir);
+
+  // Ensure all necessary are created
+  const filepaths = [
+    "bedrock.yaml",
+    "maintainers.yaml",
+    "azure-pipelines.yaml"
+  ].map(filename => path.join(randomTmpDir, filename));
+
+  for (const filepath of filepaths) {
+    expect(fs.existsSync(filepath)).toBe(true);
+  }
+});
+
+test("bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml gets generated for all package directories in a mono-repo", async () => {
+  const randomTmpDir = path.join(os.tmpdir(), uuid());
+  fs.mkdirSync(randomTmpDir);
+
+  // Create 3 empty stub project
+  const randomPackagesDir = uuid();
+  const randomSubProjectDirs = Array.from({ length: 3 }, (_, i) => {
+    const projectDir = path.join(randomTmpDir, randomPackagesDir, i.toString());
+    expect(shell.mkdir("-p", projectDir).code).toBe(0);
+    return projectDir;
+  });
+
+  // Initialize the monorepo
+  await initialize(randomTmpDir, {
+    monoRepo: true,
+    packagesDir: randomPackagesDir
+  });
+
+  for (const subProjectDir of randomSubProjectDirs) {
+    // Ensure all sub-projects have the necessary files
+    const filepaths = [
+      "bedrock.yaml",
+      "maintainers.yaml",
+      "azure-pipelines.yaml"
+    ].map(filename => path.join(subProjectDir, filename));
+
+    for (const filepath of filepaths) {
+      expect(fs.existsSync(filepath)).toBe(true);
+    }
+  }
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,290 @@
+import commander from "commander";
+import fs from "fs";
+import yaml from "js-yaml";
+import path from "path";
+import shell from "shelljs";
+import { promisify } from "util";
+import { logger } from "../logger";
+import { IBedrockFile, IMaintainersFile } from "../types";
+
+/**
+ * Adds the init command to the commander command object
+ *
+ * @param command Commander command object to decorate
+ */
+export const initCommand = (command: commander.Command): void => {
+  command
+    .command("init")
+    .alias("i")
+    .description(
+      "Initialize your spk repository. Will add starter bedrock, maintainers, and azure-pipelines YAML files to your project."
+    )
+    .option(
+      "-m, --mono-repo",
+      "Initialize this repository as a mono-repo. All directories under `packages` (modifiable with `-d` flag) will be initialized as packages.",
+      false
+    )
+    .option(
+      "-d, --packages-dir <dir>",
+      "The directory containing the mono-repo packages. This is a noop if `-m` not set.",
+      "packages"
+    )
+    .action(async opts => {
+      const { monoRepo = false, packagesDir = "packages" } = opts;
+      const projectPath = process.cwd();
+      try {
+        // Type check all parsed command line args here.
+        if (typeof monoRepo !== "boolean") {
+          throw new Error(
+            `monoRepo must be of type boolean, ${typeof monoRepo} given.`
+          );
+        }
+        if (typeof packagesDir !== "string") {
+          throw new Error(
+            `packagesDir must be of type 'string', ${typeof packagesDir} given.`
+          );
+        }
+        await initialize(projectPath, { monoRepo, packagesDir });
+      } catch (err) {
+        logger.error(
+          `Error occurred while initializing project ${projectPath}`
+        );
+        logger.error(err);
+      }
+    });
+};
+
+/**
+ * Initializes the `rootProject` with a bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml file
+ * If opts.monoRepo == true, the root directly will be initialized as a mono-repo
+ * If opts.monoRepo == true, all direct subdirectories under opts.packagesDir will be initialized as individual projects
+ *
+ * @param rootProject Project root directory which will get initialized
+ * @param opts Extra options to pass to initialize
+ */
+export const initialize = async (
+  rootProject: string,
+  opts?: { monoRepo: boolean; packagesDir?: string }
+) => {
+  const { monoRepo = false, packagesDir = "packages" } = opts || {};
+  logger.info(
+    `Initializing project ${rootProject}${monoRepo ? " as a mono-repo" : ""}`
+  );
+
+  // Get a list of the target paths to initialize
+  let projectPaths = [path.resolve(rootProject)];
+  if (monoRepo) {
+    const packages = path.join(rootProject, packagesDir);
+    const lsRet = shell.ls(packages);
+    if (lsRet.code !== 0) {
+      throw new Error(`Error parsing listing files in ${packages}`);
+    }
+
+    projectPaths = lsRet
+      .map(p => path.join(rootProject, packagesDir, p))
+      .filter(out => typeof out === "string" && fs.statSync(out).isDirectory());
+  }
+
+  // Initialize all paths
+  for (const projectPath of projectPaths) {
+    await Promise.all([
+      generateBedrockFile(projectPath),
+      generateMaintainersFile(projectPath),
+      generateAzurePipelinesYaml(projectPath)
+    ]);
+  }
+
+  logger.info(`Project initialization complete!`);
+};
+
+/**
+ * Writes out a default maintainers.yaml file
+ *
+ * @param targetPath Path to generate the maintainers.yaml file
+ */
+const generateMaintainersFile = async (targetPath: string = "") => {
+  const absPath = path.resolve(targetPath);
+  logger.info(`Generating maintainers.yaml file in ${absPath}`);
+
+  // Get default name/email from git host
+  const [gitName, gitEmail] = await Promise.all(
+    ["name", "email"].map(field => {
+      return new Promise<string>(resolve => {
+        shell.exec(
+          `git config user.${field}`,
+          { silent: true },
+          (code, stdout) => {
+            if (code === 0) {
+              return resolve(stdout.trim());
+            }
+            logger.warn(
+              `Unable to parse git.${field} from host. Leaving blank value in maintainers.yaml file`
+            );
+            return resolve("");
+          }
+        );
+      });
+    })
+  );
+
+  // Populate maintainers file
+  const maintainersFile: IMaintainersFile = {
+    maintainers: [
+      {
+        email: gitEmail,
+        name: gitName
+      }
+    ]
+  };
+
+  // Check if a maintainer.yaml already exists; skip write if present
+  const maintainersFilePath = path.join(absPath, "maintainers.yaml");
+  logger.debug(`Writing maintainers.yaml file to ${maintainersFilePath}`);
+  if (fs.existsSync(maintainersFilePath)) {
+    logger.warn(
+      `Existing maintainers.yaml found at ${maintainersFilePath}, skipping generation`
+    );
+  } else {
+    // Write out
+    await promisify(fs.writeFile)(
+      maintainersFilePath,
+      yaml.safeDump(maintainersFile),
+      "utf8"
+    );
+  }
+};
+
+/**
+ * Writes out a default bedrock.yaml
+ *
+ * @param targetPath Path to generate the the bedrock.yaml file in
+ */
+const generateBedrockFile = async (targetPath: string = "") => {
+  const absPath = path.resolve(targetPath);
+  logger.info(`Generating bedrock.yaml file in ${absPath}`);
+
+  // Populate bedrock file
+  const bedrockFile: IBedrockFile = {
+    helm: { chart: { git: "", branch: "", path: "" } }
+  };
+
+  // Check if a bedrock.yaml already exists; skip write if present
+  const bedrockFilePath = path.join(absPath, "bedrock.yaml");
+  logger.debug(`Writing bedrock.yaml file to ${bedrockFilePath}`);
+  if (fs.existsSync(bedrockFilePath)) {
+    logger.warn(
+      `Existing bedrock.yaml found at ${bedrockFilePath}, skipping generation`
+    );
+  } else {
+    // Write out
+    await promisify(fs.writeFile)(
+      bedrockFilePath,
+      yaml.safeDump(bedrockFile),
+      "utf8"
+    );
+  }
+};
+
+/**
+ * Writes out the starter azure-pipelines.yaml file to `targetPath`
+ *
+ * @param targetPath Path to write the azure-pipelines.yaml file to
+ */
+const generateAzurePipelinesYaml = async (targetPath: string = "") => {
+  const absTargetPath = path.resolve(targetPath);
+  logger.info(`Generating starter azure-pipelines.yaml in ${absTargetPath}`);
+
+  // Check if azure-pipelines.yaml already exists; if it does, skip generation
+  const azurePipelinesYamlPath = path.join(
+    absTargetPath,
+    "azure-pipelines.yaml"
+  );
+  logger.debug(
+    `Writing azure-pipelines.yaml file to ${azurePipelinesYamlPath}`
+  );
+  if (fs.existsSync(azurePipelinesYamlPath)) {
+    logger.warn(
+      `Existing azure-pipelines.yaml found at ${azurePipelinesYamlPath}, skipping generation`
+    );
+  } else {
+    const starterYaml = await starterAzurePipelines({
+      relProjectPaths: [path.relative(process.cwd(), absTargetPath)]
+    });
+    // Write
+    await promisify(fs.writeFile)(azurePipelinesYamlPath, starterYaml, "utf8");
+  }
+};
+
+/**
+ * Returns a starter azure-pipelines.yaml string
+ * Starter azure-pipelines.yaml based on: https://github.com/andrebriggs/monorepo-example/blob/master/service-A/azure-pipelines.yml
+ *
+ * @param opts Template options to pass to the the starter yaml
+ */
+const starterAzurePipelines = async (opts: {
+  relProjectPaths?: string[];
+  vmImage?: string;
+  branches?: string[];
+  varGroups?: string[];
+}) => {
+  const {
+    relProjectPaths = ["."],
+    vmImage = "ubuntu-latest",
+    branches = ["master"],
+    varGroups = []
+  } = opts;
+
+  // Helper to concat list of script commands to a multi line string
+  const generateYamlScript = (lines: string[]): string => lines.join("\n");
+
+  // Ensure any blank paths are turned into "./"
+  const cleanedPaths = relProjectPaths.map(p => (p === "" ? "./" : p));
+
+  // based on https://github.com/andrebriggs/monorepo-example/blob/master/service-A/azure-pipelines.yml
+  const starter = {
+    trigger: {
+      branches: { include: branches },
+      paths: { include: cleanedPaths }
+    },
+    variables: {
+      group: varGroups
+    },
+    pool: {
+      vmImage
+    },
+    steps: [
+      {
+        displayName: "Run a multi-line script",
+        script: generateYamlScript([
+          `printenv | sort`,
+          `pwd`,
+          `ls -la`,
+          `echo "The name of this service is: $(BUILD.BUILDNUMBER)"`
+        ])
+      },
+      {
+        displayName: "Azure Login",
+        script: generateYamlScript([
+          `echo "az login --service-principal --username $(SP_APP_ID) --password $(SP_PASS) --tenant $(SP_TENANT)"`,
+          `az login --service-principal --username "$(SP_APP_ID)" --password "$(SP_PASS)" --tenant "$(SP_TENANT)"`
+        ])
+      },
+      ...cleanedPaths.map(projectPath => {
+        return {
+          displayName: "ACR Build and Publish",
+          script: generateYamlScript([
+            `cd ${projectPath} #Hardcoded path. Need to make sure Build.DefinitionName matches directory. It's case sensitive`,
+            `echo "az acr build -r $(ACR_NAME) --image $(Build.DefinitionName):$(build.SourceBranchName)-$(build.BuildId) ."`,
+            `az acr build -r $(ACR_NAME) --image $(Build.DefinitionName):$(build.SourceBranchName)-$(build.BuildId) .`
+          ])
+        };
+      }),
+      {
+        displayName: "Run a one-line script",
+        script: generateYamlScript([`echo Hello, world!`])
+      }
+    ]
+  };
+
+  return yaml.safeDump(starter, { lineWidth: Number.MAX_SAFE_INTEGER });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,28 +12,33 @@
  */
 import commander from "commander";
 import { addCommand } from "./commands/add";
+import { initCommand } from "./commands/init";
 import { shellCommand } from "./commands/shell";
-import { logger } from "./logger";
+import { enableVerboseLogging, logger } from "./logger";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Instantiate core command object
 ////////////////////////////////////////////////////////////////////////////////
 const command = new commander.Command()
   .version((() => require("../package.json").version)())
-  .option("-v, --verbose", "verbose logging");
+  .option("-v, --verbose", "verbose logging")
+  .on("option:verbose", () => {
+    enableVerboseLogging();
+  });
 
 ////////////////////////////////////////////////////////////////////////////////
-// Add decorators here
+// Add commands/decorators here
 ////////////////////////////////////////////////////////////////////////////////
+initCommand(command);
 shellCommand(command);
 addCommand(command);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Catch-all for unknown commands
 ////////////////////////////////////////////////////////////////////////////////
-command.command("*").action(cmd => {
+command.on("command:*", cmd => {
   logger.error(`Unknown command "${cmd}"`);
-  cmd.outputHelp();
+  command.outputHelp();
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/logger/index.test.ts
+++ b/src/logger/index.test.ts
@@ -1,31 +1,58 @@
 import fs from "fs";
 import path from "path";
-import { logger } from ".";
+import uuid from "uuid/v4";
+import { enableVerboseLogging, logger, disableVerboseLogging } from ".";
 
-test("A new info log gets added to the combined log", () => {
-  const randomString = Math.random()
-    .toString(36)
-    .replace(/[^a-z]+/g, "")
-    .substr(0, 5);
+const logFile = path.join(process.cwd(), "spk.log");
+
+test("A new info log gets added to logs", () => {
+  const randomString = uuid();
+
+  // should appear in combined log file
   logger.info(randomString, () => {
-    expect(
-      fs.readFileSync(path.join(process.cwd(), "spk-combined.log"), {
-        encoding: "utf8"
-      })
-    ).toMatch(new RegExp(`.+${randomString}.+`, "s"));
+    expect(fs.readFileSync(logFile, "utf8")).toMatch(
+      new RegExp(`.+${randomString}.+`, "s")
+    );
   });
 });
 
-test("A new error log gets added to the error log", () => {
-  const randomString = Math.random()
-    .toString(36)
-    .replace(/[^a-z]+/g, "")
-    .substr(0, 5);
+test("A new error log gets added to logs", () => {
+  const randomString = uuid();
+
+  // should appear in error log file
   logger.error(randomString, () => {
-    expect(
-      fs.readFileSync(path.join(process.cwd(), "spk-error.log"), {
-        encoding: "utf8"
-      })
-    ).toMatch(new RegExp(`.+${randomString}.+`, "s"));
+    expect(fs.readFileSync(logFile, "utf8")).toMatch(
+      new RegExp(`.+${randomString}.+`, "s")
+    );
+  });
+});
+
+test("Set verbose logging", () => {
+  const randomString = uuid();
+
+  // debug logs should not appear in logs
+  logger.debug(randomString, () => {
+    expect(fs.readFileSync(logFile, "utf8")).not.toMatch(
+      new RegExp(`.+${randomString}.+`, "s")
+    );
+  });
+
+  enableVerboseLogging();
+
+  // debug logs should now appear in logs
+  logger.debug(randomString, () => {
+    expect(fs.readFileSync(logFile, "utf8")).toMatch(
+      new RegExp(`.+${randomString}.+`, "s")
+    );
+  });
+
+  disableVerboseLogging();
+
+  // debug logs should now not appear in logs
+  const newRandomString = uuid();
+  logger.debug(newRandomString, () => {
+    expect(fs.readFileSync(logFile, "utf8")).not.toMatch(
+      new RegExp(`.+${newRandomString}.+`, "s")
+    );
   });
 });

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,27 +1,28 @@
-// Ripped & edited from: https://github.com/winstonjs/winston/blob/master/examples/quick-start.js
 import { createLogger, format, transports } from "winston";
 
 // tslint:disable:object-literal-sort-keys
+// visit https://github.com/winstonjs/logform for format options
 export const logger = createLogger({
   level: "info",
-  format: format.combine(
-    format.timestamp({
-      format: "YYYY-MM-DD HH:mm:ss"
-    }),
-    format.errors({ stack: true }),
-    format.splat(),
-    format.json()
-  ),
+  format: format.combine(format.timestamp(), format.errors({ stack: true })),
   defaultMeta: { service: "spk" },
   transports: [
-    //
-    // - Write to all logs with level `info` and below to `combined.log`
-    // - Write all logs error (and below) to `error.log`.
-    //
-    new transports.File({ filename: "spk-error.log", level: "error" }),
-    new transports.File({ filename: "spk-combined.log" }),
+    new transports.File({
+      filename: "spk.log",
+      format: format.simple()
+    }),
     new transports.Console({
-      format: format.combine(format.colorize(), format.simple())
+      format: format.cli()
     })
   ]
 });
+
+export const enableVerboseLogging = () => {
+  logger.info("Enabling verbose logging");
+  logger.level = "silly";
+};
+
+export const disableVerboseLogging = () => {
+  logger.info("Disabling verbose logging");
+  logger.level = "info";
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,29 @@
+export interface IMaintainersFile {
+  maintainers: Array<{
+    name: string;
+    email: string;
+    website?: string;
+  }>;
+}
+
+export interface IBedrockFile {
+  helm: {
+    chart:
+      | {
+          repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
+          chart: string; // chart name (eg; zookeeper)
+        }
+      | ({
+          git: string; // git url to clone (eg; https://github.com/helm/charts.git)
+          path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
+        } & (
+          | {
+              sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)
+              tag?: string; // indicate the semantics of the sha (eg; v1.0.2)
+            }
+          | {
+              branch: string; // branch to checkout (eg; master)
+            }
+        ));
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,17 +10,17 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.1.0":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
-  integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
+  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.5.5"
-    "@babel/helpers" "^7.5.5"
-    "@babel/parser" "^7.5.5"
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helpers" "^7.6.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -29,12 +29,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
-  integrity sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+"@babel/generator@^7.4.0", "@babel/generator@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
+  integrity sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==
   dependencies:
-    "@babel/types" "^7.5.5"
+    "@babel/types" "^7.6.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -68,14 +68,14 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
-"@babel/helpers@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.5.5.tgz#63908d2a73942229d1e6685bc2a0e730dde3b75e"
-  integrity sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==
+"@babel/helpers@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
+  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
   dependencies:
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
 
 "@babel/highlight@^7.0.0":
   version "7.5.0"
@@ -86,10 +86,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.5.5":
+"@babel/parser@^7.1.0", "@babel/parser@^7.4.3":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
   integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
+
+"@babel/parser@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
+  integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
 
 "@babel/parser@~7.4.4":
   version "7.4.5"
@@ -110,34 +115,34 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
-  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
+  integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
-  integrity sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
+  integrity sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.5.5"
+    "@babel/generator" "^7.6.0"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
-  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -419,6 +424,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/js-yaml@^3.12.1":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.1.tgz#5c6f4a1eabca84792fbd916f0cb40847f123c656"
+  integrity sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -446,6 +456,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/uuid@^3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
+  integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -2614,9 +2631,9 @@ iferr@^0.1.5:
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
 ignore-walk@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
-  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.2.tgz#99d83a246c196ea5c93ef9315ad7b0819c35069b"
+  integrity sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==
   dependencies:
     minimatch "^3.0.4"
 
@@ -5526,9 +5543,9 @@ terser-webpack-plugin@^1.4.1:
     worker-farm "^1.7.0"
 
 terser@^4.1.2:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.2.1.tgz#1052cfe17576c66e7bc70fcc7119f22b155bdac1"
-  integrity sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.0.tgz#0259070576ff34d89c5cd2b8d91055cdce0212d5"
+  integrity sha512-w5CzrvQOwYAH54aG22IrUJI4yX1w62XQmMdEOM6H4w0ii6rc3HJ89fmcOGN5mRwBWfUgaqO7RJTp4aoY/uE+qQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -5871,7 +5888,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
- Added `init|i` command which will initialize a repository as either a basic or mono-repo based on the `-m` flag
- Cleaned up logging to be all output to a single `spk.log` file

The initialize command will automatically generate a bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml for either the root directory it is run on or for all subdirectories under the directory specified by the `-d` (short form for `--packages-dir`) option (defaults to: 'packages/') if `-m` (short form for `--mono-repo` is passed as well.

Resolves https://github.com/microsoft/bedrock/issues/581