### PR TITLE
spk deployment reduce required params for init

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "commander": "^3.0.1",
     "js-yaml": "^3.13.1",
     "shelljs": "^0.8.3",
-    "spektate": "^0.1.4",
+    "spektate": "^0.1.5",
     "uuid": "^3.3.3",
     "winston": "^3.2.1"
   }

--- a/src/commands/deployment/helper.ts
+++ b/src/commands/deployment/helper.ts
@@ -73,10 +73,6 @@ export class Helper {
       config.STORAGE_ACCOUNT_NAME === undefined ||
       config.STORAGE_ACCOUNT_KEY === "" ||
       config.STORAGE_ACCOUNT_KEY === undefined ||
-      config.GITHUB_MANIFEST_USERNAME === "" ||
-      config.GITHUB_MANIFEST_USERNAME === undefined ||
-      config.MANIFEST === "" ||
-      config.MANIFEST === undefined ||
       config.AZURE_PROJECT === "" ||
       config.AZURE_PROJECT === undefined ||
       config.AZURE_ORG === "" ||
@@ -139,8 +135,8 @@ export class Helper {
     commitId?: string,
     service?: string,
     deploymentId?: string
-  ) => {
-    Deployment.getDeploymentsBasedOnFilters(
+  ): Promise<Deployment[]> => {
+    return Deployment.getDeploymentsBasedOnFilters(
       config.STORAGE_ACCOUNT_NAME,
       config.STORAGE_ACCOUNT_KEY,
       config.STORAGE_TABLE_NAME,
@@ -153,15 +149,15 @@ export class Helper {
       p1Id,
       commitId,
       service,
-      deploymentId,
-      (deployments: Deployment[]) => {
-        if (outputFormat === OUTPUT_FORMAT.JSON) {
-          logger.info(JSON.stringify(deployments, null, 2));
-        } else {
-          Helper.printDeployments(deployments, outputFormat);
-        }
+      deploymentId
+    ).then((deployments: Deployment[]) => {
+      if (outputFormat === OUTPUT_FORMAT.JSON) {
+        logger.info(JSON.stringify(deployments, null, 2));
+      } else {
+        Helper.printDeployments(deployments, outputFormat);
       }
-    );
+      return deployments;
+    });
   };
 
   /**

--- a/src/commands/deployment/init.ts
+++ b/src/commands/deployment/init.ts
@@ -53,8 +53,6 @@ export const initCommandDecorator = (command: commander.Command): void => {
         if (
           opts.azureOrg &&
           opts.azureProject &&
-          opts.manifest &&
-          opts.githubManifestUsername &&
           opts.storageAccountKey &&
           opts.storageAccountName &&
           opts.storagePartitionKey &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,10 +5373,10 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-spektate@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.4.tgz#ab065021b38d4f2fc01c6afe73074627e7f47604"
-  integrity sha512-ySaP9FFOvWuz5OeEeKTx4uoX+coaZr8q2h94SDDwJSeOL3rOGXWwWEOnMlhclsq/Cd60fv0E6Td64TSfMik+Tg==
+spektate@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.5.tgz#7d34fc6dc81970a43a2e113da0d03981d02abe84"
+  integrity sha512-doSQ1UFAfcHa1xi5mpF/i8oGemtuAnP/NA+Bn1t03ojnb04oKzbcSPF76fOyGBf8XgmxYvY/ai+yP2ncx0QopA==
   dependencies:
     axios "^0.19.0"
     azure-storage "^2.10.3"


### PR DESCRIPTION
- Stop using callbacks
- reduce the number of mandatory params for init (temporary, until we start utilizing global init)

eg. of using init: 

```
spk deployment init 
  --azure-org epicstuff 
  --azure-project hellobedrock 
  --storage-account-key <key> 
  --storage-account-name <storagename> 
  --storage-partition-key hello-bedrock 
  --storage-table-name deployments
```