### PR TITLE
Adding created services to bedrock.yaml

### DIFF
--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -10,7 +10,7 @@ import {
 } from "../../lib/fileutils";
 import { exec } from "../../lib/shell";
 import { logger } from "../../logger";
-import { IBedrockFile, IMaintainersFile } from "../../types";
+import { IBedrockFile, IMaintainersFile, IHelmConfig } from "../../types";
 
 /**
  * Adds the init command to the commander command object
@@ -223,8 +223,17 @@ const generateBedrockFile = async (
         absProjectPath,
         absPackagePath
       );
+
+      const helm: IHelmConfig = {
+        chart: {
+          branch: "",
+          git: "",
+          path: ""
+        }
+      };
+
       file.services["./" + relPathToPackageFromRoot] = {
-        helm: { chart: { git: "", branch: "", path: "" } }
+        helm
       };
       return file;
     },

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -10,7 +10,7 @@ import {
 } from "../../lib/fileutils";
 import { exec } from "../../lib/shell";
 import { logger } from "../../logger";
-import { IBedrockFile, IMaintainersFile, IHelmConfig } from "../../types";
+import { IBedrockFile, IHelmConfig, IMaintainersFile } from "../../types";
 
 /**
  * Adds the init command to the commander command object

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -26,10 +26,7 @@ describe("Adding a service to a repo directory", () => {
   test("New directory is created under root directory with required service files.", async () => {
     // Create random directory to initialize
     const randomTmpDir = path.join(os.tmpdir(), uuid());
-
     fs.mkdirSync(randomTmpDir);
-
-    logger.debug(randomTmpDir);
 
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
@@ -70,8 +67,6 @@ describe("Adding a service to a repo directory", () => {
     // Create random directory to initialize
     const randomTmpDir = path.join(os.tmpdir(), uuid());
     fs.mkdirSync(randomTmpDir);
-
-    logger.debug(randomTmpDir);
 
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import yaml from "js-yaml";
 import os from "os";
 import path from "path";
 import { promisify } from "util";
@@ -9,7 +8,10 @@ import {
   enableVerboseLogging,
   logger
 } from "../../logger";
-import { IMaintainersFile } from "../../types";
+import {
+  createTestBedrockYaml,
+  createTestMaintainersYaml
+} from "../../test/mockFactory";
 import { createService } from "./create";
 
 beforeAll(() => {
@@ -24,15 +26,20 @@ describe("Adding a service to a repo directory", () => {
   test("New directory is created under root directory with required service files.", async () => {
     // Create random directory to initialize
     const randomTmpDir = path.join(os.tmpdir(), uuid());
+
     fs.mkdirSync(randomTmpDir);
+
+    logger.debug(randomTmpDir);
 
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
     );
+    await writeSampleBedrockFileToDir(path.join(randomTmpDir, "bedrock.yaml"));
 
     const packageDir = "";
 
     const serviceName = uuid();
+
     logger.info(
       `creating randomTmpDir ${randomTmpDir} and service ${serviceName}`
     );
@@ -64,9 +71,12 @@ describe("Adding a service to a repo directory", () => {
     const randomTmpDir = path.join(os.tmpdir(), uuid());
     fs.mkdirSync(randomTmpDir);
 
+    logger.debug(randomTmpDir);
+
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
     );
+    await writeSampleBedrockFileToDir(path.join(randomTmpDir, "bedrock.yaml"));
 
     const packageDir = "packages";
 
@@ -99,29 +109,17 @@ describe("Adding a service to a repo directory", () => {
 });
 
 const writeSampleMaintainersFileToDir = async (maintainersFilePath: string) => {
-  const content: IMaintainersFile = {
-    services: {
-      "./": {
-        maintainers: [
-          {
-            email: "somegithubemailg@users.noreply.github.com",
-            name: "my name"
-          }
-        ]
-      },
-      "./packages/service1": {
-        maintainers: [
-          {
-            email: "hello@users.noreply.github.com",
-            name: "testUser"
-          }
-        ]
-      }
-    }
-  };
   await promisify(fs.writeFile)(
     maintainersFilePath,
-    yaml.safeDump(content),
+    createTestMaintainersYaml(),
+    "utf8"
+  );
+};
+
+const writeSampleBedrockFileToDir = async (bedrockFilePath: string) => {
+  await promisify(fs.writeFile)(
+    bedrockFilePath,
+    createTestBedrockYaml(),
     "utf8"
   );
 };

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -9,7 +9,7 @@ import {
   generateAzurePipelinesYaml,
   generateGitIgnoreFile
 } from "../../lib/fileutils";
-import { IUser, IHelmConfig } from "../../types";
+import { IHelmConfig, IUser } from "../../types";
 
 /**
  * Adds the init command to the commander command object

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -63,7 +63,6 @@ export const createCommandDecorator = (command: commander.Command): void => {
       "The email of the primary maintainer for this service.",
       "maintainer email"
     )
-    // TODO: support chart/repository configuration for helm charts.
     .action(async (serviceName, opts) => {
       const {
         helmChartChart,

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -4,7 +4,13 @@ import yaml from "js-yaml";
 import path from "path";
 import { promisify } from "util";
 import { logger } from "../logger";
-import { IAzurePipelinesYaml, IMaintainersFile, IUser } from "../types";
+import {
+  IAzurePipelinesYaml,
+  IBedrockFile,
+  IMaintainersFile,
+  IUser,
+  IHelmConfig
+} from "../types";
 
 /**
  * Writes out the starter azure-pipelines.yaml file to `targetPath`
@@ -170,4 +176,32 @@ export const generateGitIgnoreFile = (
 
   logger.info(`Writing .gitignore file to ${gitIgnoreFilePath}`);
   fs.writeFileSync(gitIgnoreFilePath, content, "utf8");
+}
+
+/**
+ * Update bedrock.yml with new service
+ *
+ * @param bedrockFilePath
+ * @param newServicePath
+ */
+export const addNewServiceToBedrockFile = (
+  bedrockFilePath: string,
+  newServicePath: string,
+  helmConfig: IHelmConfig
+) => {
+  logger.warn("hello!");
+
+  const bedrockFile = yaml.safeLoad(
+    fs.readFileSync(bedrockFilePath, "utf8")
+  ) as IBedrockFile;
+
+  logger.warn("hello!");
+  logger.debug(bedrockFile);
+
+  bedrockFile.services["./" + newServicePath] = {
+    helm: helmConfig
+  };
+
+  logger.info("Updating bedrock.yaml");
+  fs.writeFileSync(bedrockFilePath, yaml.safeDump(bedrockFile), "utf8");
 };

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -7,9 +7,9 @@ import { logger } from "../logger";
 import {
   IAzurePipelinesYaml,
   IBedrockFile,
+  IHelmConfig,
   IMaintainersFile,
-  IUser,
-  IHelmConfig
+  IUser
 } from "../types";
 
 /**
@@ -176,7 +176,7 @@ export const generateGitIgnoreFile = (
 
   logger.info(`Writing .gitignore file to ${gitIgnoreFilePath}`);
   fs.writeFileSync(gitIgnoreFilePath, content, "utf8");
-}
+};
 
 /**
  * Update bedrock.yml with new service

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -1,5 +1,5 @@
 import yaml from "js-yaml";
-import { IMaintainersFile } from "../types";
+import { IBedrockFile, IHelmConfig, IMaintainersFile } from "../types";
 
 export const createTestMaintainersYaml = (
   asString = true
@@ -21,6 +21,49 @@ export const createTestMaintainersYaml = (
             name: "testUser"
           }
         ]
+      }
+    }
+  };
+
+  return asString ? yaml.dump(data) : data;
+};
+
+export const createTestBedrockYaml = (
+  asString = true
+): IBedrockFile | string => {
+  const service1HelmConfig: IHelmConfig = {
+    chart: {
+      branch: "master",
+      git: "https://github.com/catalystcode/spk-demo-repo.git",
+      path: ""
+    }
+  };
+
+  const service2HelmConfig: IHelmConfig = {
+    chart: {
+      branch: "master",
+      git: "https://github.com/catalystcode/spk-demo-repo.git",
+      path: "/service1"
+    }
+  };
+
+  const zookeeperHelmConfig: IHelmConfig = {
+    chart: {
+      chart: "zookeeper",
+      repository: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+    }
+  };
+
+  const data: IBedrockFile = {
+    services: {
+      "./": {
+        helm: service1HelmConfig
+      },
+      "./packages/service1": {
+        helm: service2HelmConfig
+      },
+      "./zookeeper": {
+        helm: zookeeperHelmConfig
       }
     }
   };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,26 @@ interface IUser {
   website?: string;
 }
 
+export interface IHelmConfig {
+  chart:
+    | {
+        repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
+        chart: string; // chart name (eg; zookeeper)
+      }
+    | ({
+        git: string; // git url to clone (eg; https://github.com/helm/charts.git)
+        path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
+      } & (
+        | {
+            sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)
+            tag?: string; // indicate the semantics of the sha (eg; v1.0.2)
+          }
+        | {
+            branch: string; // branch to checkout (eg; master)
+          }
+      ));
+}
+
 /**
  * Bedrock config file
  * Used to capture service meta-information regarding how to deploy
@@ -23,25 +43,7 @@ interface IUser {
 export interface IBedrockFile {
   services: {
     [relativeDirectory: string]: {
-      helm: {
-        chart:
-          | {
-              repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
-              chart: string; // chart name (eg; zookeeper)
-            }
-          | ({
-              git: string; // git url to clone (eg; https://github.com/helm/charts.git)
-              path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
-            } & (
-              | {
-                  sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)
-                  tag?: string; // indicate the semantics of the sha (eg; v1.0.2)
-                }
-              | {
-                  branch: string; // branch to checkout (eg; master)
-                }
-            ));
-      };
+      helm: IHelmConfig;
     };
   };
 }


### PR DESCRIPTION
Supports two options for helm configs: helm chart or custom helm repository with branch and path.

addresses:
 - [x] Add to parent project bedrock config file (reference to new service) in https://github.com/microsoft/bedrock/issues/577