### PR TITLE
Added a top level test to demonstrate in-code end-to-end test

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "shx": "^0.3.2",
     "ts-jest": "^24.0.2",
     "ts-loader": "^6.0.4",
+    "ts-node": "^8.4.1",
     "tslint": "^5.19.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.6.2",

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -22,34 +22,34 @@ export const exec = async (
   opts: child_process.SpawnOptions = {}
 ): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
-    const process = child_process.spawn(cmd, args, opts);
+    const proc = child_process.spawn(cmd, args, opts);
     const cmdString = `${cmd} ${args.join(" ")}`;
     let stdout = "";
     let stderr = "";
 
     // Capture stdout/stderr as process runs
-    if (process.stdout) {
-      process.stdout.on("data", data => {
+    if (proc.stdout) {
+      proc.stdout.on("data", data => {
         logger.debug(`stdout -> '${cmdString}' -> ${data}`.trim());
         stdout = stdout + data;
       });
     }
-    if (process.stderr) {
-      process.stderr.on("data", data => {
+    if (proc.stderr) {
+      proc.stderr.on("data", data => {
         logger.debug(`stderr -> '${cmdString}' -> ${data}`.trim());
         stderr = stderr + data;
       });
     }
 
     // Reject on error
-    process.on("error", err => {
+    proc.on("error", err => {
       logger.verbose(`'${cmdString}' encountered an error during execution`);
       logger.verbose(err);
       reject(err);
     });
 
     // Resolve promise on completion
-    process.on("exit", code => {
+    proc.on("exit", code => {
       // Log completion of of command
       logger.verbose(`'${cmdString}' exited with code: ${code}`);
       if (stdout.length > 0) {

--- a/src/test/command.ts
+++ b/src/test/command.ts
@@ -1,0 +1,30 @@
+import { spawn, SpawnOptions } from "child_process";
+import path from "path";
+
+/**
+ * Wrapper to spawn a ts-node repl and execute a top level command
+ *
+ * @example
+ *  await execCommand(['project', 'init'], {cwd: "/some/project/to/init"})
+ *
+ * @param args Argument array to pass to ./spk
+ * @param opts NodeJS SpawnOptions options
+ */
+export const execCommand = async (args: string[], opts: SpawnOptions = {}) => {
+  const tsNode = path.resolve("node_modules/ts-node/dist/bin.js");
+  const tsConfig = path.resolve("tsconfig.json");
+  const spk = path.resolve("src/index.ts");
+
+  return new Promise<number>((resolve, reject) => {
+    const proc = spawn("node", [tsNode, "--project", tsConfig, spk, ...args], {
+      stdio: "inherit", // pipe all stdio to parent process
+      ...opts
+    });
+    proc.on("exit", code => {
+      resolve(code || 0);
+    });
+    proc.on("error", error => {
+      reject(error);
+    });
+  });
+};

--- a/src/test/project-init.test.ts
+++ b/src/test/project-init.test.ts
@@ -1,0 +1,83 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import shelljs from "shelljs";
+import uuid from "uuid/v4";
+import { execCommand } from "./command";
+
+////////////////////////////////////////////////////////////////////////////////
+// Setup
+////////////////////////////////////////////////////////////////////////////////
+beforeAll(() => {
+  jest.setTimeout(10000); // increase timeout; these tests require loading ts-node
+});
+afterAll(() => {
+  jest.setTimeout(5000); // restore to default timeout
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+
+describe("project", () => {
+  describe("init", () => {
+    describe("standard repo", () => {
+      test("creates all necessary files", async () => {
+        const randomTmpDir = path.join(os.tmpdir(), uuid());
+        shelljs.mkdir("-p", randomTmpDir);
+
+        await execCommand(["project", "init"], { cwd: randomTmpDir });
+
+        const createdFiles = fs.readdirSync(randomTmpDir);
+        for (const file of [
+          ".gitignore",
+          "Dockerfile",
+          "azure-pipelines.yaml",
+          "bedrock.yaml",
+          "maintainers.yaml",
+          "spk.log"
+        ]) {
+          expect(createdFiles.includes(file)).toBe(true);
+        }
+      });
+    });
+
+    describe("mono repo", () => {
+      test("creates all necessary files", async () => {
+        const randomTmpDir = path.join(os.tmpdir(), uuid());
+        const packagePaths = ["a", "b", "c"].map(serviceDir => {
+          const packagePath = path.join(randomTmpDir, "packages", serviceDir);
+          shelljs.mkdir("-p", packagePath);
+          return packagePath;
+        });
+
+        await execCommand(["project", "init", "-m"], { cwd: randomTmpDir });
+
+        // Test all root files are generated in the mono repo
+        const rootFiles = fs.readdirSync(randomTmpDir);
+        for (const file of [
+          "bedrock.yaml",
+          "maintainers.yaml",
+          "packages",
+          "spk.log"
+        ]) {
+          expect(rootFiles.includes(file)).toBe(true);
+        }
+        for (const file of ["Dockerfile", "azure-pipelines.yaml"]) {
+          expect(rootFiles.includes(file)).toBe(false);
+        }
+
+        for (const packagePath of packagePaths) {
+          const filesInService = fs.readdirSync(packagePath);
+          for (const expectedFile of [
+            ".gitignore",
+            "Dockerfile",
+            "azure-pipelines.yaml"
+          ]) {
+            expect(filesInService.includes(expectedFile)).toBe(true);
+          }
+        }
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
+  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -2070,6 +2075,11 @@ diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -4267,7 +4277,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
@@ -6470,6 +6480,17 @@ ts-loader@^6.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
+
 tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -7057,3 +7078,8 @@ yargs@^13.2.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Added a top level test to demonstrate how to test a top level command.
To do so, this test spawns its own ts-node repl and executes the code as
if it were running the spk executable itself.

These tests do not add to the code coverage exported from Jest, but are
good for testing end-to-end scenarios; With this, we can programmatically
test the execution of sequentially top level commands and ensure the
output of the commands is correct.