### PR TITLE
Better warning messages for Config()

### DIFF
--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -46,37 +46,35 @@ export const installHldToManifestPipelineDecorator = (
       const { azure_devops } = Config();
 
       const {
-        hldUrl = azure_devops && azure_devops.hld_repository,
-        manifestUrl = azure_devops && azure_devops.manifest_repository
+        hldUrl = azure_devops?.hld_repository,
+        manifestUrl = azure_devops?.manifest_repository
       } = opts;
-
-      const manifestRepoName = getRepositoryName(manifestUrl);
-
-      const {
-        orgName = azure_devops && azure_devops.org,
-        personalAccessToken = azure_devops && azure_devops.access_token,
-        devopsProject = azure_devops && azure_devops.project,
-        hldName = getRepositoryName(hldUrl),
-        pipelineName = hldName + "-to-" + manifestRepoName,
-        buildScriptUrl = BUILD_SCRIPT_URL
-      } = opts;
-
-      if (
-        !isValidConfig(
-          orgName,
-          devopsProject,
-          pipelineName,
-          manifestUrl,
-          hldName,
-          hldUrl,
-          buildScriptUrl,
-          personalAccessToken
-        )
-      ) {
-        process.exit(1);
-      }
 
       try {
+        const {
+          orgName = azure_devops?.org,
+          personalAccessToken = azure_devops?.access_token,
+          devopsProject = azure_devops?.project,
+          hldName = getRepositoryName(hldUrl),
+          pipelineName = hldName + "-to-" + getRepositoryName(manifestUrl),
+          buildScriptUrl = BUILD_SCRIPT_URL
+        } = opts;
+
+        if (
+          !isValidConfig(
+            orgName,
+            devopsProject,
+            pipelineName,
+            manifestUrl,
+            hldName,
+            hldUrl,
+            buildScriptUrl,
+            personalAccessToken
+          )
+        ) {
+          throw Error(`Invalid configuration provided`);
+        }
+
         await installHldToManifestPipeline(
           orgName,
           personalAccessToken,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import { IBedrockFile, IConfigYaml, IMaintainersFile } from "./types";
 // State
 ////////////////////////////////////////////////////////////////////////////////
 let spkConfig: IConfigYaml = {}; // DANGEROUS! this var is globally retrievable and mutable via Config()
+let hasWarnedAboutUninitializedConfig = false; // has emitted an initialization warning if global config does not exist
 ////////////////////////////////////////////////////////////////////////////////
 // Helpers
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,7 +84,7 @@ const getKeyVaultSecret = async (
   }
 
   if (keyVaultKey === undefined) {
-    keyVaultKey = await ((spkConfig.introspection || {}).azure || {}).key;
+    keyVaultKey = await spkConfig.introspection?.azure?.key;
   }
 
   return keyVaultKey;
@@ -101,14 +102,20 @@ export const Config = (): IConfigYaml => {
     try {
       loadConfiguration();
     } catch (err) {
-      logger.warn(err);
+      logger.verbose(err);
+      if (!hasWarnedAboutUninitializedConfig) {
+        logger.warn(
+          `Error loading SPK configuration file; run \`spk init\` to initialize your global configuration or ensure you have passed all required parameters to the called function.`
+        );
+        hasWarnedAboutUninitializedConfig = true;
+      }
     }
   }
 
   const introspectionAzure = {
-    ...(spkConfig.introspection || {}).azure,
+    ...spkConfig.introspection?.azure,
     get key() {
-      const { account_name } = (spkConfig.introspection || {}).azure || {};
+      const account_name = spkConfig.introspection?.azure?.account_name;
       return getKeyVaultSecret(spkConfig.key_vault_name, account_name);
     }
   };
@@ -250,7 +257,7 @@ export const loadConfiguration = (filepath: string = defaultConfigFile()) => {
     const data = readYaml<IConfigYaml>(filepath);
     spkConfig = loadConfigurationFromLocalEnv(data || {});
   } catch (err) {
-    logger.error(`An error occurred while loading configuration\n ${err}`);
+    logger.verbose(`An error occurred while loading configuration\n ${err}`);
     throw err;
   }
 };


### PR DESCRIPTION
Fixes some logging inconsistencies for when attempting to call `Config()` for an
uninitialized SPK project (ie; has not run `spk init`). Before `error` level
logs would be emitted, now only a single `warn` is emitted with IO `Error`s
being `verbose` logged.

- A single warning is emitted when a commands is called that uses `config()` but
  `.spk/config.yaml` is not found.
- Thrown errors from `loadConfiguration` are now `verbose` logged.

fixes https://github.com/microsoft/bedrock/issues/794