### PR TITLE
Writing global config variable to file

### DIFF
--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -67,18 +67,26 @@ describe("Initializing a project with a non-existent file", () => {
 
 describe("Writing to default config location", () => {
   test("Default config location exists", async () => {
-    const filename = path.resolve(mockFileName);
-    const defaultFileName = path.resolve(defaultFileLocation);
-    await writeConfigToDefaultLocation(filename);
-    const readFile = (fileName: string) =>
-      util.promisify(fs.readFile)(fileName, "utf-8");
+    try {
+      const filename = path.resolve(mockFileName);
+      process.env.test_name = "testStorageName";
+      process.env.test_key = "testStorageKey";
+      loadConfiguration(filename);
+      config.deployment!.pipeline!.access_token = "unit_test_token";
 
-    await readFile(defaultFileName).then(async data1 => {
-      await readFile(filename).then(data2 => {
-        expect(data1).toEqual(data2);
-      });
-    });
+      await writeConfigToDefaultLocation();
+      loadConfiguration(defaultFileLocation);
 
+      expect(config.deployment!).toBeDefined();
+      expect(config.deployment!.pipeline!).toBeDefined();
+      expect(config.deployment!.pipeline!.access_token!).toBe(
+        "unit_test_token"
+      );
+    } catch (e) {
+      logger.error(e);
+      // Make sure execution does not get here:
+      expect(true).toBeFalsy();
+    }
     logger.info("Able to write to default config location");
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,7 +28,9 @@ export const initCommandDecorator = (command: commander.Command): void => {
           return;
         }
         loadConfiguration(opts.file);
-        await writeConfigToDefaultLocation(opts.file);
+
+        await writeConfigToDefaultLocation();
+
         logger.info("Successfully initialized the spk tool!");
       } catch (err) {
         logger.error(`Error occurred while initializing`);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import * as os from "os";
 import { logger } from "../logger";
 import { IConfigYaml } from "../types";
 
-export const defaultFileLocation = os.homedir() + "/.spk-config.yaml";
+export const defaultFileLocation = os.homedir() + "/.spk/config.yaml";
 export let config: IConfigYaml = {};
 
 /**
@@ -107,12 +107,19 @@ export const readYamlFile = <T>(fileLocation: string): T => {
 };
 
 /**
- * Writes configuration to a file
+ * Writes the global config object to default location
  */
-export const writeConfigToDefaultLocation = async (fileName: string) => {
-  if (fileName !== defaultFileLocation) {
-    await fs
-      .createReadStream(fileName)
-      .pipe(fs.createWriteStream(defaultFileLocation));
+export const writeConfigToDefaultLocation = async () => {
+  try {
+    const data = yaml.safeDump(config);
+    const defaultDir = os.homedir() + "/.spk";
+    if (!fs.existsSync(defaultDir)) {
+      fs.mkdirSync(defaultDir);
+    }
+    fs.writeFileSync(defaultFileLocation, data);
+  } catch (err) {
+    logger.error(
+      `Error occurred while writing config to default location ${err}`
+    );
   }
 };

--- a/src/commands/mocks/spk-config.yaml
+++ b/src/commands/mocks/spk-config.yaml
@@ -29,6 +29,10 @@ deployment:
   storage:
     account_name: "${env:test_name}"
     key: "${env:test_key}"
+  pipeline:
+    org: "orgname"
+    project: "project-name"
+    access_token: ""
 services:
   project_name:
   PAT:


### PR DESCRIPTION
So that cluster creation commands can write pre-reqs validation variables to config file, as opposed to running the checks at a later time 