### PR TITLE
Added command `spk ingress-route create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Commands:
 - [spk init](./docs/init.md)
 - [spk project](./docs/project-management.md)
 - [spk service](./docs/service-management.md)
-- [spk variable group](./docs/variable-group.md)
+- [spk variable-group](./docs/variable-group.md)
+- [spk ingress-group](./docs/ingress-route-management.md)
 
 ## Getting Started
 

--- a/docs/ingress-route-management.md
+++ b/docs/ingress-route-management.md
@@ -1,0 +1,73 @@
+# Ingress Route Management
+
+Manage your Traefik `IngressRoute`s
+
+## Commands
+
+### create
+
+A command to create Kubernetes Traefik `IngressRoute`s.
+
+The primary usage of this command is to be used via pipelines to modifying your
+HLD with the appropriate manifests for ring based routing.
+
+```sh
+Usage: ingress-route create|c [options] <service> <port>
+
+Create a Traefik IngressRoute for a target <service>:<port>
+
+Options:
+  -r, --ring <ring>             the ring to deploy this service to, if provided the generated IngressRoute will target service `<service>-<ring>` (default: "")
+  --entry-point <entry-point>   the Traefik IngressRoute entryPoint; can be either 'web' or 'web-secure'; defaults to allowing all traffic if left blank (default: "")
+  --namespace <namespace>       a namespace to inject into the outputted Kubernetes manifest (default: "")
+  -o, --output-file <filepath>  filepath to output the IngressRoute YAML to; defaults to outputting to stdout (default: "")
+  -h, --help                    output usage information
+```
+
+#### Examples:
+
+**Outputting to stdout (useful if you need to pipe the output):**
+
+```sh
+$ spk ingress-route create my-service 80 --ring production --entry-point web --namespace my-fancy-ns
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: my-service-production
+  namespace: my-fancy-ns
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: 'PathPrefix(`/my-service`) && Headers(`Ring`, `production`)'
+      services:
+        - name: my-service-production
+          port: 80
+```
+
+**Outputting to to a file:**
+
+Note: the directory specified via `--output-file` will be automatically created
+if it does not exist.
+
+```sh
+$ spk ingress-route create my-service 80 --ring production --entry-point web --namespace my-fancy-ns --output-file ~/my/k8s/manifests/ingress.yaml
+info:    Writing IngressRule YAML to /Users/User/my/k8s/manifests/ingress.yaml
+info:    Successfully wrote IngressRule YAML to /Users/User/my/k8s/manifests/ingress.yaml
+$ cat ~/my/k8s/manifests/ingress.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: my-service-production
+  namespace: my-fancy-ns
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: 'PathPrefix(`/my-service`) && Headers(`Ring`, `production`)'
+      services:
+        - name: my-service-production
+          port: 80
+```

--- a/docs/init.md
+++ b/docs/init.md
@@ -1,6 +1,6 @@
 # SPK Init
 
-Initalize the `spk` cli for the first time.
+Initialize the `spk` cli for the first time.
 
 Usage:
 

--- a/src/commands/ingress-route/create.ts
+++ b/src/commands/ingress-route/create.ts
@@ -1,0 +1,115 @@
+import commander from "commander";
+import { writeFileSync } from "fs";
+import fs from "fs";
+import yaml from "js-yaml";
+import path from "path";
+import shelljs from "shelljs";
+import { TraefikIngressRoute } from "../../lib/traefik/ingress-route";
+import { logger } from "../../logger";
+
+export const create = (command: commander.Command): void => {
+  command
+    .command("create <service> <port>")
+    .alias("c")
+    .description("Create a Traefik IngressRoute for a target <service>:<port>")
+    .option(
+      "-r, --ring <ring>",
+      "the ring to deploy this service to, if provided the generated IngressRoute will target service `<service>-<ring>`",
+      ""
+    )
+    .option(
+      "--entry-point <entry-point>",
+      "the Traefik IngressRoute entryPoint; can be either 'web' or 'web-secure'; defaults to allowing all traffic if left blank",
+      ""
+    )
+    .option(
+      "--namespace <namespace>",
+      "a namespace to inject into the outputted Kubernetes manifest",
+      ""
+    )
+    .option(
+      "-o, --output-file <filepath>",
+      "filepath to output the IngressRoute YAML to; defaults to outputting to stdout",
+      ""
+    )
+    .action(
+      async (service, port, { ring, entryPoint, namespace, outputFile }) => {
+        try {
+          // type-check everything
+          const portAsNum = Number.parseInt(port, 10);
+          if (typeof portAsNum !== "number" || isNaN(portAsNum)) {
+            throw Error(
+              `<port> expects a base 10 parsable number, unable to convert '${port}' to a number`
+            );
+          }
+          if (typeof service !== "string") {
+            throw Error(
+              `<service> expects a 'string' value, '${typeof service} provided'`
+            );
+          }
+          if (typeof ring !== "string") {
+            throw Error(
+              `--ring expects a 'string' value, '${typeof ring}' provided`
+            );
+          }
+          if (!["", "web", "web-secure"].includes(entryPoint)) {
+            throw Error(
+              `--entry-point expects a 'string' value of either 'web' or 'web-secure', '${entryPoint}' provided`
+            );
+          }
+          if (typeof namespace !== "string") {
+            throw Error(
+              `--namespace expects a 'string' value, '${typeof namespace}' provided`
+            );
+          }
+
+          // create the route
+          const ingressRoute = TraefikIngressRoute(service, ring, portAsNum, {
+            entryPoints: [entryPoint].filter(entry => entry !== ""),
+            namespace
+          });
+          const routeYaml = yaml.safeDump(ingressRoute, {
+            lineWidth: Number.MAX_SAFE_INTEGER
+          });
+
+          // output to file or stdout based on --output-file
+          if (!!outputFile) {
+            // Write out file
+            if (typeof outputFile !== "string") {
+              throw Error(
+                `--output-file <filepath> expects a 'string', ${typeof outputFile} provided`
+              );
+            }
+
+            // Ensure the parent directories exist
+            const outputPath = path.resolve(outputFile);
+            const outputDir = outputPath
+              .split(path.sep)
+              .slice(0, -1)
+              .join(path.sep);
+            if (!fs.existsSync(outputDir)) {
+              logger.warn(
+                `Output directory for ${outputFile} specified by --output-path does not exist, creating directory ${outputDir}`
+              );
+              const { code } = shelljs.mkdir("-p", outputDir);
+              if (code !== 0) {
+                throw Error(`unable to create directory ${outputDir}`);
+              }
+            }
+
+            // Write out the YAML
+            logger.info(`Writing IngressRule YAML to ${outputPath}`);
+            writeFileSync(outputPath, routeYaml);
+            logger.info(`Successfully wrote IngressRule YAML to ${outputPath}`);
+          } else {
+            // log to stdout by default
+            // tslint:disable-next-line: no-console
+            console.log(routeYaml);
+          }
+        } catch (err) {
+          logger.error(err);
+          process.exitCode = 1;
+        }
+      }
+    );
+};

--- a/src/commands/ingress-route/index.ts
+++ b/src/commands/ingress-route/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "../command";
+import { create } from "./create";
+
+export const ingressCommand = Command(
+  "ingress-route",
+  "Create and manage Traefik IngressRoutes for a Bedrock project.",
+  [create]
+);

--- a/src/commands/service/create-revision.ts
+++ b/src/commands/service/create-revision.ts
@@ -35,7 +35,6 @@ export const createServiceRevisionCommandDecorator = (
       "--org-name <organization-name>",
       "Your Azure DevOps organization name; falls back to azure_devops.org in your spk config"
     )
-    .option("")
     .action(async opts => {
       try {
         const { azure_devops } = Config();
@@ -49,7 +48,7 @@ export const createServiceRevisionCommandDecorator = (
         // Give defaults
         ////////////////////////////////////////////////////////////////////////
         // default pull request against initial ring
-        const bedrockConfig = await Bedrock();
+        const bedrockConfig = Bedrock();
         const defaultRings = Object.entries(bedrockConfig.rings || {})
           .map(([branch, config]) => ({ branch, ...config }))
           .filter(ring => ring.isDefault);

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export const readYaml = <T>(filepath: string): T => {
     const contents = fs.readFileSync(filepath, "utf8");
     return yaml.safeLoad(contents) as T;
   }
-  throw new Error(`Unable to load file '${filepath}'`);
+  throw Error(`Unable to load file '${filepath}'`);
 };
 
 /**
@@ -50,7 +50,7 @@ const loadConfigurationFromLocalEnv = <T>(configObj: T): T => {
             obj[key] = process.env[matchValue];
           } else {
             logger.error(`Env variable needs to be defined for ${matchValue}`);
-            throw new Error(
+            throw Error(
               `Environment variable needs to be defined for ${matchValue} since it's referenced in the config file.`
             );
           }
@@ -87,13 +87,13 @@ export const Config = (): IConfigYaml => {
 /**
  * Returns the current bedrock.yaml file for the project
  */
-export const Bedrock = async () =>
+export const Bedrock = () =>
   readYaml<IBedrockFile>(path.join(process.cwd(), "bedrock.yaml"));
 
 /**
  * Returns the current maintainers.yaml file for the project
  */
-export const Maintainers = async () =>
+export const Maintainers = () =>
   readYaml<IMaintainersFile>(path.join(process.cwd(), "maintainers.yaml"));
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { Command, executeCommand } from "./commands/command";
 import { deploymentCommand } from "./commands/deployment";
 import { hldCommand } from "./commands/hld";
 import { infraCommand } from "./commands/infra";
+import { ingressCommand } from "./commands/ingress-route";
 import { initCommandDecorator } from "./commands/init";
 import { projectCommand } from "./commands/project";
 import { serviceCommand } from "./commands/service";
@@ -40,7 +41,8 @@ const rootCommand = Command(
     serviceCommand,
     infraCommand,
     hldCommand,
-    variableGroupCommand
+    variableGroupCommand,
+    ingressCommand
   ]
 );
 

--- a/src/lib/traefik/ingress-route.test.ts
+++ b/src/lib/traefik/ingress-route.test.ts
@@ -1,0 +1,52 @@
+import uuid from "uuid/v4";
+import { TraefikIngressRoute } from "./ingress-route";
+
+describe("TraefikIngressRoute", () => {
+  test("the right object name and service name is created", () => {
+    const routeWithoutRing = TraefikIngressRoute("my-service", "", 80);
+    expect(routeWithoutRing.metadata.name).toBe("my-service");
+    expect(routeWithoutRing.spec.routes[0].services[0].name).toBe("my-service");
+    const routeWithRing = TraefikIngressRoute("my-service", "prod", 80);
+    expect(routeWithRing.metadata.name).toBe("my-service-prod");
+    expect(routeWithRing.spec.routes[0].services[0].name).toBe(
+      "my-service-prod"
+    );
+  });
+
+  test("manifest namespace gets injected properly", () => {
+    const randomNamespaces = Array.from({ length: 10 }, () => uuid());
+    for (const namespace of randomNamespaces) {
+      const withoutNamespace = TraefikIngressRoute("foo", "bar", 80, {
+        namespace
+      });
+      expect(withoutNamespace.metadata.namespace).toBe(namespace);
+    }
+  });
+
+  test("the service port gets properly injected", () => {
+    const randomPorts = Array.from({ length: 10 }, () =>
+      Math.floor(Math.random() * 1000)
+    );
+    for (const servicePort of randomPorts) {
+      const route = TraefikIngressRoute("foo", "", servicePort);
+      expect(route.spec.routes[0].services[0].port).toBe(servicePort);
+    }
+  });
+
+  test("entryPoints gets injected properly", () => {
+    const withoutEntryPoints = TraefikIngressRoute("foo", "bar", 80);
+    expect(typeof withoutEntryPoints.spec.entryPoints).toBe("undefined");
+    const withJustWeb = TraefikIngressRoute("foo", "bar", 80, {
+      entryPoints: ["web"]
+    });
+    expect(withJustWeb.spec.entryPoints).toStrictEqual(["web"]);
+    const withJustWebSecure = TraefikIngressRoute("foo", "bar", 80, {
+      entryPoints: ["web-secure"]
+    });
+    expect(withJustWebSecure.spec.entryPoints).toStrictEqual(["web-secure"]);
+    const withBoth = TraefikIngressRoute("foo", "bar", 80, {
+      entryPoints: ["web", "web-secure"]
+    });
+    expect(withBoth.spec.entryPoints).toStrictEqual(["web", "web-secure"]);
+  });
+});

--- a/src/lib/traefik/ingress-route.ts
+++ b/src/lib/traefik/ingress-route.ts
@@ -1,0 +1,94 @@
+type TraefikEntryPoints = Array<"web" | "web-secure">; // web === 80; web-secure === 443;
+
+/**
+ * Interface for a Traefik IngressRoute
+ *
+ * @see https://docs.traefik.io/routing/providers/kubernetes-crd/
+ */
+interface ITraefikIngressRoute {
+  apiVersion: "traefik.containo.us/v1alpha1";
+  kind: "IngressRoute";
+  metadata: {
+    name: string;
+    namespace?: string;
+  };
+  spec: {
+    entryPoints?: TraefikEntryPoints; // defaults to allowing all traffic if not defined
+    routes: Array<{
+      match: string;
+      kind: "Rule";
+      priority?: number;
+      middlewares?: Array<{ name: string }>;
+      services: Array<{
+        name: string;
+        port: number;
+        healthCheck?: {
+          path: string;
+          host: string;
+          intervalSeconds: number;
+          timeoutSeconds: number;
+        };
+        weight?: number;
+        passHostHeader?: boolean;
+        responseForwarding?: {
+          flushInterval: string; // eg '100ms'
+        };
+        strategy?: "RoundRobin";
+      }>;
+    }>;
+  };
+}
+
+/**
+ * Factory to create a minimal Traefik IngressRoute with route rules
+ * corresponding to a PathPrefix matching `/<serviceName>` and a header match
+ * rule matching a `Ring` header to `<ringName>`.
+ *
+ * If `ringName` is an empty string, the header match rule is not included.
+ *
+ * @param serviceName name of the service to create the IngressRoute for
+ * @param ringName name of the ring to which the service belongs
+ * @param opts options to specify the manifest namespace and IngressRoute entryPoints
+ */
+export const TraefikIngressRoute = (
+  serviceName: string,
+  ringName: string,
+  servicePort: number,
+  opts: {
+    namespace?: string;
+    entryPoints?: TraefikEntryPoints;
+  } = {}
+): ITraefikIngressRoute => {
+  const { entryPoints, namespace } = opts;
+  const name = !!ringName ? `${serviceName}-${ringName}` : serviceName;
+  const routeMatchPathPrefix = `PathPrefix(\`/${serviceName}\`)`;
+  const routeMatchHeaders = ringName && `Headers(\`Ring\`, \`${ringName}\`)`; // no 'X-' prefix for header: https://tools.ietf.org/html/rfc6648
+  const routeMatch = [routeMatchPathPrefix, routeMatchHeaders]
+    .filter(matchRule => !!matchRule)
+    .join(" && ");
+
+  return {
+    apiVersion: "traefik.containo.us/v1alpha1",
+    kind: "IngressRoute",
+    metadata: {
+      name,
+      ...(() => (!!namespace ? { namespace } : {}))()
+    },
+    spec: {
+      ...(() =>
+        !!entryPoints && entryPoints.length > 0 ? { entryPoints } : {})(),
+      routes: [
+        {
+          kind: "Rule",
+          match: routeMatch,
+          services: [
+            {
+              name,
+              port: servicePort
+            }
+          ]
+        }
+      ]
+    }
+  };
+};


### PR DESCRIPTION
Added the `spk ingress-route create` command which allows users to create
Traefik `IngressRoute` manifests for the Traefik 2 IngressRoute CRD.

The command is setup such that a target `<service>` and `<port>` are required;
these will be used together to target a service in the Kubernetes cluster
matching `<service>:<port>`. If a `--ring` is provided, the target service
becomes `<service>-<ring>:<port>`.

The YAML output can either be outputted to a file with the `--output-file`
option, the option allows the user to specify any path-like directory on the
host; in the case of relative directories, it is resolved from the `cwd` of spk.
If a use leaves the `--output-file` blank or provides and empty string, the YAML
is printed to `stdout` with no additional log messages; this is useful if one
needs to pipe the output to in a pipeline.

closes https://github.com/microsoft/bedrock/issues/619