### PR TITLE
Middleware Tracking/Injection for Services

### DIFF
--- a/docs/service-management.md
+++ b/docs/service-management.md
@@ -38,17 +38,19 @@ Usage: service create|c [options] <service-name>
 Add a new service into this initialized spk project repository
 
 Options:
-  -c, --helm-chart-chart <helm-chart>            bedrock helm chart name. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
-  -r, --helm-chart-repository <helm-repository>  bedrock helm chart repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
-  -b, --helm-config-branch <helm-branch>         bedrock custom helm chart configuration branch. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
-  -p, --helm-config-path <helm-path>             bedrock custom helm chart configuration path. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
-  -g, --helm-config-git <helm-git>               bedrock helm chart configuration git repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
-  -d, --packages-dir <dir>                       The directory containing the mono-repo packages. (default: "")
-  -n, --display-name <display-name>              Display name of the service.
-  -m, --maintainer-name <maintainer-name>        The name of the primary maintainer for this service. (default: "maintainer name")
-  -e, --maintainer-email <maintainer-email>      The email of the primary maintainer for this service. (default: "maintainer email")
-  --git-push                                     SPK CLI will try to commit and push these changes to a new origin/branch named after the service. (default: false)
-  -h, --help                                     output usage information
+  -c, --helm-chart-chart <helm-chart>                         bedrock helm chart name. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
+  -r, --helm-chart-repository <helm-repository>               bedrock helm chart repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
+  -b, --helm-config-branch <helm-branch>                      bedrock custom helm chart configuration branch. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
+  -p, --helm-config-path <helm-path>                          bedrock custom helm chart configuration path. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
+  -g, --helm-config-git <helm-git>                            bedrock helm chart configuration git repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one. (default: "")
+  -d, --packages-dir <dir>                                    The directory containing the mono-repo packages. (default: "")
+  -n, --display-name <display-name>                           Display name of the service. (default: "")
+  -m, --maintainer-name <maintainer-name>                     The name of the primary maintainer for this service. (default: "maintainer name")
+  -e, --maintainer-email <maintainer-email>                   The email of the primary maintainer for this service. (default: "maintainer email")
+  --git-push                                                  SPK CLI will try to commit and push these changes to a new origin/branch named after the service. (default: false)
+  --variable-group-name <variable-group-name>                 The Azure DevOps Variable Group.
+  --middlewares <comma-delimitated-list-of-middleware-names>  Traefik2 middlewares you wish to to be injected into your Traefik2 IngressRoutes (default: "")
+  -h, --help                                                  output usage information
 ```
 
 **NOTE:**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "contributors": [],
   "license": "MIT",
   "scripts": {
-    "build": "shx rm -rf dist && webpack && pkg dist/spk.js && shx mv spk-{linux,macos,win.exe} dist",
+    "build": "shx rm -rf dist && webpack && pkg -t node12-linux-x64,node12-macos-x64,node12-win-x64 dist/spk.js && shx mv spk-{linux,macos,win.exe} dist",
     "lint": "tslint 'src/**/*.ts{,x}'",
     "lint-fix": "tslint --fix 'src/**/*.ts{,x}'",
     "test": "jest --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --coverageReporters=html",

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { promisify } from "util";
 import uuid from "uuid/v4";
+import { Bedrock } from "../../config";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import {
   disableVerboseLogging,
@@ -35,6 +36,7 @@ describe("validate pipeline config", () => {
     "test/packages",
     "test-maintainer",
     "test@maintainer.com",
+    "my,middleware,string",
     true,
     "testVariableGroup",
     "testDisplayName"
@@ -57,11 +59,14 @@ describe("validate pipeline config", () => {
 });
 
 describe("Adding a service to a repo directory", () => {
-  test("New directory is created under root directory with required service files.", async () => {
+  let randomTmpDir: string = "";
+  beforeEach(async () => {
     // Create random directory to initialize
-    const randomTmpDir = path.join(os.tmpdir(), uuid());
+    randomTmpDir = path.join(os.tmpdir(), uuid());
     fs.mkdirSync(randomTmpDir);
+  });
 
+  test("New directory is created under root directory with required service files.", async () => {
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
     );
@@ -98,10 +103,6 @@ describe("Adding a service to a repo directory", () => {
   });
 
   test("New directory is created under '/packages' directory with required service files.", async () => {
-    // Create random directory to initialize
-    const randomTmpDir = path.join(os.tmpdir(), uuid());
-    fs.mkdirSync(randomTmpDir);
-
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
     );
@@ -138,10 +139,6 @@ describe("Adding a service to a repo directory", () => {
   });
 
   test("New directory is created under '/packages' directory with required service files and git push enabled.", async () => {
-    // Create random directory to initialize
-    const randomTmpDir = path.join(os.tmpdir(), uuid());
-    fs.mkdirSync(randomTmpDir);
-
     await writeSampleMaintainersFileToDir(
       path.join(randomTmpDir, "maintainers.yaml")
     );
@@ -175,6 +172,84 @@ describe("Adding a service to a repo directory", () => {
     }
 
     expect(checkoutCommitPushCreatePRLink).toHaveBeenCalled();
+  });
+
+  test("empty middleware list is created when none provided", async () => {
+    await writeSampleMaintainersFileToDir(
+      path.join(randomTmpDir, "maintainers.yaml")
+    );
+    await writeSampleBedrockFileToDir(path.join(randomTmpDir, "bedrock.yaml"));
+
+    const packageDir = "";
+    const serviceName = uuid();
+    logger.info(
+      `creating randomTmpDir ${randomTmpDir} and service ${serviceName}`
+    );
+
+    // create service with no middleware
+    await createService(randomTmpDir, serviceName, packageDir, false);
+
+    // Check temp test directory exists
+    expect(fs.existsSync(randomTmpDir)).toBe(true);
+
+    // Check service directory exists
+    const serviceDirPath = path.join(randomTmpDir, packageDir, serviceName);
+    expect(fs.existsSync(serviceDirPath)).toBe(true);
+
+    // get bedrock config
+    const bedrockConfig = Bedrock(randomTmpDir);
+
+    // check the added service has an empty list for middlewares
+    for (const [servicePath, service] of Object.entries(
+      bedrockConfig.services
+    )) {
+      if (servicePath.includes(serviceName)) {
+        expect(service.middlewares).toBeDefined();
+        expect(Array.isArray(service.middlewares)).toBe(true);
+        expect(service.middlewares!.length).toBe(0);
+      }
+    }
+  });
+
+  test("middleware gets added when provided", async () => {
+    await writeSampleMaintainersFileToDir(
+      path.join(randomTmpDir, "maintainers.yaml")
+    );
+    await writeSampleBedrockFileToDir(path.join(randomTmpDir, "bedrock.yaml"));
+
+    const packageDir = "";
+    const serviceName = uuid();
+    logger.info(
+      `creating randomTmpDir ${randomTmpDir} and service ${serviceName}`
+    );
+
+    // add some middlewares
+    const middlewares = ["foo", "bar", "baz"];
+    await createService(randomTmpDir, serviceName, packageDir, false, {
+      middlewares
+    });
+
+    // Check temp test directory exists
+    expect(fs.existsSync(randomTmpDir)).toBe(true);
+
+    // Check service directory exists
+    const serviceDirPath = path.join(randomTmpDir, packageDir, serviceName);
+    expect(fs.existsSync(serviceDirPath)).toBe(true);
+
+    // get bedrock config
+    const bedrockConfig = Bedrock(randomTmpDir);
+
+    // check that the added service has the expected middlewares
+    for (const [servicePath, service] of Object.entries(
+      bedrockConfig.services
+    )) {
+      if (servicePath.includes(serviceName)) {
+        expect(service.middlewares).toBeDefined();
+        expect(Array.isArray(service.middlewares)).toBe(true);
+        expect(service.middlewares?.length).toBe(middlewares.length);
+        expect(service.middlewares).toStrictEqual(middlewares);
+      }
+    }
   });
 });
 

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -1,7 +1,7 @@
 import commander from "commander";
 import path from "path";
 import shelljs from "shelljs";
-import { Bedrock } from "../../config";
+import { BedrockAsync } from "../../config";
 import {
   addNewServiceToBedrockFile,
   addNewServiceToMaintainersFile,
@@ -11,7 +11,7 @@ import {
 } from "../../lib/fileutils";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import { logger } from "../../logger";
-import { IBedrockFile, IHelmConfig, IUser } from "../../types";
+import { IHelmConfig, IUser } from "../../types";
 
 /**
  * Adds the create command to the service command object
@@ -77,9 +77,19 @@ export const createCommandDecorator = (command: commander.Command): void => {
     )
     .option(
       "--variable-group-name <variable-group-name>",
-      "The Azure DevOps Variable Group."
+      "The Azure DevOps Variable Group.",
+      undefined
+    )
+    .option(
+      "--middlewares <comma-delimitated-list-of-middleware-names>",
+      "Traefik2 middlewares you wish to to be injected into your Traefik2 IngressRoutes",
+      ""
     )
     .action(async (serviceName, opts) => {
+      const bedrock = await BedrockAsync().catch(err => {
+        logger.warn(err);
+        return undefined;
+      });
       const {
         displayName,
         helmChartChart,
@@ -90,27 +100,14 @@ export const createCommandDecorator = (command: commander.Command): void => {
         packagesDir,
         maintainerName,
         maintainerEmail,
+        middlewares,
         gitPush
       } = opts;
+      const variableGroupName =
+        opts.variableGroupName ?? (bedrock?.variableGroups ?? [])[0] ?? ""; // fall back to bedrock.yaml when <variable-group-name> argument is not specified; default to empty string
 
       const projectPath = process.cwd();
       try {
-        // fall back to bedrock.yaml when <variable-group-name> argument is not specified
-        let bedrockFile: IBedrockFile | undefined;
-        try {
-          bedrockFile = Bedrock();
-        } catch (err) {
-          logger.info(err);
-        }
-
-        const {
-          variableGroupName = bedrockFile &&
-            bedrockFile.variableGroups &&
-            bedrockFile.variableGroups![0]
-        } = opts;
-
-        logger.info(`variable name: ${variableGroupName}`);
-
         if (
           !isValidConfig(
             helmChartChart,
@@ -122,12 +119,13 @@ export const createCommandDecorator = (command: commander.Command): void => {
             packagesDir,
             maintainerName,
             maintainerEmail,
+            middlewares,
             gitPush,
             variableGroupName,
             displayName
           )
         ) {
-          process.exit(1);
+          throw Error(`Invalid configuration provided`);
         }
 
         await createService(projectPath, serviceName, packagesDir, gitPush, {
@@ -139,16 +137,18 @@ export const createCommandDecorator = (command: commander.Command): void => {
           helmConfigPath,
           maintainerEmail,
           maintainerName,
+          middlewares: (middlewares as string)
+            .split(",")
+            .map(str => str.trim()),
           variableGroups:
-            variableGroupName === undefined || variableGroupName === null
-              ? []
-              : [variableGroupName]
+            variableGroupName.length > 0 ? [variableGroupName] : []
         });
       } catch (err) {
         logger.error(
           `Error occurred adding service ${serviceName} to project ${projectPath}`
         );
         logger.error(err);
+        process.exit(1);
       }
     });
 };
@@ -164,6 +164,7 @@ export const createCommandDecorator = (command: commander.Command): void => {
  * @param packagesDir Packages directory
  * @param maintainerName Name of maintainer
  * @param maintainerEmail Email of maintainer
+ * @param middlewares comma-delimitated list of Traefik2 middlewares
  * @param gitPush Push to git
  * @param variableGroupName Variable group name
  */
@@ -177,6 +178,7 @@ export const isValidConfig = (
   packagesDir: any,
   maintainerName: any,
   maintainerEmail: any,
+  middlewares: any,
   gitPush: any,
   variableGroupName: any,
   displayName: any
@@ -234,16 +236,17 @@ export const isValidConfig = (
       `maintainerEmail must be of type 'string', ${typeof maintainerEmail} given.`
     );
   }
+  if (typeof middlewares !== "string") {
+    missingConfig.push(
+      `middlewares must be of type of 'string', ${typeof middlewares} given.`
+    );
+  }
   if (typeof gitPush !== "boolean") {
     missingConfig.push(
       `gitPush must be of type 'boolean', ${typeof gitPush} given.`
     );
   }
-  if (
-    variableGroupName === null ||
-    variableGroupName === undefined ||
-    typeof variableGroupName !== "string"
-  ) {
+  if (typeof variableGroupName !== "string") {
     missingConfig.push(
       `variableGroupName must be of type 'string', ${typeof variableGroupName} given.`
     );
@@ -270,38 +273,30 @@ export const createService = async (
   packagesDir: string,
   gitPush: boolean,
   opts?: {
-    displayName: string;
-    helmChartChart: string;
-    helmChartRepository: string;
-    helmConfigBranch: string;
-    helmConfigGit: string;
-    helmConfigPath: string;
-    maintainerEmail: string;
-    maintainerName: string;
+    displayName?: string;
+    helmChartChart?: string;
+    helmChartRepository?: string;
+    helmConfigBranch?: string;
+    helmConfigGit?: string;
+    helmConfigPath?: string;
+    maintainerEmail?: string;
+    maintainerName?: string;
     variableGroups?: string[];
+    middlewares?: string[];
   }
 ) => {
   const {
-    displayName,
-    helmChartChart,
-    helmChartRepository,
-    helmConfigBranch,
-    helmConfigPath,
-    helmConfigGit,
-    maintainerName,
-    maintainerEmail,
-    variableGroups
-  } = opts || {
-    displayName: "",
-    helmChartChart: "",
-    helmChartRepository: "",
-    helmConfigBranch: "",
-    helmConfigGit: "",
-    helmConfigPath: "",
-    maintainerEmail: "",
-    maintainerName: "",
-    variableGroups: []
-  };
+    displayName = "",
+    helmChartChart = "",
+    helmChartRepository = "",
+    helmConfigBranch = "",
+    helmConfigPath = "",
+    helmConfigGit = "",
+    maintainerName = "",
+    maintainerEmail = "",
+    middlewares = [],
+    variableGroups = []
+  } = opts ?? {};
 
   logger.info(
     `Adding Service: ${serviceName}, to Project: ${rootProjectPath} under directory: ${packagesDir}`
@@ -366,7 +361,8 @@ export const createService = async (
     path.join(rootProjectPath, "bedrock.yaml"),
     newServiceRelativeDir,
     displayName,
-    helmConfig
+    helmConfig,
+    middlewares
   );
 
   // If requested, create new git branch, commit, and push

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,8 @@ export const Config = (): IConfigYaml => {
  * Does some validations against the file; if errors occur, an Exception is
  * thrown:
  * - Validates the helm configurations for all service entries
+ *
+ * @param fileDirectory the project directory containing the bedrock.yaml file
  */
 export const Bedrock = (fileDirectory = process.cwd()): IBedrockFile => {
   const bedrockYamlPath = path.join(fileDirectory, "bedrock.yaml");
@@ -168,12 +170,33 @@ export const Bedrock = (fileDirectory = process.cwd()): IBedrockFile => {
 };
 
 /**
+ * Async wrapper for the Bedrock() function
+ * Use this if preferring to use Promise based control flow over try/catch as
+ * Bedrock() can throw and Error
+ *
+ * @param fileDirectory the project directory containing the bedrock.yaml file
+ */
+export const BedrockAsync = async (
+  fileDirectory = process.cwd()
+): Promise<IBedrockFile> => Bedrock(fileDirectory);
+
+/**
  * Returns the current maintainers.yaml file for the project
  */
 export const Maintainers = (
   fileDirectory: string = process.cwd()
 ): IMaintainersFile =>
   readYaml<IMaintainersFile>(path.join(fileDirectory, "maintainers.yaml"));
+
+/**
+ * Async wrapper for Maintainers() function
+ * Use this if preferring to use Promise based control flow over try/catch as
+ * Maintainers() can throw and Error
+ *
+ * @param fileDirectory the project directory containing the maintainers.yaml file
+ */
+export const MaintainersAsync = (fileDirectory: string = process.cwd()) =>
+  Maintainers(fileDirectory);
 
 /**
  * Helper to write out a bedrock.yaml or maintainers.yaml file to the project root

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -275,10 +275,11 @@ describe("Adding a new service to a Bedrock file", () => {
     const expected: IBedrockFile = {
       rings: {},
       services: {
-        ...((defaultBedrockFileObject as any) as IBedrockFile).services,
+        ...(defaultBedrockFileObject as IBedrockFile).services,
         ["./" + servicePath]: {
           displayName: svcDisplayName,
-          helm: helmConfig
+          helm: helmConfig,
+          middlewares: []
         }
       }
     };

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -618,7 +618,8 @@ export const addNewServiceToBedrockFile = (
   bedrockFilePath: string,
   newServicePath: string,
   svcDisplayName: string,
-  helmConfig: IHelmConfig
+  helmConfig: IHelmConfig,
+  middlewares: string[] = []
 ) => {
   const bedrockFile = yaml.safeLoad(
     fs.readFileSync(bedrockFilePath, "utf8")
@@ -626,7 +627,8 @@ export const addNewServiceToBedrockFile = (
 
   bedrockFile.services["./" + newServicePath] = {
     displayName: svcDisplayName,
-    helm: helmConfig
+    helm: helmConfig,
+    middlewares
   };
 
   logger.info("Updating bedrock.yaml");

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -51,6 +51,7 @@ export interface IBedrockFile {
   services: {
     [relativeDirectory: string]: {
       displayName?: string;
+      middlewares?: string[];
       helm: IHelmConfig;
     };
   };


### PR DESCRIPTION
Added support for tracking and injecting Traefik2 middlewares on a per-service
basis.

- Services tracked in `bedrock.yaml` now supports an optional `middlewares` key
  that accepts a list of Traefik2 middlewares.
  - These middlewares are injected into the outputted Traefik2 `IngressRoutes`
    generated from `spk hld reconcile`.
- Fixed broken user input validations for `variableGroupName`.
- Fixed `build` script in `package.json`. Was breaking on hosts that use Node 13
  as pkg currently does not have prebuilt binaries for versions `>12`

closes https://github.com/microsoft/bedrock/issues/779