### PR TITLE
Use a config param for private src repo access token

### DIFF
--- a/spk-config.yaml
+++ b/spk-config.yaml
@@ -23,6 +23,7 @@ introspection:
     table_name: "storage-account-table-name" # Must be defined to run spk deployment commands
     partition_key: "storage-account-table-partition-key" # Must be defined to run spk deployment commands
     key: "storage-access-key" # Must be defined to run spk deployment commands. Use ${env:INTROSPECTION_STORAGE_ACCESS_KEY} and set it in .env file
+    source_repo_access_token: "source_repo_access_token" # Optional. Define this to see author names in the dashboard
 
     # Following 5 fields are needed only if using spk to onboard to use introspection tool
     service_principal_id: "service-principal-id"

--- a/spk-config.yaml
+++ b/spk-config.yaml
@@ -23,7 +23,7 @@ introspection:
     table_name: "storage-account-table-name" # Must be defined to run spk deployment commands
     partition_key: "storage-account-table-partition-key" # Must be defined to run spk deployment commands
     key: "storage-access-key" # Must be defined to run spk deployment commands. Use ${env:INTROSPECTION_STORAGE_ACCESS_KEY} and set it in .env file
-    source_repo_access_token: "source_repo_access_token" # Optional. Define this to see author names in the dashboard
+    source_repo_access_token: "source_repo_access_token" # Optional. Required only when source repository is private (in order to render the author column in dashboard)
 
     # Following 5 fields are needed only if using spk to onboard to use introspection tool
     service_principal_id: "service-principal-id"

--- a/src/commands/deployment/dashboard.ts
+++ b/src/commands/deployment/dashboard.ts
@@ -137,6 +137,13 @@ const getEnvVars = (): string[] => {
       "REACT_APP_PIPELINE_ACCESS_TOKEN=" + config.azure_devops!.access_token
     );
   }
+  if (config.introspection!.azure!.source_repo_access_token) {
+    envVars.push("-e");
+    envVars.push(
+      "REACT_APP_SOURCE_REPO_ACCESS_TOKEN=" +
+        config.introspection!.azure!.source_repo_access_token
+    );
+  }
 
   return envVars;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -151,6 +151,7 @@ export interface IConfigYaml {
       table_name?: string;
       partition_key?: string;
       key?: string;
+      source_repo_access_token?: string;
       service_principal_id?: string;
       service_principal_secret?: string;
       subscription_id?: string;


### PR DESCRIPTION
Closes https://github.com/microsoft/bedrock/issues/707

When the source repo is private, spektate needs a personal access token to get Author information. 

Corresponding PR in spektate: https://github.com/microsoft/spektate/pull/42