### PR TITLE
Bug: resource-group property is missing in spk-config.yaml

### DIFF
--- a/spk-config.yaml
+++ b/spk-config.yaml
@@ -29,3 +29,4 @@ introspection:
     service_principal_secret: "service-principal-secret"
     subscription_id: "subscription-id"
     tenant_id: "tenant-id"
+    resource_group: "resource-group-name"


### PR DESCRIPTION
Bedrock bug: [bedrock/issues/701](https://github.com/microsoft/bedrock/issues/701)