### PR TITLE
Added support for repo cloning in spk infra scaffold

### DIFF
--- a/docs/cloud-infra-management.md
+++ b/docs/cloud-infra-management.md
@@ -78,16 +78,16 @@ spk infra scaffold|s [options]
 
 Options:
   -n, --name <name>                              Cluster name for scaffolding
-  -s, --source <cluster definition github repo>  Source URL for the repository containing the terraform deployment
-  -v, --version <repository version>             Version or tag for the repository so a fixed version is referenced
-  -t, --template <path to variables.tf>          Location of variables.tf for the terraform deployment
+  -s, --source <tf source github repo url>       Source URL for the repository containing the terraform deployment
+  -v, --version <repository (tag) version>       Version or tag for the repository so a fixed version is referenced
+  -t, --template <path to tf files in repo>      Location of variables.tf for the terraform deployment
   -h, --help                                     Usage information
 ```
 
 #### scaffold sample
 
 ```
-spk infra scaffold --name discovery-service --source https://github.com/microsoft/bedrock --version "0.0.1" --template /microsoft/bedrock/cluster/environments/azure-simple
+spk infra scaffold --name discovery-service --source https://github.com/microsoft/bedrock --version "v0.12.0" --template /cluster/environments/azure-simple
 ```
 
 Output:
@@ -99,7 +99,7 @@ definition.json
   "name": "discovery-service",
   "source": "https://github.com/microsoft/bedrock",
   "template": "bedrock/cluster/environments/azure-simple",
-  "version": "0.0.1",
+  "version": "v0.12.0",
   "variables": {
     "agent_vm_count": "3",
     "agent_vm_size": "Standard_D2s_v3",

--- a/docs/cloud-infra-management.md
+++ b/docs/cloud-infra-management.md
@@ -74,7 +74,7 @@ It will do the following:
 Usage:
 spk infra scaffold|s [options]
 
-> `spk infra scaffold --name discovery-service --source https://github.com/microsoft/bedrock --version "0.0.1" --template /microsoft/bedrock/cluster/environments/azure-simple`
+> `spk infra scaffold --name discovery-service --source https://github.com/microsoft/bedrock --version "v0.12.0" --template /cluster/environments/azure-simple`
 
 Options:
   -n, --name <name>                              Cluster name for scaffolding

--- a/src/commands/infra/generate.ts
+++ b/src/commands/infra/generate.ts
@@ -7,7 +7,7 @@ import simpleGit from "simple-git/promise";
 import { logger } from "../../logger";
 import { copyTfTemplate } from "./scaffold";
 
-const spkTemplatesPath = path.join(os.homedir(), ".spk/templates");
+export const spkTemplatesPath = path.join(os.homedir(), ".spk/templates");
 const git = simpleGit();
 
 /**
@@ -80,7 +80,8 @@ export const validateDefinition = async (
 };
 
 /**
- * Checks if working definition.json is present in the provided project path with validated source & version
+ * Checks if working definition.json is present in the provided
+ * project path with validated source & version
  *
  * @param projectPath Path to the definition.json file
  */
@@ -226,7 +227,6 @@ export const parseDefinitionJson = async (projectPath: string) => {
  * each key to resemble:
  *
  * key = "value"
- *
  *
  */
 export const generateSpkTfvars = async (

--- a/src/commands/infra/generate.ts
+++ b/src/commands/infra/generate.ts
@@ -5,9 +5,9 @@ import * as os from "os";
 import path from "path";
 import simpleGit from "simple-git/promise";
 import { logger } from "../../logger";
+import * as infra_common from "./infra_common";
 import { copyTfTemplate } from "./scaffold";
 
-export const spkTemplatesPath = path.join(os.homedir(), ".spk/templates");
 const git = simpleGit();
 
 /**
@@ -62,7 +62,7 @@ export const validateDefinition = async (
 ): Promise<boolean> => {
   try {
     // If templates folder does not exist, create cache templates directory
-    mkdirp.sync(spkTemplatesPath);
+    mkdirp.sync(infra_common.spkTemplatesPath);
     if (!fs.existsSync(path.join(projectPath, "definition.json"))) {
       logger.error(
         `Provided project path for generate is invalid or definition.json cannot be found: ${projectPath}`
@@ -124,11 +124,8 @@ export const validateRemoteSource = async (
 ): Promise<boolean> => {
   const [source, template, version] = definitionJSON;
   // Converting source name to storable folder name
-  const httpReg = /^(.*?)\.com/;
-  const punctuationReg = /[^\w\s]/g;
-  let sourceFolder = source.replace(httpReg, "");
-  sourceFolder = sourceFolder.replace(punctuationReg, "_").toLowerCase();
-  const sourcePath = path.join(spkTemplatesPath, sourceFolder);
+  const sourceFolder = await infra_common.repoCloneRegex(source);
+  const sourcePath = path.join(infra_common.spkTemplatesPath, sourceFolder);
   logger.warn(`Converted to: ${sourceFolder}`);
   logger.info(`Checking if source: ${sourcePath} is stored locally.`);
   try {
@@ -208,7 +205,7 @@ export const parseDefinitionJson = async (projectPath: string) => {
   let sourceFolder = source.replace(httpReg, "");
   sourceFolder = sourceFolder.replace(punctuationReg, "_").toLowerCase();
   const templatePath = path.join(
-    spkTemplatesPath,
+    infra_common.spkTemplatesPath,
     sourceFolder,
     definitionJSON.template
   );

--- a/src/commands/infra/generate.ts
+++ b/src/commands/infra/generate.ts
@@ -5,7 +5,7 @@ import * as os from "os";
 import path from "path";
 import simpleGit from "simple-git/promise";
 import { logger } from "../../logger";
-import * as infra_common from "./infra_common";
+import * as infraCommon from "./infra_common";
 import { copyTfTemplate } from "./scaffold";
 
 const git = simpleGit();
@@ -62,7 +62,7 @@ export const validateDefinition = async (
 ): Promise<boolean> => {
   try {
     // If templates folder does not exist, create cache templates directory
-    mkdirp.sync(infra_common.spkTemplatesPath);
+    mkdirp.sync(infraCommon.spkTemplatesPath);
     if (!fs.existsSync(path.join(projectPath, "definition.json"))) {
       logger.error(
         `Provided project path for generate is invalid or definition.json cannot be found: ${projectPath}`
@@ -124,8 +124,8 @@ export const validateRemoteSource = async (
 ): Promise<boolean> => {
   const [source, template, version] = definitionJSON;
   // Converting source name to storable folder name
-  const sourceFolder = await infra_common.repoCloneRegex(source);
-  const sourcePath = path.join(infra_common.spkTemplatesPath, sourceFolder);
+  const sourceFolder = await infraCommon.repoCloneRegex(source);
+  const sourcePath = path.join(infraCommon.spkTemplatesPath, sourceFolder);
   logger.warn(`Converted to: ${sourceFolder}`);
   logger.info(`Checking if source: ${sourcePath} is stored locally.`);
   try {
@@ -191,8 +191,7 @@ export const createGenerated = async (projectPath: string): Promise<string> => {
 };
 
 /**
- * Parses the definition.json file and copies the appropriate template
- * to "-generated" directory
+ * Parses the definition.json file and returns the appropriate template path
  *
  * @param projectPath Path to the definition.json file
  * @param generatedPath Path to the generated directory
@@ -200,12 +199,9 @@ export const createGenerated = async (projectPath: string): Promise<string> => {
 export const parseDefinitionJson = async (projectPath: string) => {
   const definitionJSON = await readDefinitionJson(projectPath);
   const source = definitionJSON.source;
-  const httpReg = /^(.*?)\.com/;
-  const punctuationReg = /[^\w\s]/g;
-  let sourceFolder = source.replace(httpReg, "");
-  sourceFolder = sourceFolder.replace(punctuationReg, "_").toLowerCase();
+  const sourceFolder = await infraCommon.repoCloneRegex(source);
   const templatePath = path.join(
-    infra_common.spkTemplatesPath,
+    infraCommon.spkTemplatesPath,
     sourceFolder,
     definitionJSON.template
   );

--- a/src/commands/infra/infra_common.ts
+++ b/src/commands/infra/infra_common.ts
@@ -1,0 +1,14 @@
+import * as os from "os";
+import path from "path";
+
+export const spkTemplatesPath = path.join(os.homedir(), ".spk/templates");
+
+export const repoCloneRegex = async (source: string): Promise<string> => {
+  const httpReg = /^(.*?)\.com/;
+  const punctuationReg = /[^\w\s]/g;
+  const sourceFolder = source
+    .replace(httpReg, "")
+    .replace(punctuationReg, "_")
+    .toLowerCase();
+  return sourceFolder;
+};

--- a/src/commands/infra/scaffold.ts
+++ b/src/commands/infra/scaffold.ts
@@ -4,7 +4,8 @@ import fs from "fs";
 import fsextra from "fs-extra";
 import path from "path";
 import { logger } from "../../logger";
-import { spkTemplatesPath, validateRemoteSource } from "./generate";
+import { validateRemoteSource } from "./generate";
+import * as infra_common from "./infra_common";
 
 /**
  * Adds the init command to the commander command object
@@ -39,13 +40,11 @@ export const scaffoldCommandDecorator = (command: commander.Command): void => {
           );
         }
         const scaffoldDefinition = [opts.source, opts.template, opts.version];
-        const httpReg = /^(.*?)\.com/;
-        const punctuationReg = /[^\w\s]/g;
-        const sourceFolder = opts.source
-          .replace(httpReg, "")
-          .replace(punctuationReg, "_")
-          .toLowerCase();
-        const sourcePath = path.join(spkTemplatesPath, sourceFolder);
+        const sourceFolder = await infra_common.repoCloneRegex(opts.source);
+        const sourcePath = path.join(
+          infra_common.spkTemplatesPath,
+          sourceFolder
+        );
         await validateRemoteSource(scaffoldDefinition);
         await copyTfTemplate(path.join(sourcePath, opts.template), opts.name);
         await validateVariablesTf(

--- a/src/commands/infra/scaffold.ts
+++ b/src/commands/infra/scaffold.ts
@@ -5,7 +5,7 @@ import fsextra from "fs-extra";
 import path from "path";
 import { logger } from "../../logger";
 import { validateRemoteSource } from "./generate";
-import * as infra_common from "./infra_common";
+import * as infraCommon from "./infra_common";
 
 /**
  * Adds the init command to the commander command object
@@ -40,9 +40,9 @@ export const scaffoldCommandDecorator = (command: commander.Command): void => {
           );
         }
         const scaffoldDefinition = [opts.source, opts.template, opts.version];
-        const sourceFolder = await infra_common.repoCloneRegex(opts.source);
+        const sourceFolder = await infraCommon.repoCloneRegex(opts.source);
         const sourcePath = path.join(
-          infra_common.spkTemplatesPath,
+          infraCommon.spkTemplatesPath,
           sourceFolder
         );
         await validateRemoteSource(scaffoldDefinition);


### PR DESCRIPTION
Closes https://github.com/microsoft/bedrock/issues/762.

This reuses code from `spk infra generate`. `--source`, `--template`, and `--version` arguments will now be used against a remote repo, as opposed to a local repo.