### PR TITLE
`spk deployment`: Adding init and get commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test-watch": "jest --watchAll"
   },
   "devDependencies": {
+    "@types/cli-table": "^0.3.0",
     "@types/jest": "^24.0.18",
     "@types/js-yaml": "^3.12.1",
     "@types/node": "^12.7.4",
@@ -45,13 +46,9 @@
     ]
   },
   "dependencies": {
-    "@types/cli-table": "^0.3.0",
     "cli-table": "^0.3.1",
     "commander": "^3.0.1",
-    "fs": "0.0.1-security",
     "js-yaml": "^3.13.1",
-    "open": "^6.4.0",
-    "os": "^0.1.1",
     "shelljs": "^0.8.3",
     "spektate": "^0.1.2",
     "uuid": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,15 @@
     ]
   },
   "dependencies": {
+    "@types/cli-table": "^0.3.0",
+    "cli-table": "^0.3.1",
     "commander": "^3.0.1",
+    "fs": "0.0.1-security",
     "js-yaml": "^3.13.1",
+    "open": "^6.4.0",
+    "os": "^0.1.1",
     "shelljs": "^0.8.3",
+    "spektate": "^0.1.2",
     "uuid": "^3.3.3",
     "winston": "^3.2.1"
   }

--- a/src/commands/deployment/get.ts
+++ b/src/commands/deployment/get.ts
@@ -2,6 +2,10 @@ import commander from "commander";
 import { logger } from "../../logger";
 import { Helper, OUTPUT_FORMAT } from "./helper";
 
+/**
+ * Adds the get command to the commander command object
+ * @param command Commander command object to decorate
+ */
 export const getCommandDecorator = (command: commander.Command): void => {
   command
     .command("get")
@@ -52,6 +56,10 @@ export const getCommandDecorator = (command: commander.Command): void => {
     });
 };
 
+/**
+ * Processes the output format based on defaults
+ * @param outputFormat Output format specified by the user
+ */
 function processOutputFormat(outputFormat: string): OUTPUT_FORMAT {
   if (outputFormat && outputFormat.toLowerCase() === "wide") {
     return OUTPUT_FORMAT.WIDE;

--- a/src/commands/deployment/get.ts
+++ b/src/commands/deployment/get.ts
@@ -1,0 +1,63 @@
+import commander from "commander";
+import { logger } from "../../logger";
+import { Helper, OUTPUT_FORMAT } from "./helper";
+
+export const getCommandDecorator = (command: commander.Command): void => {
+  command
+    .command("get")
+    .alias("g")
+    .description(
+      "Get deployment(s) for a service, release environment, build Id, commit Id, or image tag."
+    )
+    .option(
+      "-b, --build-id <build-id>",
+      "Get deployments for a particular build Id from source repository"
+    )
+    .option(
+      "-c, --commit-id <commit-id>",
+      "Get deployments for a particular commit Id from source repository"
+    )
+    .option(
+      "-i, --image-tag <image-tag>",
+      "Get deployments for a particular image tag"
+    )
+    .option(
+      "-e, --env <environment>",
+      "Get deployments for a particular environment"
+    )
+    .option(
+      "-s, --service <service-name>",
+      "Get deployments for a particular service"
+    )
+    .option(
+      "-o, --output <output-format>",
+      "Get output in one of these forms: normal, wide, JSON"
+    )
+    .action(async opts => {
+      try {
+        Helper.verifyAppConfiguration(() => {
+          Helper.getDeployments(
+            processOutputFormat(opts.output),
+            opts.env,
+            opts.imageTag,
+            opts.buildId,
+            opts.commitId,
+            opts.service
+          );
+        });
+      } catch (err) {
+        logger.error(`Error occurred while getting deployment(s)`);
+        logger.error(err);
+      }
+    });
+};
+
+function processOutputFormat(outputFormat: string): OUTPUT_FORMAT {
+  if (outputFormat && outputFormat.toLowerCase() === "wide") {
+    return OUTPUT_FORMAT.WIDE;
+  } else if (outputFormat && outputFormat.toLowerCase() === "json") {
+    return OUTPUT_FORMAT.JSON;
+  }
+
+  return OUTPUT_FORMAT.NORMAL;
+}

--- a/src/commands/deployment/helper.ts
+++ b/src/commands/deployment/helper.ts
@@ -1,0 +1,221 @@
+import Table from "cli-table";
+import * as fs from "fs";
+import * as os from "os";
+import Deployment from "spektate/lib/Deployment";
+import AzureDevOpsPipeline from "spektate/lib/pipeline/AzureDevOpsPipeline";
+import IPipeline from "spektate/lib/pipeline/Pipeline";
+import { logger } from "../../logger";
+
+let hldPipeline: IPipeline;
+let clusterPipeline: IPipeline;
+let srcPipeline: IPipeline;
+const fileLocation = os.homedir() + "/.Spektate";
+export let config: { [id: string]: string } = {};
+export enum OUTPUT_FORMAT {
+  NORMAL = 0,
+  WIDE = 1,
+  JSON = 2
+}
+
+export class Helper {
+  public static initializePipelines() {
+    srcPipeline = new AzureDevOpsPipeline(
+      config.AZURE_ORG,
+      config.AZURE_PROJECT,
+      false,
+      config.AZURE_PIPELINE_ACCESS_TOKEN
+    );
+    hldPipeline = new AzureDevOpsPipeline(
+      config.AZURE_ORG,
+      config.AZURE_PROJECT,
+      true,
+      config.AZURE_PIPELINE_ACCESS_TOKEN
+    );
+    clusterPipeline = new AzureDevOpsPipeline(
+      config.AZURE_ORG,
+      config.AZURE_PROJECT,
+      false,
+      config.AZURE_PIPELINE_ACCESS_TOKEN
+    );
+  }
+
+  public static verifyAppConfiguration = (callback?: () => void) => {
+    if (
+      config.STORAGE_TABLE_NAME === "" ||
+      config.STORAGE_TABLE_NAME === undefined ||
+      config.STORAGE_PARTITION_KEY === "" ||
+      config.STORAGE_PARTITION_KEY === undefined ||
+      config.STORAGE_ACCOUNT_NAME === "" ||
+      config.STORAGE_ACCOUNT_NAME === undefined ||
+      config.STORAGE_ACCOUNT_KEY === "" ||
+      config.STORAGE_ACCOUNT_KEY === undefined ||
+      config.GITHUB_MANIFEST_USERNAME === "" ||
+      config.GITHUB_MANIFEST_USERNAME === undefined ||
+      config.MANIFEST === "" ||
+      config.MANIFEST === undefined ||
+      config.AZURE_PROJECT === "" ||
+      config.AZURE_PROJECT === undefined ||
+      config.AZURE_ORG === "" ||
+      config.AZURE_ORG === undefined
+    ) {
+      Helper.configureAppFromFile(callback);
+    } else {
+      Helper.initializePipelines();
+      if (callback) {
+        callback();
+      }
+    }
+  };
+
+  public static configureAppFromFile = (callback?: () => void) => {
+    fs.readFile(fileLocation, (error, data) => {
+      if (error) {
+        logger.error(error);
+      }
+      const array = data.toString().split("\n");
+      array.forEach((row: string) => {
+        const key = row.split(/=(.+)/)[0];
+        const value = row.split(/=(.+)/)[1];
+        config[key] = value;
+      });
+      Helper.initializePipelines();
+      if (callback) {
+        callback();
+      }
+    });
+  };
+
+  public static writeConfigToFile = (configMap: any) => {
+    let data = "";
+    Object.keys(configMap).forEach(key => {
+      data += "\n" + key + "=" + configMap[key];
+    });
+    fs.writeFile(fileLocation, data, (error: any) => {
+      if (error) {
+        logger.error(error);
+      }
+    });
+  };
+
+  public static getDeployments = (
+    outputFormat: OUTPUT_FORMAT,
+    environment?: string,
+    imageTag?: string,
+    p1Id?: string,
+    commitId?: string,
+    service?: string
+  ) => {
+    Deployment.getDeploymentsBasedOnFilters(
+      config.STORAGE_ACCOUNT_NAME,
+      config.STORAGE_ACCOUNT_KEY,
+      config.STORAGE_TABLE_NAME,
+      config.STORAGE_PARTITION_KEY,
+      srcPipeline,
+      hldPipeline,
+      clusterPipeline,
+      environment,
+      imageTag,
+      p1Id,
+      commitId,
+      service,
+      (deployments: Deployment[]) => {
+        if (outputFormat === OUTPUT_FORMAT.JSON) {
+          logger.info(JSON.stringify(deployments));
+        } else {
+          Helper.printDeployments(deployments, outputFormat);
+        }
+      }
+    );
+  };
+
+  public static printDeployments = (
+    deployments: Deployment[],
+    outputFormat: OUTPUT_FORMAT
+  ) => {
+    if (deployments.length > 0) {
+      let row = [];
+      row.push("Start Time");
+      row.push("Service");
+      row.push("Commit");
+      row.push("Src to ACR");
+      row.push("Image Tag");
+      row.push("Result");
+      row.push("ACR to HLD");
+      row.push("Env");
+      row.push("Hld Commit");
+      row.push("Result");
+      row.push("HLD to Manifest");
+      row.push("Result");
+      if (outputFormat === OUTPUT_FORMAT.WIDE) {
+        row.push("Duration");
+        row.push("Status");
+        row.push("Manifest Commit");
+        row.push("End Time");
+      }
+      const table = new Table({ head: row });
+      deployments.forEach(deployment => {
+        row = [];
+        row.push(
+          deployment.srcToDockerBuild
+            ? deployment.srcToDockerBuild.startTime.toLocaleString()
+            : ""
+        );
+        row.push(deployment.service);
+        row.push(deployment.commitId);
+        row.push(
+          deployment.srcToDockerBuild ? deployment.srcToDockerBuild.id : ""
+        );
+        row.push(deployment.imageTag);
+        row.push(
+          deployment.srcToDockerBuild
+            ? Helper.getStatus(deployment.srcToDockerBuild.result)
+            : ""
+        );
+        row.push(
+          deployment.dockerToHldRelease ? deployment.dockerToHldRelease.id : ""
+        );
+        row.push(deployment.environment.toUpperCase());
+        row.push(deployment.hldCommitId);
+        row.push(
+          deployment.dockerToHldRelease
+            ? Helper.getStatus(deployment.dockerToHldRelease.status)
+            : ""
+        );
+        row.push(
+          deployment.hldToManifestBuild ? deployment.hldToManifestBuild.id : ""
+        );
+        row.push(
+          deployment.hldToManifestBuild
+            ? Helper.getStatus(deployment.hldToManifestBuild.result)
+            : ""
+        );
+        if (outputFormat === OUTPUT_FORMAT.WIDE) {
+          row.push(deployment.duration() + " mins");
+          row.push(deployment.status());
+          row.push(deployment.manifestCommitId);
+          row.push(
+            deployment.hldToManifestBuild &&
+              deployment.hldToManifestBuild.finishTime &&
+              !isNaN(deployment.hldToManifestBuild.finishTime.getTime())
+              ? deployment.hldToManifestBuild.finishTime.toLocaleString()
+              : ""
+          );
+        }
+        table.push(row);
+      });
+
+      logger.info(table.toString());
+    } else {
+      logger.info("No deployments found for specified filters.");
+    }
+  };
+
+  public static getStatus = (status: string) => {
+    if (status === "succeeded") {
+      return "\u2713";
+    } else if (!status) {
+      return "...";
+    }
+    return "\u0445";
+  };
+}

--- a/src/commands/deployment/helper.ts
+++ b/src/commands/deployment/helper.ts
@@ -11,13 +11,34 @@ let clusterPipeline: IPipeline;
 let srcPipeline: IPipeline;
 const fileLocation = os.homedir() + "/.Spektate";
 export let config: { [id: string]: string } = {};
+
+/**
+ * Output formats to display service details
+ */
 export enum OUTPUT_FORMAT {
+  /**
+   * Normal format
+   */
   NORMAL = 0,
+
+  /**
+   * Wide table format
+   */
   WIDE = 1,
+
+  /**
+   * JSON format
+   */
   JSON = 2
 }
 
+/**
+ * Helper functions for `deployment` commands
+ */
 export class Helper {
+  /**
+   * Initializes the pipelines assuming that the configuration has been loaded
+   */
   public static initializePipelines() {
     srcPipeline = new AzureDevOpsPipeline(
       config.AZURE_ORG,
@@ -39,6 +60,9 @@ export class Helper {
     );
   }
 
+  /**
+   * Performs verification of config values to make sure subsequent commands can be run
+   */
   public static verifyAppConfiguration = (callback?: () => void) => {
     if (
       config.STORAGE_TABLE_NAME === "" ||
@@ -67,12 +91,16 @@ export class Helper {
     }
   };
 
+  /**
+   * Loads configuration from a file
+   */
   public static configureAppFromFile = (callback?: () => void) => {
-    fs.readFile(fileLocation, (error, data) => {
+    fs.readFile(fileLocation, "utf8", (error, data) => {
       if (error) {
         logger.error(error);
+        throw error;
       }
-      const array = data.toString().split("\n");
+      const array = data.split(/\r?\n/);
       array.forEach((row: string) => {
         const key = row.split(/=(.+)/)[0];
         const value = row.split(/=(.+)/)[1];
@@ -85,6 +113,9 @@ export class Helper {
     });
   };
 
+  /**
+   * Writes configuration to a file
+   */
   public static writeConfigToFile = (configMap: any) => {
     let data = "";
     Object.keys(configMap).forEach(key => {
@@ -97,6 +128,9 @@ export class Helper {
     });
   };
 
+  /**
+   * Gets a list of deployments for the specified filters
+   */
   public static getDeployments = (
     outputFormat: OUTPUT_FORMAT,
     environment?: string,
@@ -128,6 +162,9 @@ export class Helper {
     );
   };
 
+  /**
+   * Prints deployments in a terminal table
+   */
   public static printDeployments = (
     deployments: Deployment[],
     outputFormat: OUTPUT_FORMAT
@@ -210,6 +247,9 @@ export class Helper {
     }
   };
 
+  /**
+   * Gets a status indicator icon
+   */
   public static getStatus = (status: string) => {
     if (status === "succeeded") {
       return "\u2713";

--- a/src/commands/deployment/index.ts
+++ b/src/commands/deployment/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "../command";
+import { getCommandDecorator } from "./get";
+import { initCommandDecorator } from "./init";
+
+export const deploymentCommand = Command(
+  "deployment",
+  "Introspect your deployments",
+  [getCommandDecorator, initCommandDecorator]
+);

--- a/src/commands/deployment/index.ts
+++ b/src/commands/deployment/index.ts
@@ -2,6 +2,9 @@ import { Command } from "../command";
 import { getCommandDecorator } from "./get";
 import { initCommandDecorator } from "./init";
 
+/**
+ * `deployment` command
+ */
 export const deploymentCommand = Command(
   "deployment",
   "Introspect your deployments",

--- a/src/commands/deployment/init.ts
+++ b/src/commands/deployment/init.ts
@@ -2,6 +2,10 @@ import commander from "commander";
 import { logger } from "../../logger";
 import { config, Helper } from "./helper";
 
+/**
+ * Adds the init command to the commander command object
+ * @param command Commander command object to decorate
+ */
 export const initCommandDecorator = (command: commander.Command): void => {
   command
     .command("init")

--- a/src/commands/deployment/init.ts
+++ b/src/commands/deployment/init.ts
@@ -1,0 +1,80 @@
+import commander from "commander";
+import { logger } from "../../logger";
+import { config, Helper } from "./helper";
+
+export const initCommandDecorator = (command: commander.Command): void => {
+  command
+    .command("init")
+    .alias("i")
+    .description("Initialize the deployment tool for the first time")
+    .option(
+      "-o, --azure-org <azure-org>",
+      "Organization under which the project lives in Azure"
+    )
+    .option(
+      "--azure-pipeline-access-token <azure-pipeline-access-token>",
+      "Access token for the pipeline (if private)"
+    )
+    .option(
+      "-p, --azure-project <azure-project>",
+      "Project under which pipeline lives in Azure"
+    )
+    .option("-m, --manifest <manifest>", "Name of the Manifest repository")
+    .option(
+      "--manifest-access-token <manifest-access-token>",
+      "Access token for the manifest repository (if private)"
+    )
+    .option(
+      "-u, --github-manifest-username <github-manifest-username>",
+      "Username of the Github account who owns manifest repository"
+    )
+    .option(
+      "-k, --storage-account-key <storage-account-key>",
+      "Account Key for the storage table"
+    )
+    .option(
+      "-n, --storage-account-name <storage-account-name",
+      "Account name for the storage table"
+    )
+    .option(
+      "-s, --storage-partition-key <storage-partition-key>",
+      "Partition key in the storage table"
+    )
+    .option(
+      "-t, --storage-table-name <storage-table-name>",
+      "Name of the table in storage"
+    )
+    .action(async opts => {
+      try {
+        if (
+          opts.azureOrg &&
+          opts.azureProject &&
+          opts.manifest &&
+          opts.githubManifestUsername &&
+          opts.storageAccountKey &&
+          opts.storageAccountName &&
+          opts.storagePartitionKey &&
+          opts.storageTableName
+        ) {
+          config.AZURE_ORG = opts.azureOrg;
+          config.AZURE_PROJECT = opts.azureProject;
+          config.MANIFEST = opts.manifest;
+          config.GITHUB_MANIFEST_USERNAME = opts.githubManifestUsername;
+          config.STORAGE_ACCOUNT_KEY = opts.storageAccountKey;
+          config.STORAGE_ACCOUNT_NAME = opts.storageAccountName;
+          config.STORAGE_PARTITION_KEY = opts.storagePartitionKey;
+          config.STORAGE_TABLE_NAME = opts.storageTableName;
+          config.AZURE_PIPELINE_ACCESS_TOKEN = opts.azurePipelineAccessToken;
+          config.MANIFEST_ACCESS_TOKEN = opts.manifestAccessToken;
+          Helper.writeConfigToFile(config);
+        } else {
+          logger.info(
+            "You need to specify each of the config settings in order to run any command."
+          );
+        }
+      } catch (err) {
+        logger.error(`Error occurred while initializing`);
+        logger.error(err);
+      }
+    });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
  * - etc...
  */
 import { Command, executeCommand } from "./commands/command";
+import { deploymentCommand } from "./commands/deployment";
 import { projectCommand } from "./commands/project";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,7 +26,7 @@ const rootCommand = Command(
       c.version(require("../package.json").version);
     }
   ],
-  [projectCommand]
+  [projectCommand, deploymentCommand]
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,6 +378,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cli-table@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cli-table/-/cli-table-0.3.0.tgz#f1857156bf5fd115c6a2db260ba0be1f8fc5671c"
+  integrity sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -876,6 +881,31 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
+azure-storage@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.3.tgz#c5966bf929d87587d78f6847040ea9a4b1d4a50a"
+  integrity sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==
+  dependencies:
+    browserify-mime "~1.2.9"
+    extend "^3.0.2"
+    json-edm-parser "0.1.2"
+    md5.js "1.3.4"
+    readable-stream "~2.0.0"
+    request "^2.86.0"
+    underscore "~1.8.3"
+    uuid "^3.0.0"
+    validator "~9.4.1"
+    xml2js "0.2.8"
+    xmlbuilder "^9.0.7"
+
 babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
@@ -1042,6 +1072,11 @@ browserify-des@^1.0.0:
     des.js "^1.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+browserify-mime@~1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/browserify-mime/-/browserify-mime-1.2.9.tgz#aeb1af28de6c0d7a6a2ce40adb68ff18422af31f"
+  integrity sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
@@ -1292,6 +1327,13 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-table@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
+  integrity sha1-9TsFJmqLGguTSz0IIebi3FkUriM=
+  dependencies:
+    colors "1.0.3"
+
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -1364,6 +1406,11 @@ colornames@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
   integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
+
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
 colors@^1.2.1:
   version "1.3.3"
@@ -1577,6 +1624,13 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2039,7 +2093,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2210,6 +2264,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2274,6 +2335,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fs@0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
 
 fsevents@^1.2.7:
   version "1.2.9"
@@ -2766,6 +2832,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -3440,6 +3511,13 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-edm-parser@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/json-edm-parser/-/json-edm-parser-0.1.2.tgz#1e60b0fef1bc0af67bc0d146dfdde5486cd615b4"
+  integrity sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=
+  dependencies:
+    jsonparse "~1.2.0"
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -3480,6 +3558,11 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonparse@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.2.0.tgz#5c0c5685107160e72fe7489bddea0b44c2bc67bd"
+  integrity sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3761,6 +3844,14 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+md5.js@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
+  integrity sha1-6b296UogpawYsENA/Fdk1bCdkB0=
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -4229,6 +4320,13 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
+  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+  dependencies:
+    is-wsl "^1.1.0"
+
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -4277,6 +4375,11 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+os@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/os/-/os-0.1.1.tgz#208845e89e193ad4d971474b93947736a56d13f3"
+  integrity sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=
 
 osenv@^0.1.4:
   version "0.1.5"
@@ -4592,6 +4695,11 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -4776,6 +4884,18 @@ readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  integrity sha1-j5A0HmilPMySh4jaz80Rs265t44=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -4850,7 +4970,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@~2.88.0:
+request@^2.86.0, request@^2.87.0, request@~2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -5035,6 +5155,11 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sax@0.5.x:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
+  integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
 sax@^1.2.4:
   version "1.2.4"
@@ -5265,6 +5390,14 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+spektate@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.2.tgz#7f54e901126fdaa27a8dda0af34ba44d962937d2"
+  integrity sha512-Wqz7B7UbU0x7Z5iRC5baWpmGNJq9hqFUmcm0n6fJ4cWxaVM/L8KAyWA+EzPcz960AYjmFkOTYlpu+EDSZbIrKA==
+  dependencies:
+    axios "^0.19.0"
+    azure-storage "^2.10.3"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -5422,6 +5555,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -5785,6 +5923,11 @@ uid2@0.0.3:
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
   integrity sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=
 
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -5888,7 +6031,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.0.0, uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -5905,6 +6048,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@~9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-9.4.1.tgz#abf466d398b561cd243050112c6ff1de6cc12663"
+  integrity sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==
 
 verror@1.10.0:
   version "1.10.0"
@@ -6133,6 +6281,18 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.8.tgz#9b81690931631ff09d1957549faf54f4f980b3c2"
+  integrity sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=
+  dependencies:
+    sax "0.5.x"
+
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,11 +2336,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
@@ -4320,13 +4315,6 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
-  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
-  dependencies:
-    is-wsl "^1.1.0"
-
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -4375,11 +4363,6 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-os@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/os/-/os-0.1.1.tgz#208845e89e193ad4d971474b93947736a56d13f3"
-  integrity sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=
 
 osenv@^0.1.4:
   version "0.1.5"


### PR DESCRIPTION
- consuming npm package that contains data access layer for `spk deployment <command>` (corresponding [PR](https://github.com/microsoft/spektate/pull/33) in spektate)
- added `init` and `get` commands as a start
- (still need to add unit tests for this area)