### PR TITLE
Added task in pipeline to fail build on code coverage regression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,8 @@ steps:
       checkCoverage: true
       coverageFailOption: 'Previous Value'
       coverageType: branches
-      buildConfiguration: '$(BuildConfiguration)'
-      buildPlatform: '$(BuildPlatform)'
+      buildConfiguration: ''
+      buildPlatform: ''
       explicitFilter: true
       baseDefinitionId: 128
       baseBranchRef: refs/heads/master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ steps:
       artifact: spk_linux_node_12
     condition: and(eq(variables['Agent.JobStatus'], 'Succeeded'), endsWith(variables['Agent.JobName'], 'node_12_x'))
 
-  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
+  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@6
     displayName: 'Check build quality'
     inputs:
       checkWarnings: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,9 @@ steps:
   - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
     displayName: 'Check build quality'
     inputs:
+      checkWarnings: false
+      warningFailOption: fixed
+      warningFilters: ''
       showStatistics: true
       checkCoverage: true
       coverageFailOption: 'Previous Value'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,3 +59,18 @@ steps:
       path: $(System.DefaultWorkingDirectory)/dist/spk-linux
       artifact: spk_linux_node_12
     condition: and(eq(variables['Agent.JobStatus'], 'Succeeded'), endsWith(variables['Agent.JobName'], 'node_12_x'))
+
+  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
+    displayName: 'Check build quality'
+    inputs:
+      showStatistics: true
+      checkCoverage: true
+      coverageFailOption: 'Previous Value'
+      coverageType: branches
+      buildConfiguration: '$(BuildConfiguration)'
+      buildPlatform: '$(BuildPlatform)'
+      explicitFilter: true
+      baseDefinitionId: 128
+      baseBranchRef: refs/heads/master
+      runTitle: 'Code Coverage Evaluation'
+    condition: and(eq(variables['Agent.JobStatus'], 'Succeeded'), endsWith(variables['Agent.JobName'], 'node_12_x'))


### PR DESCRIPTION
Added a [Build Quality Checks](https://marketplace.visualstudio.com/items?itemName=mspremier.BuildQualityChecks#adding-the-task-to-a-yaml-build-definition) task to the `azure-pipelines.yaml`.

The configuration will compare branch coverage numbers from the previous build to the current one. If lower the build will failure. In turn GitHub PR checks will failure. 

Hopefully to this drive paying attention to testing. 

Closes https://github.com/microsoft/bedrock/issues/860