### PR TITLE
Fixed missing Config() fallback for create-revision command

### DIFF
--- a/src/commands/service/create-revision.ts
+++ b/src/commands/service/create-revision.ts
@@ -1,6 +1,6 @@
 import commander from "commander";
 import { join } from "path";
-import { Bedrock } from "../../config";
+import { Bedrock, Config } from "../../config";
 import { createPullRequest } from "../../lib/git/azure";
 import { getCurrentBranch, getOriginUrl } from "../../lib/gitutils";
 import { logger } from "../../logger";
@@ -38,7 +38,11 @@ export const createServiceRevisionCommandDecorator = (
     .option("")
     .action(async opts => {
       try {
-        const { orgName, personalAccessToken } = opts;
+        const { azure_devops } = Config();
+        const {
+          orgName = azure_devops && azure_devops.org,
+          personalAccessToken = azure_devops && azure_devops.access_token
+        } = opts;
         let { description, remoteUrl, sourceBranch, title } = opts;
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/lib/git/azure.ts
+++ b/src/lib/git/azure.ts
@@ -9,6 +9,7 @@ import { IAzureDevOpsOpts, PullRequest } from ".";
 import { Config } from "../../config";
 import { logger } from "../../logger";
 import { azdoUrl } from "../azdoutil";
+import { getOriginUrl } from "../gitutils";
 
 ////////////////////////////////////////////////////////////////////////////////
 // State
@@ -49,15 +50,14 @@ const generatePRUrl = async (
  * Authenticates using config and credentials from global config and returns
  * an Azure DevOps Git API
  */
-export const GitAPI = async (opts: IAzureDevOpsOpts = {}) => {
+export const GitAPI = async (opts: IAzureDevOpsOpts = {}): Promise<IGitApi> => {
   // Load the gitApi if it has not been initialized
   if (typeof gitApi === "undefined") {
     // Load config from opts and fallback to spk config
-    const config = Config();
+    const { azure_devops } = Config();
     const {
-      personalAccessToken = config.azure_devops &&
-        config.azure_devops.access_token,
-      orgName = config.azure_devops && config.azure_devops.org
+      personalAccessToken = azure_devops && azure_devops.access_token,
+      orgName = azure_devops && azure_devops.org
     } = opts;
 
     // PAT and devops URL are required
@@ -128,17 +128,15 @@ export const createPullRequest: PullRequest = async (
   const gitOrigin: string =
     originPushUrl.length > 0
       ? originPushUrl
-      : await promisify(exec)("git config --get remote.origin.url")
-          .then(out => out.stdout.trim())
-          .catch(err => {
-            logger.error(err);
-            logger.error(
-              `Error parsing remote origin from git client, run 'git config --get remote.origin.url' for more information`
-            );
-            return Promise.reject(
-              Error(`No remote origin found in the current git repository`)
-            );
-          });
+      : await getOriginUrl().catch(err => {
+          logger.error(err);
+          logger.error(
+            `Error parsing remote origin from git client, run 'git config --get remote.origin.url' for more information`
+          );
+          return Promise.reject(
+            Error(`No remote origin found in the current git repository`)
+          );
+        });
 
   // fetch all repositories associated with the personal access token
   const gitAPI = await GitAPI(options);

--- a/src/lib/gitutils.ts
+++ b/src/lib/gitutils.ts
@@ -5,7 +5,7 @@ import { exec } from "./shell";
 /**
  * Gets the current working branch.
  */
-export const getCurrentBranch = async () => {
+export const getCurrentBranch = async (): Promise<string> => {
   try {
     const branch = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
     return branch;
@@ -23,7 +23,7 @@ export const getCurrentBranch = async () => {
 export const checkoutBranch = async (
   branchName: string,
   createNewBranch: boolean
-) => {
+): Promise<void> => {
   try {
     if (createNewBranch) {
       await exec("git", ["checkout", "-b", `${branchName}`]);
@@ -31,7 +31,7 @@ export const checkoutBranch = async (
       await exec("git", ["checkout", `${branchName}`]);
     }
   } catch (_) {
-    throw new Error(`Unable to checkout git branch ${branchName}: ` + _);
+    throw Error(`Unable to checkout git branch ${branchName}: ` + _);
   }
 };
 
@@ -40,11 +40,11 @@ export const checkoutBranch = async (
  *
  * @param branchName
  */
-export const deleteBranch = async (branchName: string) => {
+export const deleteBranch = async (branchName: string): Promise<void> => {
   try {
     await exec("git", ["branch", "-D", `${branchName}`]);
   } catch (_) {
-    throw new Error(`Unable to delete git branch ${branchName}: ` + _);
+    throw Error(`Unable to delete git branch ${branchName}: ` + _);
   }
 };
 
@@ -54,12 +54,15 @@ export const deleteBranch = async (branchName: string) => {
  * @param directory
  * @param branchName
  */
-export const commitDir = async (directory: string, branchName: string) => {
+export const commitDir = async (
+  directory: string,
+  branchName: string
+): Promise<void> => {
   try {
     await exec("git", ["add", `${directory}`]);
     await exec("git", ["commit", "-m", `Adding new service: ${branchName}`]);
   } catch (_) {
-    throw new Error(
+    throw Error(
       `Unable to commit changes in ${directory} to git branch ${branchName}: ` +
         _
     );
@@ -71,18 +74,18 @@ export const commitDir = async (directory: string, branchName: string) => {
  *
  * @param branchName
  */
-export const pushBranch = async (branchName: string) => {
+export const pushBranch = async (branchName: string): Promise<void> => {
   try {
     await exec("git", ["push", "-u", "origin", `${branchName}`]);
   } catch (_) {
-    throw new Error(`Unable to push git branch ${branchName}: ` + _);
+    throw Error(`Unable to push git branch ${branchName}: ` + _);
   }
 };
 
 /**
  * Gets the origin url.
  */
-export const getOriginUrl = async () => {
+export const getOriginUrl = async (): Promise<string> => {
   try {
     const originUrl = await exec("git", [
       "config",
@@ -92,9 +95,8 @@ export const getOriginUrl = async () => {
     logger.debug(`Got git origin url ${originUrl}`);
     return originUrl;
   } catch (_) {
-    throw new Error(`Unable to get git origin URL.: ` + _);
+    throw Error(`Unable to get git origin URL.: ` + _);
   }
-  return "";
 };
 
 /**
@@ -109,7 +111,7 @@ export const getPullRequestLink = async (
   baseBranch: string,
   newBranch: string,
   originUrl: string
-) => {
+): Promise<string> => {
   try {
     const gitComponents = GitUrlParse(originUrl);
     if (gitComponents.resource.includes("dev.azure.com")) {
@@ -125,7 +127,7 @@ export const getPullRequestLink = async (
       return "Could not determine origin repository, or it is not a supported provider. Please check for the newly pushed branch and open a PR manually.";
     }
   } catch (_) {
-    throw new Error(
+    throw Error(
       `"Could not determine git provider, or it is not a supported type.": ` + _
     );
   }
@@ -134,7 +136,7 @@ export const getPullRequestLink = async (
 export const checkoutCommitPushCreatePRLink = async (
   newBranchName: string,
   directory: string
-) => {
+): Promise<void> => {
   try {
     const currentBranch = await getCurrentBranch();
     try {


### PR DESCRIPTION
Added the missing `--personal-access-token` and `--org-name` fallback
for the `create-revision` command. Flags still take precedent, but if
they are not present, the values expressed in spk-config.yaml will be
used.