### PR TITLE
Added source to ACR workflow

### DIFF
--- a/docs/service-management.md
+++ b/docs/service-management.md
@@ -33,8 +33,9 @@ Global options:
 Add a new service into this initialized spk project repository
 
 ```
-Usage:
-spk service create|c [options] <service-name>
+Usage: service create|c [options] <service-name>
+
+Add a new service into this initialized spk project repository
 
 Options:
   -c, --helm-chart-chart <helm-chart>            bedrock helm chart name. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
@@ -61,7 +62,7 @@ Configure Azure DevOps for a bedrock managed service.
 ```
 Usage: service create-pipeline|p [options] <service-name>
 
-Configure Azure DevOps for a bedrock managed service
+Configure Azure DevOps for a bedrock managed service.
 
 Options:
   -n, --pipeline-name <pipeline-name>                  Name of the pipeline to be created
@@ -70,7 +71,7 @@ Options:
   -r, --repo-name <repo-name>                          Repository Name in Azure DevOps
   -u, --repo-url <repo-url>                            Repository URL
   -d, --devops-project <devops-project>                Azure DevOps Project
-  -l, --packages-dir <packages-dir>                    The monorepository directory containing this service definition. ie. '--packages-dir packages' if my-service is located under ./packages/my-service.
+  -l, --packages-dir <packages-dir>                    The mono-repository directory containing this service definition. ie. '--packages-dir packages' if my-service is located under ./packages/my-service. Omitting this option implies this is a not a mono-repository.
   -h, --help                                           output usage information
 ```
 

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -63,7 +63,7 @@ export const installHldToManifestPipelineDecorator = (
         );
       } catch (err) {
         logger.error(
-          `Error occured installing pipeline for HLD to Manifest pipeline`
+          `Error occurred installing pipeline for HLD to Manifest pipeline`
         );
         logger.error(err);
         process.exit(1);

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -1,8 +1,6 @@
 import commander from "commander";
 import path from "path";
 import shelljs from "shelljs";
-import { logger } from "../../logger";
-
 import {
   addNewServiceToBedrockFile,
   addNewServiceToMaintainersFile,
@@ -11,6 +9,7 @@ import {
   generateStarterAzurePipelinesYaml
 } from "../../lib/fileutils";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
+import { logger } from "../../logger";
 import { IHelmConfig, IUser } from "../../types";
 
 /**

--- a/src/commands/variable-group/create.ts
+++ b/src/commands/variable-group/create.ts
@@ -1,6 +1,7 @@
 import { VariableGroup } from "azure-devops-node-api/interfaces/ReleaseInterfaces";
 import commander from "commander";
 import fs from "fs";
+import path from "path";
 import { readYaml } from "../../config";
 import { IAzureDevOpsOpts } from "../../lib/git";
 import {
@@ -102,11 +103,13 @@ export const create = async (
   filepath: string,
   accessOpts: IAzureDevOpsOpts
 ) => {
-  logger.info("Creating variale group");
+  logger.info(
+    `Creating Variable Group from group definition '${path.resolve(filepath)}'`
+  );
   try {
     fs.statSync(filepath);
     const data = readYaml<IVariableGroupData>(filepath);
-    logger.debug(`Varible Group Yaml data: ${JSON.stringify(data)}`);
+    logger.debug(`Variable Group Yaml data: ${JSON.stringify(data)}`);
 
     // validate variable group type
 
@@ -118,7 +121,7 @@ export const create = async (
       variableGroup = await addVariableGroup(data, accessOpts);
     } else {
       throw new Error(
-        `Varible Group type "${data.type}" is not supported. Only "Vsts" and "AzureKeyVault" are valid types and case sensitive.`
+        `Variable Group type "${data.type}" is not supported. Only "Vsts" and "AzureKeyVault" are valid types and case sensitive.`
       );
     }
   } catch (err) {

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -89,12 +89,14 @@ export const starterAzurePipelines = async (opts: {
   vmImage?: string;
   branches?: string[];
   variableGroups?: string[];
+  variables?: Array<{ name: string; value: string }>;
 }): Promise<IAzurePipelinesYaml> => {
   const {
     relProjectPaths = ["."],
     vmImage = "ubuntu-latest",
     branches = ["master"],
-    variableGroups = []
+    variableGroups = [],
+    variables = []
   } = opts;
 
   // Ensure any blank paths are turned into "./"
@@ -109,20 +111,11 @@ export const starterAzurePipelines = async (opts: {
       branches: { include: branches },
       paths: { include: cleanedPaths }
     },
-    variables: [...variableGroups.map(group => ({ group }))],
+    variables: [...variableGroups.map(group => ({ group })), ...variables],
     pool: {
       vmImage
     },
     steps: [
-      {
-        script: generateYamlScript([
-          `printenv | sort`,
-          `pwd`,
-          `ls -la`,
-          `echo "The name of this service is: $(BUILD.BUILDNUMBER)"`
-        ]),
-        displayName: "Run a multi-line script"
-      },
       {
         script: generateYamlScript([
           `echo "az login --service-principal --username $(SP_APP_ID) --password $(SP_PASS) --tenant $(SP_TENANT)"`,
@@ -131,22 +124,55 @@ export const starterAzurePipelines = async (opts: {
         displayName: "Azure Login"
       },
       ...cleanedPaths.map(projectPath => {
+        const projectPathParts = projectPath
+          .split(path.sep)
+          .filter(p => p !== "");
+        // If a the projectPath contains more than 1 segment (a service in a
+        // mono-repo), use the last part as the project name as it will the
+        // folder containing the Dockerfile. Otherwise, its a standard service
+        // and does not need a a project name
+        const projectName =
+          projectPathParts.length > 1
+            ? "-" + projectPathParts.slice(-1)[0]
+            : "";
         return {
           script: generateYamlScript([
             `cd ${projectPath} # Need to make sure Build.DefinitionName matches directory. It's case sensitive`,
             `echo "az acr build -r $(ACR_NAME) --image $(Build.DefinitionName):$(build.SourceBranchName)-$(build.BuildId) ."`,
-            `az acr build -r $(ACR_NAME) --image $(Build.DefinitionName):$(build.SourceBranchName)-$(build.BuildId) .`
+            `az acr build -r $(ACR_NAME) --image $(Build.DefinitionName)${projectName}:$(build.SourceBranchName)-$(build.BuildId) .`
           ]),
           displayName: "ACR Build and Publish"
         };
-      }),
-      {
-        script: generateYamlScript([`echo Hello, world!`]),
-        displayName: "Run a one-line script"
-      }
+      })
     ]
   };
   // tslint:enable: object-literal-sort-keys
+
+  const requiredPipelineVariables = [
+    `'ACR_NAME' (name of your ACR)`,
+    `'SP_APP_ID' (service principal ID with access to your ACR)`,
+    `'SP_PASS' (service principal secret)`,
+    `'SP_TENANT' (service principal tenant)`
+  ].join(", ");
+
+  for (const relPath of cleanedPaths) {
+    const relPathParts = relPath.split(path.sep).filter(p => p !== "");
+    const packagesDir =
+      relPathParts.length > 1 ? relPathParts.slice(-2)[0] : undefined;
+    const packagesOption = packagesDir ? `--packages-dir ${packagesDir} ` : "";
+    const serviceName =
+      relPathParts.length > 1
+        ? relPathParts.slice(-2)[1]
+        : process
+            .cwd()
+            .split(path.sep)
+            .slice(-1)[0];
+    const spkServiceCreatePipelineCmd =
+      "spk service create-pipeline " + packagesOption + serviceName;
+    logger.info(
+      `Generated azure-pipelines.yaml for service in path '${relPath}'. Commit and push this file to master before attempting to deploy via the command '${spkServiceCreatePipelineCmd}'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
+    );
+  }
 
   return starter;
 };

--- a/src/lib/pipelines/pipelines.ts
+++ b/src/lib/pipelines/pipelines.ts
@@ -212,10 +212,23 @@ export const createPipelineForDefinition = async (
   logger.info("Creating pipeline for definition");
 
   try {
-    return await buildApi.createDefinition(definition, azdoProject);
+    logger.debug(
+      `Creating BuildDefinition based on ${JSON.stringify(definition)}`
+    );
+    const createdDefn = await buildApi.createDefinition(
+      definition,
+      azdoProject
+    );
+    // type definition for createDefinition is wrong. It will resolve a `null` if an error occurs in azdo
+    if (!createdDefn) {
+      throw Error(
+        `Error creating BuildDefinition; buildApi.createDefinition() returned an invalid value of ${createdDefn}`
+      );
+    }
+    return createdDefn;
   } catch (e) {
     logger.error(e);
-    throw new Error("Error creating definition");
+    throw Error("Error creating definition");
   }
 };
 
@@ -231,16 +244,16 @@ export const queueBuild = async (
   azdoProject: string,
   definitionId: number
 ): Promise<Build> => {
-  const buildReference = {
+  const buildReference: Build = {
     definition: {
       id: definitionId
     }
-  } as Build;
+  };
 
   try {
     return await buildApi.queueBuild(buildReference, azdoProject);
   } catch (e) {
     logger.error(e);
-    throw new Error("Error queueing build");
+    throw Error("Error queueing build");
   }
 };

--- a/src/lib/pipelines/variableGroup.ts
+++ b/src/lib/pipelines/variableGroup.ts
@@ -17,7 +17,9 @@ import { createServiceEndpointIfNotExists } from "./serviceEndpoint";
 let taskApi: ITaskAgentApi | undefined; // keep track of the gitApi so it can be reused
 
 /**
- * Creates AzDo `azure-devops-node-api.WebApi.ITaskAgentApi` with `orgUrl` and `token and returns `ITaskAgentApi`
+ * Creates AzDo `azure-devops-node-api.WebApi.ITaskAgentApi` with `orgUrl` and
+ * `token and returns `ITaskAgentApi`
+ *
  * @param opts optionally override spk config with Azure DevOps access options
  * @returns new `ITaskAgentApi` object
  */
@@ -40,7 +42,9 @@ export const TaskApi = async (
 };
 
 /**
- * Adds Variable group `groupConfig` in Azure DevOps project and returns `VariableGroup` object
+ * Adds Variable group `groupConfig` in Azure DevOps project and returns
+ * `VariableGroup` object
+ *
  * @param variableGroupData with required variables
  * @param opts optionally override spk config with Azure DevOps access options
  * @returns newly created `VariableGroup` object
@@ -63,7 +67,7 @@ export const addVariableGroup = async (
     // map variables from configuration
     const variablesMap = await buildVariablesMap(variableGroupData.variables!);
 
-    // create variable group parameterts
+    // create variable group parameters
     const params: VariableGroupParameters = {
       description: variableGroupData.description,
       name: variableGroupData.name,
@@ -79,7 +83,9 @@ export const addVariableGroup = async (
 };
 
 /**
- * * Adds Variable group `groupConfig` with Key Valut maopping in Azure DevOps project and returns `VariableGroup` object
+ * Adds Variable group `groupConfig` with Key Value mapping in Azure DevOps
+ * project and returns `VariableGroup` object
+ *
  * @param variableGroupData with required variables
  * @param opts optionally override spk config with Azure DevOps access options
  * @returns newly created `VariableGroup` object
@@ -122,10 +128,10 @@ export const addVariableGroupWithKeyVaultMap = async (
       vault: variableGroupData.key_vault_provider!.name
     };
 
-    // map variables as secrets from inout
+    // map variables as secrets from input
     const secretsMap = await buildVariablesMap(variableGroupData.variables!);
 
-    // creating variable group parameterts
+    // creating variable group parameters
     const params: VariableGroupParameters = {
       description: variableGroupData.description,
       name: variableGroupData.name,
@@ -142,28 +148,35 @@ export const addVariableGroupWithKeyVaultMap = async (
 };
 
 /**
- * * Adds Variable group with `VariableGroupParameters` data and returns `VariableGroup` object.
+ * Adds Variable group with `VariableGroupParameters` data and returns
+ * `VariableGroup` object.
  *
- * @param variableGroupdata The Variable group data
+ * @param variableGroupData The Variable group data
  * @param accessToAllPipelines Whether the variable group should be accessible by all pipelines
  * @param opts optionally override spk config with Azure DevOps access options
  * @returns newly created `VariableGroup` object
  */
 export const doAddVariableGroup = async (
-  variableGroupdata: VariableGroupParameters,
+  variableGroupData: VariableGroupParameters,
   accessToAllPipelines: boolean,
   opts: IAzureDevOpsOpts = {}
 ): Promise<VariableGroup> => {
-  const message: string = `Variable Group ${variableGroupdata.name}`;
+  const message: string = `Variable Group ${variableGroupData.name}`;
   const config = Config();
   const { project = config.azure_devops && config.azure_devops.project } = opts;
+  if (typeof project !== "string") {
+    throw Error(
+      `Azure DevOps Project not defined; ensure that azure_devops.project is set`
+    );
+  }
   try {
     logger.debug(
-      `Creating new Variable Group ${JSON.stringify(variableGroupdata)}`
+      `Creating new Variable Group ${JSON.stringify(variableGroupData)}`
     );
+    logger.info(`Attempting to create Variable Group in project '${project}'`);
     const taskClient: ITaskAgentApi = await TaskApi(opts);
     const group: VariableGroup = await taskClient.addVariableGroup(
-      variableGroupdata,
+      variableGroupData,
       project!
     );
     logger.debug(`Created new Variable Group: ${JSON.stringify(group)}`);
@@ -181,11 +194,12 @@ export const doAddVariableGroup = async (
 };
 
 /**
- * * Enables authorization for all pipelines to access Variable group with `variableGroup` data and returns `true` if successful
+ * Enables authorization for all pipelines to access Variable group with
+ * `variableGroup` data and returns `true` if successful
  *
  * @param variableGroup The Variable group object
  * @param opts optionally override spk config with Azure DevOps access options
- * @returns `true` if successfull; otherwise `false`
+ * @returns `true` if successful; otherwise `false`
  */
 export const authorizeAccessToAllPipelines = async (
   variableGroup: VariableGroup,
@@ -239,7 +253,7 @@ export const authorizeAccessToAllPipelines = async (
 };
 
 /**
- * * Key/value interface for variables
+ * Key/value interface for variables
  *
  */
 export interface IVariablesMap {
@@ -247,7 +261,8 @@ export interface IVariablesMap {
 }
 
 /**
- * * Creates `IVariablesMap` object from variables key/value apirs
+ * Creates `IVariablesMap` object from variables key/value pairs
+ *
  * @param variableGroup The Variable group object
  * @returns `IVariablesMap[]` with Varibale Group variables
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/runtime@^7.4.5":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@~7.4.4":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
@@ -581,9 +588,9 @@
     "@types/jest" "*"
 
 "@types/jest@*", "@types/jest@^24.0.18":
-  version "24.0.19"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.19.tgz#f7036058d2a5844fe922609187c0ad8be430aff5"
-  integrity sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==
+  version "24.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.20.tgz#729d5fe8684e7fb06368d3bd557ac6d91289d861"
+  integrity sha512-M8ebEkOpykGdLoRrmew7UowTZ1DANeeP0HiSIChl/4DGgmnSC1ntitNtkyNSXjMTsZvXuaxJrxjImEnRWNPsPw==
   dependencies:
     "@types/jest-diff" "*"
 
@@ -617,14 +624,14 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^12.7.8":
-  version "12.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.6.tgz#2f8d551aef252de78f42acdccd53f5a8ce0cac4d"
-  integrity sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ==
+  version "12.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
+  integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
 
 "@types/node@^8.0.47":
-  version "8.10.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.55.tgz#3951a64ebce1927b050fd1e420dc6f332be8a1e0"
-  integrity sha512-iZeh1EgupfmAAOASk580R1SL5lWF3CsBVgVH0395qyNF8fhO16xy1UwAav2PdGxIIsYRn7RzJgMGjdsvam6YYg==
+  version "8.10.56"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.56.tgz#f1d55b979163cc0cfb6b927b6e4bf9632bcc8fe7"
+  integrity sha512-5yWs9hy3UWdandOgvmmPCNJ3jI5/o8syatQWOmiAO/9/PptOQ+0O2ANKHltFhE4MGCt/QiVkoxQFUbeha9Yf4w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1067,6 +1074,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-metadata-inferer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz#66e24fae9d30ca961fac4880b7fc466f09b25165"
+  integrity sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -1348,6 +1360,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@^4.6.3:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.2.tgz#1bb984531a476b5d389cedecb195b2cd69fb1348"
+  integrity sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==
+  dependencies:
+    caniuse-lite "^1.0.30001004"
+    electron-to-chromium "^1.3.295"
+    node-releases "^1.1.38"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -1495,6 +1516,16 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+caniuse-db@^1.0.30000977:
+  version "1.0.30001005"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001005.tgz#a61131ed16f519fbef25612e36dced8e69635455"
+  integrity sha512-MSRfm2N6FRDSpAJ00ipCuFe0CNink5JJOFzl4S7fLSBJdowhGq3uMxzkWGTjvvReo1PuWfK5YYJydJJ+9mJebw==
+
+caniuse-lite@^1.0.30001004:
+  version "1.0.30001005"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz#823054210be638c725521edcb869435dae46728d"
+  integrity sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1735,11 +1766,9 @@ concat-stream@^1.5.0:
     typedarray "^0.0.6"
 
 console-browserify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
-  integrity sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
-  dependencies:
-    date-now "^0.1.4"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
+  integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -1914,11 +1943,6 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-date-now@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
-  integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
 date-utils@*:
   version "1.2.21"
@@ -2152,6 +2176,11 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+electron-to-chromium@^1.3.295:
+  version "1.3.296"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz#a1d4322d742317945285d3ba88966561b67f3ac8"
+  integrity sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -2302,6 +2331,19 @@ escodegen@~1.11.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-compat@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz#ece063f53793e6859243ce6cb9634865f745b72e"
+  integrity sha512-QCgYy3pZ+zH10dkBJus1xER0359h1UhJjufhQRqp9Owm6BEoLZeSqxf2zINwL1OGao9Yc96xPYIW3nQj5HUryg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    ast-metadata-inferer "^0.1.1"
+    browserslist "^4.6.3"
+    caniuse-db "^1.0.30000977"
+    lodash.memoize "4.1.2"
+    mdn-browser-compat-data "^0.0.84"
+    semver "^6.1.2"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -2445,7 +2487,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.2, extend@~3.0.2:
+extend@3.0.2, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2919,10 +2961,11 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.2:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.5.tgz#1b1f94f9bfe7379adda86a8b73fb570265a0dddd"
-  integrity sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.0.tgz#d5d902dfe0f266ef79f3921b89233a5f611cdea7"
+  integrity sha512-yss1ZbupTpRfe86dpM1abxnnSfxa6eIRn3laqBPIgRYy87qgYtX6xinSOeybjYo/4AVzdTTWK5Kr06A6AllxJg==
   dependencies:
+    eslint-plugin-compat "^3.3.0"
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
@@ -4210,7 +4253,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.memoize@4.x:
+lodash.memoize@4.1.2, lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -4346,6 +4389,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdn-browser-compat-data@^0.0.84:
+  version "0.0.84"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz#791d0e238cff5779fae589f99f5b2c7b84ea44b5"
+  integrity sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==
+  dependencies:
+    extend "3.0.2"
 
 mem@^4.0.0:
   version "4.3.0"
@@ -4721,6 +4771,13 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-releases@^1.1.38:
+  version "1.1.39"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.39.tgz#c1011f30343aff5b633153b10ff691d278d08e8d"
+  integrity sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==
+  dependencies:
+    semver "^6.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5844,7 +5901,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.2.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -6074,9 +6131,9 @@ spdx-license-ids@^3.0.0:
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 spektate@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.7.tgz#39bcd1d905090f914f95b7a23bbd54ba41c939f8"
-  integrity sha512-ONYGn68wjd5efdJdcyxsGS+bwGloQR0KbHX0sT9kNsC4/kjSU8QIzgdkRBz+BKAOGeKM4g7LDCAYBta/EDpLfg==
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.10.tgz#3ea3bdfae1533c4ce5d06be4d6c892d1474e03c9"
+  integrity sha512-wwmKnbQ/kNcjve5BWWKsAZSjtDEihAKxnJF9+hzYOTSXnN2EJ5R4GQIhZnFbbVYTJyzVI6lRQy2aQ9a2u8iwVg==
   dependencies:
     axios "^0.19.0"
     azure-storage "^2.10.3"


### PR DESCRIPTION
This PR focuses around ironing out the flow of running `spk project init` or
`spk project init -m`, creating pipelines via the generated
`azure-pipelines.yaml` files, and ensuring the pipeline can create appropriately
named/tagged docker images in ACR.

In order to allow for flexibility in how SRE's choose to deploy the pipelines,
this PR does not automate the actual deployment of the pipeline. Instead, `info`
level instructions have been added specifying how to run the
`spk service create-pipeline` to deploy the `azure-pipelines.yaml` generated; If
the the user has configured the spk config correctly, the outputted command is
copy/paste ready to deploy the generated pipelines yaml:

If ran on a mono-repo:
`spk service create-pipeline --project-dir packages my-service` will be logged.

If ran on a standard repo: `spk service create-pipeline my-service` will be
logged.

The `azure-pipelines.yaml` expects 4 environment variables to be present in
order to login to `az` cli and build and push an image to ACR:

- `ACR_NAME` - name of the target ACR
- `SP_APP_ID` - service principal ID
- `SP_PASS` - service principal password
- `SP_TENANT` - service principal tenant

These requirements are also `info` logged to the end user upon
`azure-pipelines.yaml` generation.

Previously `spk service create-pipeline` only worked for mono-repositories and
the code has been refactored such that the existence of the `--packages-dir`
options implies whether or not the repository is a mono-repository or a standard
one.

closes https://github.com/microsoft/bedrock/issues/646