### PR TITLE
`spk deployment get` was showing empty list

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "node-emoji": "^1.10.0",
     "open": "^6.4.0",
     "shelljs": "^0.8.3",
-    "spektate": "^0.1.5",
+    "spektate": "^0.1.7",
     "uuid": "^3.3.3",
     "winston": "^3.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6021,10 +6021,10 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-spektate@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.5.tgz#7d34fc6dc81970a43a2e113da0d03981d02abe84"
-  integrity sha512-doSQ1UFAfcHa1xi5mpF/i8oGemtuAnP/NA+Bn1t03ojnb04oKzbcSPF76fOyGBf8XgmxYvY/ai+yP2ncx0QopA==
+spektate@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.7.tgz#39bcd1d905090f914f95b7a23bbd54ba41c939f8"
+  integrity sha512-ONYGn68wjd5efdJdcyxsGS+bwGloQR0KbHX0sT9kNsC4/kjSU8QIzgdkRBz+BKAOGeKM4g7LDCAYBta/EDpLfg==
   dependencies:
     axios "^0.19.0"
     azure-storage "^2.10.3"


### PR DESCRIPTION
because of the missing null check in spektate package. 🤦‍♀ 

Use the new version of spektate