### PR TITLE
Improve error handling for spk hld reconcile

### DIFF
--- a/src/lib/assertions.test.ts
+++ b/src/lib/assertions.test.ts
@@ -1,0 +1,41 @@
+import { assertIsStringWithContent, isString } from "./assertions";
+
+describe("isString", () => {
+  test("returns true for strings", () => {
+    expect(isString("123")).toBe(true);
+  });
+
+  test("returns false for non-strings", () => {
+    expect(isString(123)).toBe(false);
+  });
+});
+
+describe("assertIsStringWithContent", () => {
+  test("no error thrown when valid string provided", () => {
+    let error: Error | undefined;
+    try {
+      assertIsStringWithContent("123");
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeUndefined();
+  });
+
+  test("error thrown when invalid string provided", () => {
+    let error: Error | undefined;
+    try {
+      assertIsStringWithContent("");
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+
+    error = undefined;
+    try {
+      assertIsStringWithContent(123);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+  });
+});

--- a/src/lib/assertions.ts
+++ b/src/lib/assertions.ts
@@ -1,0 +1,28 @@
+/**
+ * String type-guard
+ *
+ * @param value value to type-guard as a string
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/**
+ * Assertion helper to assert that `value` is a string with a length greater
+ * than 0
+ *
+ * @param value value to assert is string of length greater than 0
+ * @param variableName name of the variable being asserted -- used for clearer error messages if provided
+ */
+export function assertIsStringWithContent(
+  value: unknown,
+  variableName?: string
+): asserts value is string {
+  if (!isString(value) || value.length === 0) {
+    const valueType = typeof value;
+    const errorMessage = variableName
+      ? `${variableName} expected to be of type 'string' with length greater than 0, '${valueType}' provided with value '${value}'`
+      : `expected value of type 'string' with length greater than 0, '${valueType}' provided with value '${value}'`;
+    throw TypeError(errorMessage);
+  }
+}

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -22,34 +22,30 @@ export const exec = async (
   opts: child_process.SpawnOptions = {}
 ): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
-    const process = child_process.spawn(cmd, args, opts);
+    const child = child_process.spawn(cmd, args, opts);
     const cmdString = `${cmd} ${args.join(" ")}`;
     let stdout = "";
     let stderr = "";
 
     // Capture stdout/stderr as process runs
-    if (process.stdout) {
-      process.stdout.on("data", data => {
-        logger.debug(`stdout -> '${cmdString}' -> ${data}`.trim());
-        stdout = stdout + data;
-      });
-    }
-    if (process.stderr) {
-      process.stderr.on("data", data => {
-        logger.debug(`stderr -> '${cmdString}' -> ${data}`.trim());
-        stderr = stderr + data;
-      });
-    }
+    child.stdout?.on("data", data => {
+      logger.debug(`stdout -> '${cmdString}' -> ${data}`.trim());
+      stdout = stdout + data;
+    });
+    child.stderr?.on("data", data => {
+      logger.debug(`stderr -> '${cmdString}' -> ${data}`.trim());
+      stderr = stderr + data;
+    });
 
     // Reject on error
-    process.on("error", err => {
+    child.on("error", err => {
       logger.verbose(`'${cmdString}' encountered an error during execution`);
       logger.verbose(err);
       reject(err);
     });
 
     // Resolve promise on completion
-    process.on("exit", code => {
+    child.on("exit", code => {
       // Log completion of of command
       logger.verbose(`'${cmdString}' exited with code: ${code}`);
       if (stdout.length > 0) {


### PR DESCRIPTION
- Logging improvements when shelling out to fabrikate via `spk hld reconcile`
  - Logs are now piped directly to the parent process and shown live as they
    occur
- Errors returned (non-0 return codes) from child processes now propagate errors
  up spk and terminate the process.

fixes https://github.com/microsoft/bedrock/issues/900