### PR TITLE
add script to bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spk",
-  "version": "1.0.0",
+  "version": "1.0.0-0",
   "description": "The missing Bedrock CLI",
   "author": "Evan Louie <evan.louie@microsoft.com> (https://evanlouie.com)",
   "contributors": [],

--- a/scripts/prerelease-version-bump.sh
+++ b/scripts/prerelease-version-bump.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+RELEASE_BRANCH=$(whoami)/release
+
+# get the latest from master, create a release branch
+git checkout master
+git pull
+git checkout -b ${RELEASE_BRANCH}
+
+# Do not tag commit
+yarn config set version-git-tag false
+
+# Commit message template
+yarn config set version-git-message "release: Bump to v%s"
+
+# Bump version following prerelease format => 1.0.0-0 becomes 1.0.0-1
+yarn version --prerelease
+git push origin ${RELEASE_BRANCH}


### PR DESCRIPTION
1. Developer can use this script to update `package.json` and push to a new branch
1. Once this branch is merge, they can manually 
    * run `yarn build` to generate the `dist` directory with the 3 binaries
    * manually create a release on GitHub

Related to https://github.com/microsoft/bedrock/issues/651