### PR TITLE
fix(671) - Fix error thrown when `spk init` has not been called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 package-lock.json
 .DS_Store
 .bedrock
+.idea
 
 # Logs
 logs

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,6 +1,5 @@
 import commander from "commander";
 import { enableVerboseLogging, logger } from "../logger";
-import { loadConfiguration } from "./init";
 
 /**
  * General interface to encapsulate a sub-command.
@@ -107,10 +106,15 @@ export const executeCommand = (cmd: ICommand, argv: string[]): void => {
   if (targetCommandName && targetCommand) {
     // If command is a sub-command, it needs to load configuration before
     // sub-command can be executed.
-    loadConfiguration();
     executeCommand(targetCommand, decrementArgv(argv));
   } else {
-    argv.length <= 2 ? cmd.command.outputHelp() : cmd.command.parse(argv);
+    // Top level try/catch. If an error occurs, log it and exit with code 1
+    try {
+      argv.length <= 2 ? cmd.command.outputHelp() : cmd.command.parse(argv);
+    } catch (err) {
+      logger.error(err);
+      process.exit(1);
+    }
   }
 };
 

--- a/src/commands/deployment/dashboard.test.ts
+++ b/src/commands/deployment/dashboard.test.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
+import { Config, loadConfiguration } from "../../config";
 import { exec } from "../../lib/shell";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
   logger
 } from "../../logger";
-import { validatePrereqs } from "../infra/vaildate";
-import { config, loadConfiguration } from "./../init";
+import { validatePrereqs } from "../infra/validate";
 import { launchDashboard } from "./dashboard";
 
 beforeAll(() => {
@@ -31,7 +31,7 @@ describe("Validate dashboard container pull", () => {
         const dockerId = await exec("docker", [
           "images",
           "-q",
-          config.introspection!.dashboard!.image!
+          Config().introspection!.dashboard!.image!
         ]);
         expect(dockerId).toBeDefined();
         expect(dashboardContainerId).not.toBe("");

--- a/src/commands/deployment/dashboard.ts
+++ b/src/commands/deployment/dashboard.ts
@@ -1,10 +1,9 @@
 import commander from "commander";
 import open = require("open");
-import { env } from "shelljs";
+import { Config } from "../../config";
 import { exec } from "../../lib/shell";
 import { logger } from "../../logger";
-import { validatePrereqs } from "../infra/vaildate";
-import { config } from "../init";
+import { validatePrereqs } from "../infra/validate";
 
 /**
  * Adds the onboard command to the commander command object
@@ -17,6 +16,7 @@ export const dashboardCommandDecorator = (command: commander.Command): void => {
     .description("Launch the service introspection dashboard")
     .option("-p, --port <port>", "Port to launch the dashboard on", 4040)
     .action(async opts => {
+      const config = Config();
       if (
         !config.introspection ||
         !config.azure_devops ||
@@ -44,6 +44,7 @@ export const launchDashboard = async (port: number): Promise<string> => {
     if (!(await validatePrereqs(["docker"], false))) {
       return "";
     }
+    const config = Config();
     const dockerRepository = config.introspection!.dashboard!.image!;
     logger.info("Pulling dashboard docker image");
     await exec("docker", ["pull", dockerRepository]);
@@ -65,6 +66,7 @@ export const launchDashboard = async (port: number): Promise<string> => {
 };
 
 const getEnvVars = (): string[] => {
+  const config = Config();
   const envVars = [];
   envVars.push("-e");
   envVars.push("REACT_APP_PIPELINE_ORG=" + config.azure_devops!.org!);

--- a/src/commands/deployment/get.ts
+++ b/src/commands/deployment/get.ts
@@ -3,8 +3,8 @@ import commander from "commander";
 import Deployment from "spektate/lib/Deployment";
 import AzureDevOpsPipeline from "spektate/lib/pipeline/AzureDevOpsPipeline";
 import IPipeline from "spektate/lib/pipeline/Pipeline";
+import { Config } from "../../config";
 import { logger } from "../../logger";
-import { config } from "../init";
 export let hldPipeline: IPipeline;
 export let clusterPipeline: IPipeline;
 export let srcPipeline: IPipeline;
@@ -123,6 +123,7 @@ export const getDeployments = (
   service?: string,
   deploymentId?: string
 ): Promise<Deployment[]> => {
+  const config = Config();
   return Deployment.getDeploymentsBasedOnFilters(
     config.introspection!.azure!.account_name!,
     config.introspection!.azure!.key!,
@@ -151,6 +152,8 @@ export const getDeployments = (
  * Initializes the pipelines assuming that the configuration has been loaded
  */
 const initialize = () => {
+  const config = Config();
+
   if (
     !config.introspection ||
     !config.azure_devops ||

--- a/src/commands/deployment/validate.test.ts
+++ b/src/commands/deployment/validate.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { config, loadConfiguration } from "./../init";
+import { Config, loadConfiguration } from "../../config";
 import { isValidConfig, isValidStorageAccount } from "./validate";
 
 import { StorageManagementClient } from "@azure/arm-storage";
@@ -55,7 +55,7 @@ describe("Validate deployment configuration", () => {
 
 describe("Validate missing deployment configuration", () => {
   test("no deployment configuration", async () => {
-    config.introspection = undefined;
+    Config().introspection = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -64,7 +64,7 @@ describe("Validate missing deployment configuration", () => {
 
 describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage", async () => {
-    config.introspection!.azure = undefined;
+    Config().introspection!.azure = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -73,7 +73,7 @@ describe("Validate missing deployment.storage configuration", () => {
 
 describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage.account_name configuration", async () => {
-    config.introspection!.azure!.account_name = undefined;
+    Config().introspection!.azure!.account_name = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -82,7 +82,7 @@ describe("Validate missing deployment.storage configuration", () => {
 
 describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage.table_name configuration", async () => {
-    config.introspection!.azure!.table_name = undefined;
+    Config().introspection!.azure!.table_name = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -91,7 +91,7 @@ describe("Validate missing deployment.storage configuration", () => {
 
 describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage.partition_key configuration", async () => {
-    config.introspection!.azure!.partition_key = undefined;
+    Config().introspection!.azure!.partition_key = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -100,7 +100,7 @@ describe("Validate missing deployment.storage configuration", () => {
 
 describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage.key configuration", async () => {
-    config.introspection!.azure!.key = undefined;
+    Config().introspection!.azure!.key = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -109,7 +109,7 @@ describe("Validate missing deployment.storage configuration", () => {
 
 describe("Validate missing deployment.pipeline configuration", () => {
   test("missing deployment.pipeline configuration", async () => {
-    config.azure_devops = undefined;
+    Config().azure_devops = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -118,7 +118,7 @@ describe("Validate missing deployment.pipeline configuration", () => {
 
 describe("Validate missing deployment.pipeline configuration", () => {
   test("missing deployment.pipeline.org configuration", async () => {
-    config.azure_devops!.org = undefined;
+    Config().azure_devops!.org = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -127,7 +127,7 @@ describe("Validate missing deployment.pipeline configuration", () => {
 
 describe("Validate missing deployment.pipeline configuration", () => {
   test("missing deployment.pipeline.project configuration", async () => {
-    config.azure_devops!.project = undefined;
+    Config().azure_devops!.project = undefined;
     const isValid = isValidConfig();
 
     expect(isValid).toBe(false);
@@ -136,30 +136,30 @@ describe("Validate missing deployment.pipeline configuration", () => {
 
 describe("Validate storage account", () => {
   test("non-existing storage account", async () => {
-    config.introspection!.azure!.account_name = "non-existing-account-name";
+    Config().introspection!.azure!.account_name = "non-existing-account-name";
     const isValid = await isValidStorageAccount();
 
     expect(isValid).toBe(false);
   });
 
   test("existing storage account no keys", async () => {
-    config.introspection!.azure!.account_name = "epi-test-no-keys";
+    Config().introspection!.azure!.account_name = "epi-test-no-keys";
     const isValid = await isValidStorageAccount();
 
     expect(isValid).toBe(false);
   });
 
   test("existing storage account with valid key", async () => {
-    config.introspection!.azure!.account_name = "epi-test";
-    config.introspection!.azure!.key = "mock access key2";
+    Config().introspection!.azure!.account_name = "epi-test";
+    Config().introspection!.azure!.key = "mock access key2";
     const isValid = await isValidStorageAccount();
 
     expect(isValid).toBe(true);
   });
 
   test("existing storage account with invalid key", async () => {
-    config.introspection!.azure!.account_name = "epi-test";
-    config.introspection!.azure!.key = "mock access key3";
+    Config().introspection!.azure!.account_name = "epi-test";
+    Config().introspection!.azure!.key = "mock access key3";
     const isValid = await isValidStorageAccount();
 
     expect(isValid).toBe(false);

--- a/src/commands/deployment/validate.ts
+++ b/src/commands/deployment/validate.ts
@@ -1,7 +1,7 @@
 import commander from "commander";
+import { Config } from "../../config";
 import { storageAccountExists } from "../../lib/azure/storage";
 import { logger } from "../../logger";
-import { config } from "../init";
 
 /**
  * Adds the validate command to the commander command object
@@ -23,7 +23,7 @@ export const validateCommandDecorator = (command: commander.Command): void => {
  */
 export const isValidConfig = (): boolean => {
   const missingConfig = [];
-
+  const config = Config();
   if (!config.introspection) {
     missingConfig.push("introspection");
   } else {
@@ -69,6 +69,7 @@ export const isValidConfig = (): boolean => {
  * Check is the configured storage account is valid
  */
 export const isValidStorageAccount = async (): Promise<boolean> => {
+  const config = Config();
   const isValid = await storageAccountExists(
     config.introspection!.azure!.resource_group!,
     config.introspection!.azure!.account_name!,

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -1,10 +1,10 @@
-import commander from "commander";
-
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
-import { logger } from "../../logger";
-
-import { config, loadConfiguration } from "../init";
-
+import {
+  BuildDefinition,
+  BuildDefinitionVariable
+} from "azure-devops-node-api/interfaces/BuildInterfaces";
+import commander from "commander";
+import { Config } from "../../config";
 import {
   createPipelineForDefinition,
   definitionForAzureRepoPipeline,
@@ -12,11 +12,7 @@ import {
   IAzureRepoPipelineConfig,
   queueBuild
 } from "../../lib/pipelines/pipelines";
-
-import {
-  BuildDefinition,
-  BuildDefinitionVariable
-} from "azure-devops-node-api/interfaces/BuildInterfaces";
+import { logger } from "../../logger";
 
 export const installHldToManifestPipelineDecorator = (
   command: commander.Command
@@ -28,7 +24,7 @@ export const installHldToManifestPipelineDecorator = (
       "Install the manifest generation pipeline to your Azure DevOps instance"
     )
     .action(async () => {
-      loadConfiguration();
+      const config = Config();
 
       if (!config) {
         logger.error("Config failed to load");

--- a/src/commands/infra/index.ts
+++ b/src/commands/infra/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "../command";
 import { createCommandDecorator } from "./create";
 import { scaffoldCommandDecorator } from "./scaffold";
-import { validateCommandDecorator } from "./vaildate";
+import { validateCommandDecorator } from "./validate";
 
 export const infraCommand = Command(
   "infra",

--- a/src/commands/infra/validate.ts
+++ b/src/commands/infra/validate.ts
@@ -2,8 +2,8 @@ import child_process from "child_process";
 import commander from "commander";
 import emoji from "node-emoji";
 import { promisify } from "util";
+import { Config } from "../../config";
 import { logger } from "../../logger";
-import { config } from "../init";
 
 const binaries: string[] = ["terraform", "git", "az", "helm"];
 const envVar: string[] = [
@@ -62,6 +62,7 @@ export const validatePrereqs = async (
   executables: string[],
   globalInit: boolean
 ): Promise<boolean> => {
+  const config = Config();
   if (!config.infra) {
     config.infra = {};
   }
@@ -92,6 +93,7 @@ export const validatePrereqs = async (
  * Validates that user is logged into Azure CLI
  */
 export const validateAzure = async (globalInit: boolean): Promise<boolean> => {
+  const config = Config();
   // Validate authentication with Azure
   if (!config.infra) {
     config.infra = {};
@@ -125,6 +127,8 @@ export const validateEnvVariables = async (
   variables: string[],
   globalInit: boolean
 ): Promise<boolean> => {
+  const config = Config();
+
   if (!config.infra) {
     config.infra = {};
   }

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,13 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as util from "util";
+import { Config, defaultFileLocation, loadConfiguration } from "../config";
 import { disableVerboseLogging, enableVerboseLogging, logger } from "../logger";
-import {
-  config,
-  defaultFileLocation,
-  loadConfiguration,
-  writeConfigToDefaultLocation
-} from "./init";
+import { writeConfigToDefaultLocation } from "./init";
 
 beforeAll(() => {
   enableVerboseLogging();
@@ -24,11 +20,11 @@ describe("Initializing a project to use spk with a config file", () => {
     process.env.test_key = "my_storage_key";
     const filename = path.resolve(mockFileName);
     loadConfiguration(filename);
-    expect(config.introspection!).toBeDefined();
-    expect(config.introspection!.azure!.account_name).toBe(
+    expect(Config().introspection!).toBeDefined();
+    expect(Config().introspection!.azure!.account_name).toBe(
       process.env.test_name
     );
-    expect(config.introspection!.azure!.key).toBe(process.env.test_key);
+    expect(Config().introspection!.azure!.key).toBe(process.env.test_key);
     logger.info("Able to initialize a basic config file");
   });
 });
@@ -72,13 +68,13 @@ describe("Writing to default config location", () => {
       process.env.test_name = "testStorageName";
       process.env.test_key = "testStorageKey";
       loadConfiguration(filename);
-      config.azure_devops!.access_token = "unit_test_token";
+      Config().azure_devops!.access_token = "unit_test_token";
 
       await writeConfigToDefaultLocation();
-      loadConfiguration(defaultFileLocation);
+      loadConfiguration(defaultFileLocation());
 
-      expect(config.azure_devops!).toBeDefined();
-      expect(config.azure_devops!.access_token!).toBe("unit_test_token");
+      expect(Config().azure_devops!).toBeDefined();
+      expect(Config().azure_devops!.access_token!).toBe("unit_test_token");
     } catch (e) {
       logger.error(e);
       // Make sure execution does not get here:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,19 +1,14 @@
 import commander from "commander";
-import dotenv = require("dotenv");
 import * as fs from "fs";
 import yaml from "js-yaml";
 import * as os from "os";
+import { Config, defaultFileLocation, loadConfiguration } from "../config";
 import { logger } from "../logger";
-import { IConfigYaml } from "../types";
 import {
   validateAzure,
   validateEnvVariables,
   validatePrereqs
-} from "./infra/vaildate";
-
-export const defaultFileLocation = os.homedir() + "/.spk/config.yaml";
-export let config: IConfigYaml = {};
-export const Config = (): IConfigYaml => config;
+} from "./infra/validate";
 
 /**
  * Adds the init command to the commander command object
@@ -60,85 +55,16 @@ export const initCommandDecorator = (command: commander.Command): void => {
 };
 
 /**
- * Loads configuration from a given filename, if provided, otherwise
- * uses the default file location ~/.spk-config.yaml
- * @param fileName file to load configuration from
- */
-export const loadConfiguration = (fileName?: string) => {
-  if (!fileName) {
-    fileName = defaultFileLocation;
-  }
-  try {
-    fs.statSync(fileName);
-    dotenv.config();
-    const data: IConfigYaml = readYamlFile<IConfigYaml>(fileName!);
-    loadConfigurationFromLocalEnv<IConfigYaml>(data);
-  } catch (err) {
-    logger.error(`An error occurred while loading configuration\n ${err}`);
-    throw err;
-  }
-};
-
-/**
- * Reads yaml file and loads any references to env vars from process.env
- * Throws an exception if any env variable references are not defined in
- * current shell
- * @param configYaml configuration in object form
- */
-export const loadConfigurationFromLocalEnv = <T>(configObj: T) => {
-  const iterate = (obj: any) => {
-    if (obj != null && obj !== undefined) {
-      Object.keys(obj).forEach(key => {
-        const regexp = /\${env:([a-zA-Z_$][a-zA-Z_$0-9]+)}/g;
-        const match = regexp.exec(obj[key]);
-        if (match && match.length >= 2) {
-          if (process.env[match[1]]) {
-            obj[key] = process.env[match[1]];
-          } else {
-            logger.error(`Env variable needs to be defined for ${match[1]}`);
-            throw new Error(
-              `Environment variable needs to be defined for ${match[1]} since it's referenced in the config file.`
-            );
-          }
-        }
-        if (typeof obj[key] === "object") {
-          iterate(obj[key]);
-        }
-      });
-    }
-  };
-
-  iterate(configObj);
-  // Set the global config so env vars are loaded into it
-  config = configObj;
-};
-
-/**
- * Reads a YAML file and loads it into an object
- * @param fileLocation path to the config file to read
- */
-export const readYamlFile = <T>(fileLocation: string): T => {
-  const data: string = fs.readFileSync(fileLocation, "utf-8");
-  try {
-    const response = yaml.safeLoad(data) as T;
-    return response;
-  } catch (err) {
-    logger.error(`Unable to parse config file ${fileLocation}`);
-    throw err;
-  }
-};
-
-/**
  * Writes the global config object to default location
  */
 export const writeConfigToDefaultLocation = async () => {
   try {
-    const data = yaml.safeDump(config);
+    const data = yaml.safeDump(Config());
     const defaultDir = os.homedir() + "/.spk";
     if (!fs.existsSync(defaultDir)) {
       fs.mkdirSync(defaultDir);
     }
-    fs.writeFileSync(defaultFileLocation, data);
+    fs.writeFileSync(defaultFileLocation(), data);
   } catch (err) {
     logger.error(
       `Error occurred while writing config to default location ${err}`

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -251,9 +251,9 @@ const generateBedrockFile = async (
       return file;
     },
     {
-      rings: defaultRings.reduce<{ [ring: string]: { default: boolean } }>(
+      rings: defaultRings.reduce<{ [ring: string]: { isDefault: boolean } }>(
         (defaults, ring) => {
-          defaults[ring] = { default: true };
+          defaults[ring] = { isDefault: true };
           return defaults;
         },
         {}

--- a/src/commands/service/create-revision.ts
+++ b/src/commands/service/create-revision.ts
@@ -1,6 +1,6 @@
 import commander from "commander";
 import { join } from "path";
-import { bedrock } from "../../config";
+import { Bedrock } from "../../config";
 import { createPullRequest } from "../../lib/git/azure";
 import { getCurrentBranch, getOriginUrl } from "../../lib/gitutils";
 import { logger } from "../../logger";
@@ -45,10 +45,10 @@ export const createServiceRevisionCommandDecorator = (
         // Give defaults
         ////////////////////////////////////////////////////////////////////////
         // default pull request against initial ring
-        const bedrockConfig = await bedrock();
+        const bedrockConfig = await Bedrock();
         const defaultRings = Object.entries(bedrockConfig.rings || {})
           .map(([branch, config]) => ({ branch, ...config }))
-          .filter(ring => ring.default);
+          .filter(ring => ring.isDefault);
         if (defaultRings.length === 0) {
           throw new Error(
             `No default rings specified in ${join(__dirname, "bedrock.yaml")}`

--- a/src/lib/azure/azurecredentials.ts
+++ b/src/lib/azure/azurecredentials.ts
@@ -1,6 +1,6 @@
 import { ClientSecretCredential } from "@azure/identity";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
-import { config } from "../../commands/init";
+import { Config } from "../../config";
 import { logger } from "../../logger";
 
 /**
@@ -12,6 +12,7 @@ export const getCredentials = async (): Promise<
   if (!verifyConfigDefined()) {
     return undefined;
   }
+  const config = Config();
 
   return new ClientSecretCredential(
     config.introspection!.azure!.tenant_id!,
@@ -29,6 +30,7 @@ export const getManagementCredentials = async (): Promise<
   if (!verifyConfigDefined()) {
     return undefined;
   }
+  const config = Config();
 
   return msRestNodeAuth.loginWithServicePrincipalSecret(
     config.introspection!.azure!.service_principal_id!,
@@ -38,6 +40,7 @@ export const getManagementCredentials = async (): Promise<
 };
 
 const verifyConfigDefined = (): boolean => {
+  const config = Config();
   if (
     config.introspection &&
     config.introspection.azure &&

--- a/src/lib/azure/storage.ts
+++ b/src/lib/azure/storage.ts
@@ -9,7 +9,7 @@ import {
 } from "@azure/arm-storage/esm/models";
 import { exec } from "child_process";
 import { promisify } from "util";
-import { config } from "../../commands/init";
+import { Config } from "../../config";
 import { logger } from "../../logger";
 import { getManagementCredentials } from "./azurecredentials";
 
@@ -22,6 +22,8 @@ import { getManagementCredentials } from "./azurecredentials";
  */
 export const getStorageClient = async (): Promise<StorageManagementClient> => {
   const creds = await getManagementCredentials();
+  const config = Config();
+
   return new StorageManagementClient(
     creds!,
     config.introspection!.azure!.subscription_id!

--- a/src/lib/git/azure.test.ts
+++ b/src/lib/git/azure.test.ts
@@ -2,14 +2,14 @@
 // Mocks
 ////////////////////////////////////////////////////////////////////////////////
 jest.mock("azure-devops-node-api");
-jest.mock("../../commands/init");
+jest.mock("../../config");
 
 ////////////////////////////////////////////////////////////////////////////////
 // Imports
 ////////////////////////////////////////////////////////////////////////////////
 import { WebApi } from "azure-devops-node-api";
 import uuid from "uuid/v4";
-import { Config } from "../../commands/init";
+import { Config } from "../../config";
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 import { createPullRequest, GitAPI } from "./azure";
 

--- a/src/lib/git/azure.ts
+++ b/src/lib/git/azure.ts
@@ -6,7 +6,7 @@ import AZGitInterfaces, {
 import { exec } from "child_process";
 import { promisify } from "util";
 import { IAzureDevOpsOpts, PullRequest } from ".";
-import { Config } from "../../commands/init";
+import { Config } from "../../config";
 import { logger } from "../../logger";
 import { azdoUrl } from "../azdoutil";
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -43,7 +43,7 @@ export interface IHelmConfig {
 export interface IBedrockFile {
   rings?: {
     [branchName: string]: {
-      default: boolean; // indicates the branch is a default branch to PR against when creating a service revision
+      isDefault: boolean; // indicates the branch is a default branch to PR against when creating a service revision
     };
   };
   services: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path");
 module.exports = {
   entry: "./src/index.ts",
   target: "node",
-  mode: "production",
+  mode: "development",
   module: {
     rules: [
       {


### PR DESCRIPTION
- Added top level try/catch for `executeCommand`.
- `loadConfiguration()` is only called when attempting to retrieve the spk config via `Config()`
- Refactored to only have config be retrievable via the `Config()` function.
- Moved code related to spk-config to `config.ts`

fixes https://github.com/microsoft/bedrock/issues/671