### PR TITLE
Allow skipping ingress route creation

### DIFF
--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -2,12 +2,15 @@ import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 
 import {
   addChartToRing,
+  checkForFabrikate,
   createRepositoryComponent,
   createRingComponent,
   createServiceComponent,
   createStaticComponent,
   IReconcileDependencies,
-  reconcileHld
+  reconcileHld,
+  testAndGetAbsPath,
+  validateInputs
 } from "./reconcile";
 
 import { IBedrockFile, IBedrockServiceConfig } from "../../types";
@@ -18,6 +21,78 @@ beforeAll(() => {
 
 afterAll(() => {
   disableVerboseLogging();
+});
+
+describe("validateInputs", () => {
+  it("should not accept an invalid input for repository-name", () => {
+    expect(() => {
+      validateInputs(10, "hld-path", "app-path");
+    }).toThrow();
+  });
+
+  it("should not accept an invalid input for hld-path", () => {
+    expect(() => {
+      validateInputs("repo-name", 10, "app-path");
+    }).toThrow();
+  });
+
+  it("should not accept an invalid input for bedrock-application-repo-path", () => {
+    expect(() => {
+      validateInputs("repo-name", "repo-name", 10);
+    }).toThrow();
+  });
+
+  it("should accept valid inputs for validateInputs", () => {
+    expect(() => {
+      validateInputs("repo-name", "repo-name", "bedrock-application-repo-path");
+    }).not.toThrow();
+  });
+});
+
+describe("checkForFabrikate", () => {
+  it("throws an error if fabrikate is not installed", () => {
+    const which = jest.fn();
+    which.mockReturnValue("");
+
+    expect(() => {
+      checkForFabrikate(which);
+    }).toThrow();
+  });
+
+  it("does not throw an error if fabrikate is installed", () => {
+    const which = jest.fn();
+    which.mockReturnValue("/some/path/to/fabrikate");
+
+    expect(() => {
+      checkForFabrikate(which);
+    }).not.toThrow();
+  });
+});
+
+describe("testAndGetAbsPath", () => {
+  it("fails to test and get an absolute path for a file", () => {
+    const test = jest.fn();
+    const log = jest.fn();
+
+    expect(() => {
+      // Could not find the path.
+      test.mockReturnValue(false);
+
+      testAndGetAbsPath(test, log, "/some/path/to/hld-path", "hld-path");
+    }).toThrow();
+  });
+
+  it("finds an absolute path for a file", () => {
+    const test = jest.fn();
+    const log = jest.fn();
+
+    expect(() => {
+      // Could not find the path.
+      test.mockReturnValue(true);
+
+      testAndGetAbsPath(test, log, "/some/path/to/hld-path", "hld-path");
+    }).not.toThrow();
+  });
 });
 
 describe("createServiceComponent", () => {

--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -1,0 +1,164 @@
+import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
+
+import {
+  addChartToRing,
+  createRepositoryComponent,
+  createRingComponent,
+  createServiceComponent,
+  createStaticComponent
+} from "./reconcile";
+
+import { IBedrockServiceConfig } from "../../types";
+
+beforeAll(() => {
+  enableVerboseLogging();
+});
+
+afterAll(() => {
+  disableVerboseLogging();
+});
+
+describe("createServiceComponent", () => {
+  it("should invoke the correct command for adding service to hld", () => {
+    const exec = jest.fn();
+    const repoInHldPath = "myMonoRepo";
+    const pathBase = "myService";
+
+    const expectedInvocation = `cd ${repoInHldPath} && mkdir -p ${pathBase} config && fab add ${pathBase} --path ./${pathBase} --method local --type component && touch ./config/common.yaml`;
+
+    createServiceComponent(exec, repoInHldPath, pathBase);
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+});
+
+describe("createRepositoryComponent", () => {
+  it("should invoke the correct command for adding repository to hld", () => {
+    const exec = jest.fn();
+    const hldPath = `myMonoRepo`;
+    const repositoryName = `myRepo`;
+
+    const expectedInvocation = `cd ${hldPath} && mkdir -p ${repositoryName} && fab add ${repositoryName} --path ./${repositoryName} --method local`;
+
+    createRepositoryComponent(exec, hldPath, repositoryName);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+});
+
+describe("createRingComponent", () => {
+  it("should invoke the correct command for adding rings to hld", () => {
+    const exec = jest.fn();
+    const svcPathInHld = `/path/to/service`;
+    const ring = `dev`;
+
+    const expectedInvocation = `cd ${svcPathInHld} && mkdir -p ${ring} config && fab add ${ring} --path ./${ring} --method local --type component && touch ./config/common.yaml`;
+
+    createRingComponent(exec, svcPathInHld, ring);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+});
+
+describe("createStaticComponent", () => {
+  it("should invoke the correct command for creating static components", () => {
+    const exec = jest.fn();
+    const ringPathInHld = `/ring/path/in/hld`;
+
+    const expectedInvocation = `cd ${ringPathInHld} && mkdir -p config static && fab add static --path ./static --method local --type static && touch ./config/common.yaml`;
+
+    createStaticComponent(exec, ringPathInHld);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+});
+
+describe("addChartToRing", () => {
+  it("should invoke the correct command for adding a helm chart with a branch version", () => {
+    const exec = jest.fn();
+    const ringPath = "/path/to/ring";
+
+    const branch = "v1";
+    const git = "github.com/company/service";
+    const path = "/charts/service";
+
+    const serviceConfig: IBedrockServiceConfig = {
+      helm: {
+        chart: {
+          branch,
+          git,
+          path
+        }
+      }
+    };
+
+    /* tslint:disable-next-line: no-string-literal */
+    const addHelmChartCommand = `fab add chart --source ${git} --path ${path} --branch ${branch}`;
+
+    const expectedInvocation = `cd ${ringPath} && ${addHelmChartCommand}`;
+
+    addChartToRing(exec, ringPath, serviceConfig);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+
+  it("should invoke the correct command for adding a helm chart with a git-sha", () => {
+    const exec = jest.fn();
+    const ringPath = "/path/to/ring";
+
+    const sha = "f8a33e1d";
+    const git = "github.com/company/service";
+    const path = "/charts/service";
+
+    const serviceConfig: IBedrockServiceConfig = {
+      helm: {
+        chart: {
+          git,
+          path,
+          sha
+        }
+      }
+    };
+
+    /* tslint:disable-next-line: no-string-literal */
+    const addHelmChartCommand = `fab add chart --source ${git} --path ${path} --version ${sha}`;
+
+    const expectedInvocation = `cd ${ringPath} && ${addHelmChartCommand}`;
+
+    addChartToRing(exec, ringPath, serviceConfig);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+
+  it("should invke the correct command for adding a helm chart with a helm repository", () => {
+    const exec = jest.fn();
+    const ringPath = "/path/to/ring";
+
+    const repository = "github.com/company/service";
+    const chart = "/charts/service";
+
+    const serviceConfig: IBedrockServiceConfig = {
+      helm: {
+        chart: {
+          chart,
+          repository
+        }
+      }
+    };
+
+    /* tslint:disable-next-line: no-string-literal */
+    const addHelmChartCommand = `fab add chart --source ${repository} --path ${chart}`;
+
+    const expectedInvocation = `cd ${ringPath} && ${addHelmChartCommand}`;
+
+    addChartToRing(exec, ringPath, serviceConfig);
+
+    expect(exec).toBeCalled();
+    expect(exec).toBeCalledWith(expectedInvocation);
+  });
+});

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -121,7 +121,7 @@ export const reconcileHldDecorator = (command: commander.Command): void => {
           absHldPath
         );
       } catch (err) {
-        logger.error(`Error occurred while reconciling HLD`);
+        logger.error(`An error occurred while reconciling HLD`);
         logger.error(err);
         process.exit(1);
       }
@@ -247,7 +247,7 @@ export const execAndLog = async (commandToRun: string) => {
   if (commandResult.stderr) {
     logger.error(commandResult.stderr);
     throw Error(
-      `Error occurred when invoking command: ${commandResult.stderr}`
+      `An error occurred when invoking command: ${commandResult.stderr}`
     );
   }
 };
@@ -398,7 +398,7 @@ export const testAndGetAbsPath = (
 ): string => {
   const absPath = path.resolve(possiblyRelativePath);
   if (!test("-e", absPath) && !test("-d", absPath)) {
-    throw new Error(`Error: could not validate ${pathType} path.`);
+    throw new Error(`Could not validate ${pathType} path.`);
   }
   log(`Found ${pathType} at ${absPath}`);
   return absPath;
@@ -408,7 +408,7 @@ export const checkForFabrikate = (which: (path: string) => string) => {
   const fabrikateInstalled = which("fab");
   if (fabrikateInstalled === "") {
     throw new Error(
-      `Error: Fabrikate not installed. Please fetch and install the latest version: https://github.com/microsoft/fabrikate/releases`
+      `Fabrikate not installed. Please fetch and install the latest version: https://github.com/microsoft/fabrikate/releases`
     );
   }
 };

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -162,6 +162,13 @@ export const reconcileHld = async (
 
       await execAndLog(createConfigAndStaticComponentCommand);
 
+      // Service explicitly requests no ingress-routes to be generated.
+      if (serviceConfig.disableRouteScaffold) {
+        logger.info(
+          `Skipping ingress route generation for service ${serviceName}`
+        );
+        continue;
+      }
       // Create Middlewares
       const staticComponentPathInRing = path.join(ringPathInHld, "static");
       const middlewaresPathInStaticComponent = path.join(

--- a/src/lib/traefik/middleware.ts
+++ b/src/lib/traefik/middleware.ts
@@ -3,7 +3,7 @@
  *
  * @see https://docs.traefik.io/routing/providers/kubernetes-crd/
  */
-interface ITraefikMiddleware {
+export interface ITraefikMiddleware {
   apiVersion: "traefik.containo.us/v1alpha1";
   kind: "Middleware";
   metadata: {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -49,14 +49,16 @@ export interface IBedrockFile {
     };
   };
   services: {
-    [relativeDirectory: string]: {
-      displayName?: string;
-      middlewares?: string[];
-      helm: IHelmConfig;
-      disableRouteScaffold?: boolean;
-    };
+    [relativeDirectory: string]: IBedrockServiceConfig;
   };
   variableGroups?: string[];
+}
+
+export interface IBedrockServiceConfig {
+  displayName?:  string;
+  middlewares?: string[];
+  helm: IHelmConfig;
+  disableRouteScaffold?: boolean;
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -53,6 +53,7 @@ export interface IBedrockFile {
       displayName?: string;
       middlewares?: string[];
       helm: IHelmConfig;
+      disableRouteScaffold?: boolean;
     };
   };
   variableGroups?: string[];


### PR DESCRIPTION
This got to be a bit bigger than the requested task, but it does add much-needed tests for reconcile:

- Allows for skipping ingress route creation, when specified in bedrock.yaml
- Adds tests for reconcile
- Refactor much of the reconcile functionality to be more modular

Fixes https://github.com/microsoft/bedrock/issues/831