### PR TITLE
Fixing azdo webpack issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "lint": "tslint 'src/**/*.ts{,x}'",
     "lint-fix": "tslint --fix 'src/**/*.ts{,x}'",
     "test": "jest --coverage --coverageReporters=cobertura --coverageReporters=html",
-    "test-coverage-html": "jest --coverage --coverageReporters=html",
-    "test-watch": "jest --watchAll"
+    "test-watch": "jest --watchAll",
+    "postinstall": "cd node_modules/azure-devops-node-api && git apply ../../patches/001-azure-devops-node.patch",
+    "test-coverage-html": "jest --coverage --coverageReporters=html"
   },
   "devDependencies": {
     "@types/cli-table": "^0.3.0",
@@ -57,7 +58,7 @@
     "@azure/arm-storage": "^10.1.0",
     "@azure/keyvault-secrets": "^4.0.0-preview.5",
     "@azure/ms-rest-nodeauth": "^3.0.0",
-    "azure-devops-node-api": "^9.0.1",
+    "azure-devops-node-api": "9.0.1",
     "cli-table": "^0.3.1",
     "commander": "^3.0.1",
     "dotenv": "^8.1.0",

--- a/patches/001-azure-devops-node.patch
+++ b/patches/001-azure-devops-node.patch
@@ -1,0 +1,11 @@
+--- WebApi.js	2019-09-12 17:26:28.000000000 -0700
++++ WebApi.js	2019-10-03 22:58:02.000000000 -0700
+@@ -145,7 +145,7 @@
+             }
+         }
+         else {
+-            const nodeApiVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
++            const nodeApiVersion = require('./package.json').version;
+             const osName = os.platform();
+             const osVersion = os.release();
+             if (requestSettings) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,7 +1098,7 @@ axios@^0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-azure-devops-node-api@^9.0.1:
+azure-devops-node-api@9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-9.0.1.tgz#ba6dce7f274db01589a653cdbdf43e71e9f9b527"
   integrity sha512-0veE4EWHObJxzwgHlydG65BjNMuLPkR1nzcQ2K51PIho1/F4llpKt3pelC30Vbex5zA9iVgQ9YZGlkkvOBSksw==


### PR DESCRIPTION
- Applies a patch against azdo module in node_modules as a post install script
- "Fixes" https://github.com/microsoft/azure-devops-node-api/issues/312, until azdo-node comes up with a better solution
- Pin devops API to 9.0.1 to prevent patch from breaking moving forward