### PR TITLE
Adding pipelines creation lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     ]
   },
   "dependencies": {
+    "azure-devops-node-api": "^9.0.1",
     "cli-table": "^0.3.1",
     "commander": "^3.0.1",
     "js-yaml": "^3.13.1",

--- a/src/lib/pipelines/pipelines.test.ts
+++ b/src/lib/pipelines/pipelines.test.ts
@@ -1,0 +1,88 @@
+import {
+  definitionForAzureRepoPipeline,
+  definitionForGithubRepoPipeline,
+  IAzureRepoPipelineConfig,
+  IGithubRepoPipelineConfig,
+  RepositoryTypes
+} from "./pipelines";
+
+import {
+  BuildDefinition,
+  BuildRepository,
+  YamlProcess
+} from "azure-devops-node-api/interfaces/BuildInterfaces";
+
+describe("It builds an azure repo pipeline definition", () => {
+  let sampleAzureConfig: IAzureRepoPipelineConfig;
+
+  beforeEach(() => {
+    sampleAzureConfig = {
+      branchFilters: ["master"],
+      maximumConcurrentBuilds: 1,
+      pipelineName: "samplePipeline",
+      repositoryName: "myRepoName",
+      repositoryUrl: "myRepoUrl",
+      yamlFileBranch: "master",
+      yamlFilePath: "path/to/azure-pipelines.yml"
+    };
+  });
+
+  test("pipeline definition is well-formed", () => {
+    const definition: BuildDefinition = definitionForAzureRepoPipeline(
+      sampleAzureConfig
+    );
+    expect(definition.name).toBe(sampleAzureConfig.pipelineName);
+
+    const repository = definition.repository as BuildRepository;
+    expect(repository).toBeDefined();
+    expect(repository.defaultBranch).toBe(sampleAzureConfig.yamlFileBranch);
+    expect(repository.id).toBe(sampleAzureConfig.repositoryName);
+    expect(repository.name).toBe(sampleAzureConfig.repositoryName);
+    expect(repository.properties).toBeUndefined();
+    expect(repository.type).toBe(RepositoryTypes.Azure);
+    expect(repository.url).toBe(sampleAzureConfig.repositoryUrl);
+
+    const process = definition.process as YamlProcess;
+    expect(process.yamlFilename).toBe(sampleAzureConfig.yamlFilePath);
+  });
+});
+
+describe("It builds a github repo pipeline definition", () => {
+  let sampleGithubConfig: IGithubRepoPipelineConfig;
+
+  beforeEach(() => {
+    sampleGithubConfig = {
+      branchFilters: ["master"],
+      maximumConcurrentBuilds: 1,
+      pipelineName: "samplePipeline",
+      repositoryName: "myRepoName",
+      repositoryUrl: "myRepoUrl",
+      serviceConnectionId: "foobar",
+      yamlFileBranch: "master",
+      yamlFilePath: "path/to/azure-pipelines.yml"
+    };
+  });
+
+  test("pipeline definition is well-formed", () => {
+    const definition: BuildDefinition = definitionForGithubRepoPipeline(
+      sampleGithubConfig
+    );
+    expect(definition.name).toBe(sampleGithubConfig.pipelineName);
+
+    const repository = definition.repository as BuildRepository;
+    expect(repository).toBeDefined();
+    expect(repository.defaultBranch).toBe(sampleGithubConfig.yamlFileBranch);
+    expect(repository.id).toBe(sampleGithubConfig.repositoryName);
+    expect(repository.name).toBe(sampleGithubConfig.repositoryName);
+    expect(repository.type).toBe(RepositoryTypes.Github);
+    expect(repository.url).toBe(sampleGithubConfig.repositoryUrl);
+
+    const properties = repository.properties!;
+    expect(properties.connectedServiceId).toBe(
+      sampleGithubConfig.serviceConnectionId
+    );
+
+    const process = definition.process as YamlProcess;
+    expect(process.yamlFilename).toBe(sampleGithubConfig.yamlFilePath);
+  });
+});

--- a/src/lib/pipelines/pipelines.ts
+++ b/src/lib/pipelines/pipelines.ts
@@ -15,20 +15,29 @@ import {
 const hostedUbuntuPool = "Hosted Ubuntu 1604";
 const hostedUbuntuPoolId = 224;
 
+/**
+ * Enum of Repository Provider types.
+ */
 export enum RepositoryTypes {
   Github = "github",
   Azure = "tfsgit"
 }
 
+/**
+ * Get an Azure DevOps Build API Client
+ * @param orgUrl An Azure DevOps Organization URL
+ * @param token A Personal Access Token (PAT) used to authenticate against DevOps.
+ * @returns BuildApi Client for Azure Devops
+ */
 export const getBuildApiClient = async (
   orgUrl: string,
-  token: string
+  personalAccessToken: string
 ): Promise<IBuildApi> => {
   return initBuildApiClient(
     getPersonalAccessTokenHandler,
     WebApi,
     orgUrl,
-    token
+    personalAccessToken
   );
 };
 
@@ -54,16 +63,29 @@ interface IPipeline {
   maximumConcurrentBuilds: number;
 }
 
+/**
+ * Interface that describes a Pipeline Configuration for an Azure DevOps
+ * backed git repository.
+ */
 export interface IAzureRepoPipelineConfig extends IPipeline {}
 
+/**
+ * Interface that describes a Pipeline Configuration for a GitHub backed
+ * git repository.
+ */
 export interface IGithubRepoPipelineConfig extends IPipeline {
   serviceConnectionId: string;
 }
 
+/**
+ * Generate a Build Definition given an Azure Repo Pipeline Configuration
+ * @param pipelineConfig Object conforming to IAzureRepoPipelineConfig that describes a high level pipeline configuration for repositories backed on Azure Repos
+ * @returns A BuildDefinition that can be consumed by a Build API Client
+ */
 export const definitionForAzureRepoPipeline = (
   pipelineConfig: IAzureRepoPipelineConfig
 ): BuildDefinition => {
-  const pipelineDefinition: BuildDefinition = {} as BuildDefinition;
+  const pipelineDefinition: BuildDefinition = {};
 
   pipelineDefinition.badgeEnabled = true;
   pipelineDefinition.triggers = [
@@ -104,6 +126,11 @@ export const definitionForAzureRepoPipeline = (
   return pipelineDefinition;
 };
 
+/**
+ * Generate a Build Definition given a GitHub Repo Pipeline Configuration
+ * @param pipelineConfig Object conforming to IGithubRepoPipelineConfig that describes a high level pipeline configuration for repositories backed on Github
+ * @returns A BuildDefinition that can be consumed by a Build API Client
+ */
 export const definitionForGithubRepoPipeline = (
   pipelineConfig: IGithubRepoPipelineConfig
 ): BuildDefinition => {
@@ -151,6 +178,13 @@ export const definitionForGithubRepoPipeline = (
   return pipelineDefinition;
 };
 
+/**
+ * Create a Pipeline with on Azure Devops.
+ * @param buildApi BuildApi Client for Azure Devops.
+ * @param azdoProject Azure DevOps Project within the authenticated Organization.
+ * @param definition A BuildDefinition that can be consumed by a Build API Client
+ * @returns The BuildDefinition that was created by the Build API Client
+ */
 export const createPipelineForDefinition = async (
   buildApi: IBuildApi,
   azdoProject: string,

--- a/src/lib/pipelines/pipelines.ts
+++ b/src/lib/pipelines/pipelines.ts
@@ -1,0 +1,160 @@
+import { getPersonalAccessTokenHandler, WebApi } from "azure-devops-node-api";
+import { IBuildApi } from "azure-devops-node-api/BuildApi";
+import {
+  AgentPoolQueue,
+  BuildDefinition,
+  BuildRepository,
+  ContinuousIntegrationTrigger,
+  DefinitionQuality,
+  DefinitionQueueStatus,
+  DefinitionTriggerType,
+  DefinitionType,
+  YamlProcess
+} from "azure-devops-node-api/interfaces/BuildInterfaces";
+
+const hostedUbuntuPool = "Hosted Ubuntu 1604";
+const hostedUbuntuPoolId = 224;
+
+export enum RepositoryTypes {
+  Github = "github",
+  Azure = "tfsgit"
+}
+
+export const getBuildApiClient = async (
+  orgUrl: string,
+  token: string
+): Promise<IBuildApi> => {
+  return initBuildApiClient(
+    getPersonalAccessTokenHandler,
+    WebApi,
+    orgUrl,
+    token
+  );
+};
+
+const initBuildApiClient = async (
+  tokenHandler: (n: string) => any,
+  webapi: typeof WebApi,
+  orgUrl: string,
+  token: string
+): Promise<IBuildApi> => {
+  const authHandler = tokenHandler(token);
+  const connection = new webapi(orgUrl, authHandler);
+
+  return connection.getBuildApi();
+};
+
+interface IPipeline {
+  pipelineName: string;
+  repositoryUrl: string;
+  repositoryName: string;
+  yamlFileBranch: string;
+  yamlFilePath: string;
+  branchFilters: string[];
+  maximumConcurrentBuilds: number;
+}
+
+export interface IAzureRepoPipelineConfig extends IPipeline {}
+
+export interface IGithubRepoPipelineConfig extends IPipeline {
+  serviceConnectionId: string;
+}
+
+export const definitionForAzureRepoPipeline = (
+  pipelineConfig: IAzureRepoPipelineConfig
+): BuildDefinition => {
+  const pipelineDefinition: BuildDefinition = {} as BuildDefinition;
+
+  pipelineDefinition.badgeEnabled = true;
+  pipelineDefinition.triggers = [
+    {
+      batchChanges: false,
+      branchFilters: pipelineConfig.branchFilters,
+      maxConcurrentBuildsPerBranch: pipelineConfig.maximumConcurrentBuilds,
+      type: DefinitionTriggerType.ContinuousIntegration
+    } as ContinuousIntegrationTrigger
+  ];
+
+  pipelineDefinition.queue = {
+    name: hostedUbuntuPool,
+    pool: {
+      id: hostedUbuntuPoolId,
+      name: hostedUbuntuPool
+    }
+  } as AgentPoolQueue;
+
+  pipelineDefinition.queueStatus = DefinitionQueueStatus.Enabled;
+
+  pipelineDefinition.name = pipelineConfig.pipelineName;
+  pipelineDefinition.type = DefinitionType.Build;
+  pipelineDefinition.quality = DefinitionQuality.Definition;
+
+  pipelineDefinition.repository = {
+    defaultBranch: pipelineConfig.yamlFileBranch,
+    id: pipelineConfig.repositoryName,
+    name: pipelineConfig.repositoryName,
+    type: RepositoryTypes.Azure,
+    url: pipelineConfig.repositoryUrl
+  } as BuildRepository;
+
+  pipelineDefinition.process = {
+    yamlFilename: pipelineConfig.yamlFilePath
+  } as YamlProcess;
+
+  return pipelineDefinition;
+};
+
+export const definitionForGithubRepoPipeline = (
+  pipelineConfig: IGithubRepoPipelineConfig
+): BuildDefinition => {
+  const pipelineDefinition: BuildDefinition = {} as BuildDefinition;
+
+  pipelineDefinition.badgeEnabled = true;
+  pipelineDefinition.triggers = [
+    {
+      batchChanges: false,
+      branchFilters: pipelineConfig.branchFilters,
+      maxConcurrentBuildsPerBranch: pipelineConfig.maximumConcurrentBuilds,
+      type: DefinitionTriggerType.ContinuousIntegration
+    } as ContinuousIntegrationTrigger
+  ];
+
+  pipelineDefinition.queue = {
+    name: hostedUbuntuPool,
+    pool: {
+      id: hostedUbuntuPoolId,
+      name: hostedUbuntuPool
+    }
+  } as AgentPoolQueue;
+
+  pipelineDefinition.queueStatus = DefinitionQueueStatus.Enabled;
+
+  pipelineDefinition.name = pipelineConfig.pipelineName;
+  pipelineDefinition.type = DefinitionType.Build;
+  pipelineDefinition.quality = DefinitionQuality.Definition;
+
+  pipelineDefinition.repository = {
+    defaultBranch: pipelineConfig.yamlFileBranch,
+    id: pipelineConfig.repositoryName,
+    name: pipelineConfig.repositoryName,
+    properties: {
+      connectedServiceId: pipelineConfig.serviceConnectionId
+    },
+    type: RepositoryTypes.Github,
+    url: pipelineConfig.repositoryUrl
+  } as BuildRepository;
+
+  pipelineDefinition.process = {
+    yamlFilename: pipelineConfig.yamlFilePath
+  } as YamlProcess;
+
+  return pipelineDefinition;
+};
+
+export const createPipelineForDefinition = async (
+  buildApi: IBuildApi,
+  azdoProject: string,
+  definition: BuildDefinition
+): Promise<BuildDefinition> => {
+  return buildApi.createDefinition(definition, azdoProject);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,6 +889,15 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+azure-devops-node-api@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-9.0.1.tgz#ba6dce7f274db01589a653cdbdf43e71e9f9b527"
+  integrity sha512-0veE4EWHObJxzwgHlydG65BjNMuLPkR1nzcQ2K51PIho1/F4llpKt3pelC30Vbex5zA9iVgQ9YZGlkkvOBSksw==
+  dependencies:
+    tunnel "0.0.4"
+    typed-rest-client "1.2.0"
+    underscore "1.8.3"
+
 azure-storage@^2.10.3:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.3.tgz#c5966bf929d87587d78f6847040ea9a4b1d4a50a"
@@ -5866,6 +5875,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.4.tgz#2d3785a158c174c9a16dc2c046ec5fc5f1742213"
+  integrity sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -5882,6 +5896,14 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+typed-rest-client@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.2.0.tgz#723085d203f38d7d147271e5ed3a75488eb44a02"
+  integrity sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==
+  dependencies:
+    tunnel "0.0.4"
+    underscore "1.8.3"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -5906,7 +5928,7 @@ uid2@0.0.3:
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
   integrity sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=
 
-underscore@~1.8.3:
+underscore@1.8.3, underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=


### PR DESCRIPTION
- Add Azure Devops Node API
- Add a pipeline creation lib and functions that create a build client, and allow one to create pipelines for repositories on AzDo or Github