### PR TITLE
Update to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## [0.4.1] - 2020-01-29
+
+### Changed
+
+- Resolved [bug](https://github.com/microsoft/bedrock/issues/916) around
+  `spk hld reconcile`
+- Resolved [bug](https://github.com/microsoft/bedrock/issues/905) around unit
+  test failure
+
 ## [0.4.0] - 2020-01-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The missing Bedrock CLI",
   "author": "Evan Louie <evan.louie@microsoft.com> (https://evanlouie.com)",
   "contributors": [],


### PR DESCRIPTION
Updating to 0.4.1
- Resolved [bug](https://github.com/microsoft/bedrock/issues/916) around `spk hld reconcile`
- Resolved [bug](https://github.com/microsoft/bedrock/issues/905) around unit test

This new release will help with testing pipelines that rely on downloading the latest release of `spk`