### PR TITLE
Specify Traefik2 IngressRoute Service Port

### DIFF
--- a/docs/service-management.md
+++ b/docs/service-management.md
@@ -50,6 +50,7 @@ Options:
   --git-push                                                  SPK CLI will try to commit and push these changes to a new origin/branch named after the service. (default: false)
   --variable-group-name <variable-group-name>                 The Azure DevOps Variable Group.
   --middlewares <comma-delimitated-list-of-middleware-names>  Traefik2 middlewares you wish to to be injected into your Traefik2 IngressRoutes (default: "")
+  --k8s-service-port <port>                                   Kubernetes service port which this service is exposed with; will be used to configure Traefik2 IngressRoutes (default: "80")
   -h, --help                                                  output usage information
 ```
 

--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -169,7 +169,8 @@ describe("addChartToRing", () => {
           git,
           path
         }
-      }
+      },
+      k8sServicePort: 1337
     };
 
     /* tslint:disable-next-line: no-string-literal */
@@ -198,7 +199,8 @@ describe("addChartToRing", () => {
           path,
           sha
         }
-      }
+      },
+      k8sServicePort: 1337
     };
 
     /* tslint:disable-next-line: no-string-literal */
@@ -225,7 +227,8 @@ describe("addChartToRing", () => {
           chart,
           repository
         }
-      }
+      },
+      k8sServicePort: 1337
     };
 
     /* tslint:disable-next-line: no-string-literal */
@@ -277,7 +280,8 @@ describe("reconcile tests", () => {
               path,
               sha
             }
-          }
+          },
+          k8sServicePort: 1337
         }
       }
     };
@@ -323,7 +327,8 @@ describe("reconcile tests", () => {
               path,
               sha
             }
-          }
+          },
+          k8sServicePort: 1337
         }
       }
     };

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -264,13 +264,17 @@ const createIngressRouteForRing = (
     staticComponentPathInRing,
     "ingress-route.yaml"
   );
-  // TODO: figure out a way to grab the port from _somewhere_; store in bedrock.yaml?
-  const ingressRoute = TraefikIngressRoute(serviceName, ring, 8000, {
-    middlewares: [
-      middlewares.metadata.name,
-      ...(serviceConfig.middlewares ?? [])
-    ]
-  });
+  const ingressRoute = TraefikIngressRoute(
+    serviceName,
+    ring,
+    serviceConfig.k8sServicePort,
+    {
+      middlewares: [
+        middlewares.metadata.name,
+        ...(serviceConfig.middlewares ?? [])
+      ]
+    }
+  );
 
   const routeYaml = yaml.safeDump(ingressRoute, {
     lineWidth: Number.MAX_SAFE_INTEGER

--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -35,9 +35,10 @@ describe("Initializing a blank/new bedrock repository", () => {
     }
 
     // ensure service specific files do not get created
-    const filepathsShouldNotExist = ["Dockerfile", "azure-pipelines.yaml"].map(
-      filename => path.join(randomTmpDir, filename)
-    );
+    const filepathsShouldNotExist = [
+      "Dockerfile",
+      "azure-pipelines.yaml"
+    ].map(filename => path.join(randomTmpDir, filename));
     for (const filepath of filepathsShouldNotExist) {
       expect(fs.existsSync(filepath)).toBe(false);
     }
@@ -65,7 +66,8 @@ describe("initializing an existing file does not modify it", () => {
               path: "./",
               sha: "bar"
             }
-          }
+          },
+          k8sServicePort: 1337
         }
       }
     };

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -216,7 +216,8 @@ const generateBedrockFile = async (
       };
 
       file.services["./" + relPathToPackageFromRoot] = {
-        helm
+        helm,
+        k8sServicePort: 80
       };
       return file;
     },

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import { promisify } from "util";
 import uuid from "uuid/v4";
-import { Bedrock } from "../../config";
+import { Bedrock, BedrockAsync } from "../../config";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import {
   disableVerboseLogging,
@@ -39,7 +39,8 @@ describe("validate pipeline config", () => {
     "my,middleware,string",
     true,
     "testVariableGroup",
-    "testDisplayName"
+    "testDisplayName",
+    80
   ];
 
   it("config is valid", () => {
@@ -81,7 +82,14 @@ describe("Adding a service to a repo directory", () => {
     );
 
     // addService call
-    await createService(randomTmpDir, serviceName, packageDir, false);
+    const k8sServicePort = 1337;
+    await createService(
+      randomTmpDir,
+      serviceName,
+      packageDir,
+      false,
+      k8sServicePort
+    );
 
     // Check temp test directory exists
     expect(fs.existsSync(randomTmpDir)).toBe(true);
@@ -100,6 +108,10 @@ describe("Adding a service to a repo directory", () => {
     }
 
     // TODO: Verify root project bedrock.yaml and maintainers.yaml has been changed too.
+    const bedrock = Bedrock(randomTmpDir);
+    const newService = bedrock.services["./" + serviceName];
+    expect(newService).toBeDefined();
+    expect(newService.k8sServicePort).toBe(k8sServicePort);
   });
 
   test("New directory is created under '/packages' directory with required service files.", async () => {
@@ -117,7 +129,7 @@ describe("Adding a service to a repo directory", () => {
     );
 
     // addService call
-    await createService(randomTmpDir, serviceName, "packages", false);
+    await createService(randomTmpDir, serviceName, "packages", false, 1337);
 
     // Check temp test directory exists
     expect(fs.existsSync(randomTmpDir)).toBe(true);
@@ -153,7 +165,7 @@ describe("Adding a service to a repo directory", () => {
     );
 
     // addService call
-    await createService(randomTmpDir, serviceName, "packages", true);
+    await createService(randomTmpDir, serviceName, "packages", true, 1337);
 
     // Check temp test directory exists
     expect(fs.existsSync(randomTmpDir)).toBe(true);
@@ -187,7 +199,7 @@ describe("Adding a service to a repo directory", () => {
     );
 
     // create service with no middleware
-    await createService(randomTmpDir, serviceName, packageDir, false);
+    await createService(randomTmpDir, serviceName, packageDir, false, 1337);
 
     // Check temp test directory exists
     expect(fs.existsSync(randomTmpDir)).toBe(true);
@@ -225,7 +237,7 @@ describe("Adding a service to a repo directory", () => {
 
     // add some middlewares
     const middlewares = ["foo", "bar", "baz"];
-    await createService(randomTmpDir, serviceName, packageDir, false, {
+    await createService(randomTmpDir, serviceName, packageDir, false, 1337, {
       middlewares
     });
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -18,7 +18,8 @@ describe("Bedrock", () => {
               chart: "elastic",
               repository: "some-repo"
             }
-          }
+          },
+          k8sServicePort: 1337
         },
         "foo/b": {
           helm: {
@@ -27,7 +28,8 @@ describe("Bedrock", () => {
               path: "some/path",
               sha: "cef8361c62e7a91887625336eb13a8f90dbcf8df"
             }
-          }
+          },
+          k8sServicePort: 1337
         }
       }
     };

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -261,13 +261,17 @@ describe("Adding a new service to a Bedrock file", () => {
         repository: "somehelmrepository"
       }
     };
+    const traefikMiddlewares = ["foo", "bar"];
+    const k8sServicePort = 8080;
 
     const writeSpy = jest.spyOn(fs, "writeFileSync");
     addNewServiceToBedrockFile(
       bedrockFilePath,
       servicePath,
       svcDisplayName,
-      helmConfig
+      helmConfig,
+      traefikMiddlewares,
+      k8sServicePort
     );
 
     const defaultBedrockFileObject = createTestBedrockYaml(false);
@@ -279,7 +283,8 @@ describe("Adding a new service to a Bedrock file", () => {
         ["./" + servicePath]: {
           displayName: svcDisplayName,
           helm: helmConfig,
-          middlewares: []
+          k8sServicePort,
+          middlewares: traefikMiddlewares
         }
       },
       variableGroups: []

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -619,7 +619,8 @@ export const addNewServiceToBedrockFile = (
   newServicePath: string,
   svcDisplayName: string,
   helmConfig: IHelmConfig,
-  middlewares: string[] = []
+  middlewares: string[],
+  k8sServicePort: number
 ) => {
   const bedrockFile = yaml.safeLoad(
     fs.readFileSync(bedrockFilePath, "utf8")
@@ -628,6 +629,7 @@ export const addNewServiceToBedrockFile = (
   bedrockFile.services["./" + newServicePath] = {
     displayName: svcDisplayName,
     helm: helmConfig,
+    k8sServicePort,
     middlewares
   };
 

--- a/src/lib/traefik/ingress-route.ts
+++ b/src/lib/traefik/ingress-route.ts
@@ -54,13 +54,13 @@ export const TraefikIngressRoute = (
   serviceName: string,
   ringName: string,
   servicePort: number,
-  opts: {
+  opts?: {
     middlewares?: string[];
     namespace?: string;
     entryPoints?: TraefikEntryPoints;
-  } = {}
+  }
 ): ITraefikIngressRoute => {
-  const { entryPoints, middlewares = [], namespace } = opts;
+  const { entryPoints, middlewares = [], namespace } = opts ?? {};
   const name = !!ringName ? `${serviceName}-${ringName}` : serviceName;
   const routeMatchPathPrefix = `PathPrefix(\`/${serviceName}\`)`;
   const routeMatchHeaders = ringName && `Headers(\`Ring\`, \`${ringName}\`)`; // no 'X-' prefix for header: https://tools.ietf.org/html/rfc6648
@@ -73,18 +73,17 @@ export const TraefikIngressRoute = (
     kind: "IngressRoute",
     metadata: {
       name,
-      ...(() => (!!namespace ? { namespace } : {}))()
+      ...(!!namespace ? { namespace } : {})
     },
     spec: {
-      ...(() =>
-        !!entryPoints && entryPoints.length > 0 ? { entryPoints } : {})(),
+      ...((entryPoints ?? []).length > 0 ? { entryPoints } : {}),
       routes: [
         {
           kind: "Rule",
           match: routeMatch,
-          middlewares: [
-            ...middlewares.map(middlewareName => ({ name: middlewareName }))
-          ],
+          middlewares: middlewares.map(middlewareName => ({
+            name: middlewareName
+          })),
           services: [
             {
               name,

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -66,13 +66,16 @@ export const createTestBedrockYaml = (
     rings: {},
     services: {
       "./": {
-        helm: service1HelmConfig
+        helm: service1HelmConfig,
+        k8sServicePort: 80
       },
       "./packages/service1": {
-        helm: service2HelmConfig
+        helm: service2HelmConfig,
+        k8sServicePort: 80
       },
       "./zookeeper": {
-        helm: zookeeperHelmConfig
+        helm: zookeeperHelmConfig,
+        k8sServicePort: 80
       }
     },
     variableGroups: []

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -59,6 +59,7 @@ export interface IBedrockServiceConfig {
   middlewares?: string[];
   helm: IHelmConfig;
   disableRouteScaffold?: boolean;
+  k8sServicePort: number; // the service port for the k8s service Traefik2 IngressRoutes will point to
 }
 
 /**


### PR DESCRIPTION
Added the ability to specify a `--k8s-service-port` to `spk service create`.
This port will now be tracked in the users `bedrock.yaml` file and be injected
to the Traefik2 IngressRoutes created via `spk hld reconcile`.

closes https://github.com/microsoft/bedrock/issues/818