### PR TITLE
Added differentiating type for bedrock.yaml

### DIFF
--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -243,6 +243,7 @@ const generateBedrockFile = async (
         chart: {
           branch: "",
           git: "",
+          method: "git",
           path: ""
         }
       };

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -237,6 +237,7 @@ export const createService = async (
     helmConfig = {
       chart: {
         chart: helmChartChart,
+        method: "helm",
         repository: helmChartRepository
       }
     };
@@ -245,6 +246,7 @@ export const createService = async (
       chart: {
         branch: helmConfigBranch,
         git: helmConfigGit,
+        method: "git",
         path: helmConfigPath
       }
     };

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -228,6 +228,7 @@ describe("Adding a new service to a Bedrock file", () => {
     const helmConfig: IHelmConfig = {
       chart: {
         chart: "somehelmchart",
+        method: "helm",
         repository: "somehelmrepository"
       }
     };

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -40,6 +40,7 @@ export const createTestBedrockYaml = (
     chart: {
       branch: "master",
       git: "https://github.com/catalystcode/spk-demo-repo.git",
+      method: "git",
       path: ""
     }
   };
@@ -48,6 +49,7 @@ export const createTestBedrockYaml = (
     chart: {
       branch: "master",
       git: "https://github.com/catalystcode/spk-demo-repo.git",
+      method: "git",
       path: "/service1"
     }
   };
@@ -55,6 +57,7 @@ export const createTestBedrockYaml = (
   const zookeeperHelmConfig: IHelmConfig = {
     chart: {
       chart: "zookeeper",
+      method: "helm",
       repository: "https://kubernetes-charts-incubator.storage.googleapis.com/"
     }
   };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,10 +21,12 @@ interface IUser {
 export interface IHelmConfig {
   chart:
     | {
+        method: "helm";
         repository: string; // repo (eg; https://kubernetes-charts-incubator.storage.googleapis.com/)
         chart: string; // chart name (eg; zookeeper)
       }
     | ({
+        method: "git";
         git: string; // git url to clone (eg; https://github.com/helm/charts.git)
         path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
       } & (


### PR DESCRIPTION
Added a differentiating type property of `method: 'git' | 'helm'` for
the bedrock IHelmConfig type so developers can, at inference time in
code, type-guard against the different methods to add Helm based
components.