### PR TITLE
fix(#708): Add bedrock.yaml and maintainers.yaml to commit when --git-push is set for service create

### DIFF
--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -298,6 +298,11 @@ export const createService = async (
 
   // If requested, create new git branch, commit, and push
   if (gitPush) {
-    await checkoutCommitPushCreatePRLink(serviceName, newServiceDir);
+    await checkoutCommitPushCreatePRLink(
+      serviceName,
+      newServiceDir,
+      path.join(rootProjectPath, "bedrock.yaml"),
+      path.join(rootProjectPath, "maintainers.yaml")
+    );
   }
 };

--- a/src/lib/gitutils.test.ts
+++ b/src/lib/gitutils.test.ts
@@ -1,7 +1,7 @@
 import { when } from "jest-when";
 import {
   checkoutBranch,
-  commitDir,
+  commitPath,
   deleteBranch,
   getCurrentBranch,
   getOriginUrl,
@@ -130,11 +130,18 @@ describe("commitDir", () => {
   it("should call exec with the proper git arguments", async () => {
     (exec as jest.Mock).mockClear();
     const directory = "./my/service/dir";
+    const bedrockFile = "./my/service/bedrock.yaml";
+    const maintainersFile = "./my/service/maintainers.yaml";
     const branchName = "mynewbranch";
-    await commitDir(directory, branchName);
+    await commitPath(branchName, directory, bedrockFile, maintainersFile);
 
     expect(exec).toHaveBeenCalledTimes(2);
-    expect(exec).toHaveBeenCalledWith("git", ["add", `${directory}`]);
+    expect(exec).toHaveBeenCalledWith("git", [
+      "add",
+      directory,
+      bedrockFile,
+      maintainersFile
+    ]);
     expect(exec).toHaveBeenCalledWith("git", [
       "commit",
       "-m",
@@ -149,7 +156,7 @@ describe("commitDir", () => {
 
     let error: Error | undefined;
     try {
-      await commitDir("directory", "branchName");
+      await commitPath("branchName", "directory");
     } catch (_) {
       error = _;
     }


### PR DESCRIPTION
- Refactored the code for `checkoutCommitPushCreatePRLink` to be more readable.
- `commitPath` now accepts a variadic number of pathspecs instead of a single
  directory (akin to how `git add ...<pathspec>` works).
- `createService` (`spk service create`) now automatically adds the
  `bedrock.yaml` and `maintainers.yaml` files to the commit (along side the new
  service directory) when creating a new service.

fixes https://github.com/microsoft/bedrock/issues/708