### PR TITLE
[FIX] Issue 924: Remove DeprecationWarnings from SPK output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import { projectCommand } from "./commands/project";
 import { serviceCommand } from "./commands/service";
 import { variableGroupCommand } from "./commands/variable-group";
 
+(process as any).noDeprecation = true;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Instantiate core command object
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
added code to suppress warning (from Evan)
did `sh validations.sh` and do not see the Buffer warning.

Fixes https://github.com/microsoft/bedrock/issues/924