### PR TITLE
[REFACTORING] replace any with interface

### DIFF
--- a/src/commands/project/create-variable-group.ts
+++ b/src/commands/project/create-variable-group.ts
@@ -6,7 +6,11 @@ import { Bedrock, Config, write } from "../../config";
 import { IAzureDevOpsOpts } from "../../lib/git";
 import { addVariableGroup } from "../../lib/pipelines/variableGroup";
 import { logger } from "../../logger";
-import { IBedrockFile, IHelmConfig, IVariableGroupData } from "../../types";
+import {
+  IBedrockFile,
+  IVariableGroupData,
+  IVariableGroupDataVariable
+} from "../../types";
 
 /**
  * Adds the create command to the variable-group command object
@@ -161,7 +165,7 @@ export const create = async (
     );
 
     // validate variable group type"
-    const vars: any = {
+    const vars: IVariableGroupDataVariable = {
       ACR_NAME: {
         value: registryName
       },
@@ -185,11 +189,12 @@ export const create = async (
         value: tenantId
       }
     };
+
     const variableGroupData: IVariableGroupData = {
       description: "Created from spk CLI",
       name: variableGroupName,
       type: "Vsts",
-      variables: vars
+      variables: [vars]
     };
 
     return await addVariableGroup(variableGroupData, accessOpts);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -132,15 +132,15 @@ export interface IServiceEndpointData {
   tenant_id: string;
 }
 
+export interface IVariableGroupDataVariable {
+  [key: string]: AzureKeyVaultVariableValue;
+}
+
 export interface IVariableGroupData {
   name: string;
   description: string;
   type: string;
-  variables: [
-    {
-      [key: string]: AzureKeyVaultVariableValue;
-    }
-  ];
+  variables: [IVariableGroupDataVariable];
   key_vault_provider?: {
     name: string;
     service_endpoint: IServiceEndpointData;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -140,7 +140,7 @@ export interface IVariableGroupData {
   name: string;
   description: string;
   type: string;
-  variables: [IVariableGroupDataVariable];
+  variables: IVariableGroupDataVariable[];
   key_vault_provider?: {
     name: string;
     service_endpoint: IServiceEndpointData;


### PR DESCRIPTION
mainly to avoid using `any` in the code base