### PR TITLE
Single project-wide bedrock & maintainers yaml files

### DIFF
--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -14,54 +14,73 @@ afterAll(() => {
   disableVerboseLogging();
 });
 
-test("bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml gets generated on init for non mono-repo", async () => {
-  // Create random directory to initialize
-  const randomTmpDir = path.join(os.tmpdir(), uuid());
-  fs.mkdirSync(randomTmpDir);
+describe("Initializing a blank standard repo", () => {
+  test("bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml gets generated in the project root on init for standard repository", async () => {
+    // Create random directory to initialize
+    const randomTmpDir = path.join(os.tmpdir(), uuid());
+    fs.mkdirSync(randomTmpDir);
 
-  // init
-  await initialize(randomTmpDir);
+    // init
+    await initialize(randomTmpDir);
 
-  // Ensure all necessary are created
-  const filepaths = [
-    "bedrock.yaml",
-    "maintainers.yaml",
-    "azure-pipelines.yaml"
-  ].map(filename => path.join(randomTmpDir, filename));
-
-  for (const filepath of filepaths) {
-    expect(fs.existsSync(filepath)).toBe(true);
-  }
-});
-
-test("bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml gets generated for all package directories in a mono-repo", async () => {
-  const randomTmpDir = path.join(os.tmpdir(), uuid());
-  fs.mkdirSync(randomTmpDir);
-
-  // Create 3 empty stub project
-  const randomPackagesDir = uuid();
-  const randomSubProjectDirs = Array.from({ length: 3 }, (_, i) => {
-    const projectDir = path.join(randomTmpDir, randomPackagesDir, i.toString());
-    expect(shell.mkdir("-p", projectDir).code).toBe(0);
-    return projectDir;
-  });
-
-  // Initialize the monorepo
-  await initialize(randomTmpDir, {
-    monoRepo: true,
-    packagesDir: randomPackagesDir
-  });
-
-  for (const subProjectDir of randomSubProjectDirs) {
-    // Ensure all sub-projects have the necessary files
+    // bedrock.yaml, maintainers.yaml, and azure-pipelines.yaml should be in a the root for a 'standard' project
     const filepaths = [
       "bedrock.yaml",
       "maintainers.yaml",
       "azure-pipelines.yaml"
-    ].map(filename => path.join(subProjectDir, filename));
+    ].map(filename => path.join(randomTmpDir, filename));
 
     for (const filepath of filepaths) {
       expect(fs.existsSync(filepath)).toBe(true);
     }
-  }
+  });
+});
+
+describe("Initializing a blank mono-repo", () => {
+  test("bedrock.yaml and maintainers.yaml get generated in the project root and azure-pipelines.yaml gets generated in all package directories in a mono-repo", async () => {
+    const randomTmpDir = path.join(os.tmpdir(), uuid());
+    fs.mkdirSync(randomTmpDir);
+
+    // Create some empty service directories
+    const randomPackagesDir = uuid();
+    const randomSubProjectDirs = Array.from({ length: 3 }, (_, i) => {
+      const projectDir = path.join(
+        randomTmpDir,
+        randomPackagesDir,
+        i.toString()
+      );
+      expect(shell.mkdir("-p", projectDir).code).toBe(0);
+      return projectDir;
+    });
+
+    // Initialize the monorepo
+    await initialize(randomTmpDir, {
+      monoRepo: true,
+      packagesDir: randomPackagesDir
+    });
+
+    // root should have bedrock.yaml and maintainers.yaml and should not be in the the package dirs
+    for (const file of ["bedrock.yaml", "maintainers.yaml"]) {
+      const filepath = path.join(randomTmpDir, file);
+      // Should be in package dir
+      expect(fs.existsSync(filepath)).toBe(true);
+
+      // Should not be in project-root dir
+      for (const subProjectDir of randomSubProjectDirs) {
+        const filepathInPackage = path.join(subProjectDir, file);
+        expect(fs.existsSync(filepathInPackage)).toBe(false);
+      }
+    }
+
+    // All package directories should have an azure-pipelines.yaml
+    for (const subProjectDir of randomSubProjectDirs) {
+      const filepath = path.join(subProjectDir, "azure-pipelines.yaml");
+      expect(fs.existsSync(filepath)).toBe(true);
+    }
+
+    // azure-pipelines.yaml should not be in the root
+    expect(fs.existsSync(path.join(randomTmpDir, "azure-pipelines.yaml"))).toBe(
+      false
+    );
+  });
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,29 +1,74 @@
+/**
+ * Maintainers file
+ */
 export interface IMaintainersFile {
-  maintainers: Array<{
-    name: string;
-    email: string;
-    website?: string;
-  }>;
+  services: {
+    [relativeDirectory: string]: {
+      maintainers: IUser[];
+      contributors?: IUser[];
+    };
+  };
 }
 
+interface IUser {
+  name: string;
+  email: string;
+  website?: string;
+}
+
+/**
+ * Bedrock config file
+ * Used to capture service meta-information regarding how to deploy
+ */
 export interface IBedrockFile {
-  helm: {
-    chart:
-      | {
-          repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
-          chart: string; // chart name (eg; zookeeper)
-        }
-      | ({
-          git: string; // git url to clone (eg; https://github.com/helm/charts.git)
-          path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
-        } & (
+  services: {
+    [relativeDirectory: string]: {
+      helm: {
+        chart:
           | {
-              sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)
-              tag?: string; // indicate the semantics of the sha (eg; v1.0.2)
+              repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
+              chart: string; // chart name (eg; zookeeper)
             }
-          | {
-              branch: string; // branch to checkout (eg; master)
-            }
-        ));
+          | ({
+              git: string; // git url to clone (eg; https://github.com/helm/charts.git)
+              path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
+            } & (
+              | {
+                  sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)
+                  tag?: string; // indicate the semantics of the sha (eg; v1.0.2)
+                }
+              | {
+                  branch: string; // branch to checkout (eg; master)
+                }
+            ));
+      };
+    };
   };
+}
+
+/**
+ * Basic AzurePipelines Interface
+ * @see https://github.com/andrebriggs/monorepo-example/blob/master/service-A/azure-pipelines.yml
+ */
+export interface IAzurePipelinesYaml {
+  trigger?: {
+    branches?: {
+      include?: string[];
+      exclude?: string[];
+    };
+    paths?: {
+      include?: string[];
+      exclude?: string[];
+    };
+  };
+  variables?: {
+    group?: string[];
+  };
+  pool?: {
+    vmImage?: string;
+  };
+  steps?: Array<{
+    displayName?: string;
+    script?: string;
+  }>;
 }


### PR DESCRIPTION
- bedrock.yaml and maintainers.yaml are now only stored in the root directory and are stored as maps keyed on the relative directory to the service.
- azure-pipelines.yaml remains the same; created in every package directory (or project-root if not a mono-repo).

The new structure for mono-repos is:

- my-mono-repo/
  - bedrock.yaml
  - maintainers.yaml
  - packages/
    - service-a/
      - azure-pipelines.yaml
    - service-b/
      - azure-pipelines.yaml
    - service-c/
      - azure-pipelines.yaml

bedrock.yaml for this would look like:

```yaml
services:
  ./packages/service-a:
    helm:
      chart:
        git: ''
        branch: ''
        path: ''
  ./packages/service-b:
    helm:
      chart:
        git: ''
        branch: ''
        path: ''
  ./packages/service-c:
    helm:
      chart:
        git: ''
        branch: ''
        path: ''
```

maintainers.yaml for this would look like:

```yaml
services:
  ./:
    maintainers:
      - email: evan.louie@microsoft.com
        name: Evan Louie
  ./packages/service-a:
    maintainers:
      - email: ''
        name: ''
  ./packages/service-b:
    maintainers:
      - email: ''
        name: ''
  ./packages/service-c:
    maintainers:
      - email: ''
        name: ''
```

The only difference when dealing with a single service repository is that the only key generated in the maps would be `./`

Refer to `./src/types.d.ts` to see the structural changes made to bedrock.yaml and maintainers.yaml

@andrebriggs heads up