### PR TITLE
Added webpack safe `exec` command

### DIFF
--- a/src/lib/shell.test.ts
+++ b/src/lib/shell.test.ts
@@ -1,0 +1,34 @@
+import { disableVerboseLogging, enableVerboseLogging } from "../logger";
+import { exec } from "./shell";
+
+beforeAll(() => {
+  enableVerboseLogging();
+});
+
+afterAll(() => {
+  disableVerboseLogging();
+});
+
+describe("Shelling out to executables that exist on system", () => {
+  test("ls", async () => {
+    let out: string | undefined;
+    try {
+      out = await exec("ls");
+    } catch (_) {
+      out = undefined;
+    }
+    expect(out).not.toBeUndefined();
+  });
+});
+
+describe("Shelling out to executables not found on PATH", () => {
+  test("An executable that does not exist", async () => {
+    let out: string | undefined;
+    try {
+      out = await exec("someRandomExecutableThatDoesNotExist");
+    } catch (_) {
+      out = undefined;
+    }
+    expect(out).toBeUndefined();
+  });
+});

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -1,0 +1,70 @@
+import child_process from "child_process";
+import { logger } from "../logger";
+
+/**
+ * Promise wrapper for child_process.spawn.
+ * Allows users to shell out commands to the host. Uses child_process.spawn()
+ * under the hood, so it is safe for long running processes and for processes
+ * which output large amounts of text (ie; larger than standard node buffer)
+ *
+ * @example
+ *  exec("ls", ["-l", "-a"])
+ *    .then(stdout => console.log(stdout))
+ *    .catch(stderr => console.error(stderr))
+ *
+ * @param cmd Command to run on host
+ * @param Arguments to pass to the command
+ * @param opts Options to pass to child_process.spawn()
+ */
+export const exec = async (
+  cmd: string,
+  args: string[] = [],
+  opts: child_process.SpawnOptions = {}
+): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    const process = child_process.spawn(cmd, args, opts);
+    const cmdString = `${cmd} ${args.join(" ")}`;
+    let stdout = "";
+    let stderr = "";
+
+    // Capture stdout/stderr as process runs
+    if (process.stdout) {
+      process.stdout.on("data", data => {
+        logger.debug(`stdout -> '${cmdString}' -> ${data}`.trim());
+        stdout = stdout + data;
+      });
+    }
+    if (process.stderr) {
+      process.stderr.on("data", data => {
+        logger.debug(`stderr -> '${cmdString}' -> ${data}`.trim());
+        stderr = stderr + data;
+      });
+    }
+
+    // Reject on error
+    process.on("error", err => {
+      logger.verbose(`'${cmdString}' encountered an error during execution`);
+      logger.verbose(err);
+      reject(err);
+    });
+
+    // Resolve promise on completion
+    process.on("exit", code => {
+      // Log completion of of command
+      logger.verbose(`'${cmdString}' exited with code: ${code}`);
+      if (stdout.length > 0) {
+        logger.verbose(`'${cmdString}': ${stdout}`.trim());
+      }
+      if (stderr.length > 0) {
+        logger.verbose(`'${cmdString}': ${stderr}`.trim());
+      }
+
+      // Resolve stdout if process exits with 0; else reject with stderr
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(stderr.trim()));
+      }
+    });
+  });
+};

--- a/src/lib/toy-calculator.test.ts
+++ b/src/lib/toy-calculator.test.ts
@@ -1,5 +1,0 @@
-import { sum } from "./toy-calculator";
-
-test("adds 1 + 2 to equal 3", () => {
-  expect(sum(1, 2)).toBe(3);
-});

--- a/src/lib/toy-calculator.ts
+++ b/src/lib/toy-calculator.ts
@@ -1,6 +1,0 @@
-import { logger } from "../logger";
-
-export const sum = (a: number, b: number): number => {
-  logger.info("Hello from the sum function");
-  return a + b;
-};


### PR DESCRIPTION
- Added a Promise wrapper function for child_process.spawn() to deal with shelling out to host. shelljs.exec currently doesn't compile well with webpack/pkg.
- Refactored init function to use new `exec` function
- Removed some dummy/sample code