### PR TITLE
Use new version of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "open": "^6.4.0",
     "shelljs": "^0.8.3",
     "simple-git": "^1.126.0",
-    "spektate": "^0.1.16",
+    "spektate": "^0.1.17",
     "uuid": "^3.3.3",
     "winston": "^3.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6192,10 +6192,10 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-spektate@^0.1.16:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.16.tgz#bd20a059bf9fdb26e3bc263570024c863c069fac"
-  integrity sha512-JMq8HROZfF63GoLYfRi3a+JCal/dldc7xi+v85IUha0C4Rp88rZXsODjaKD53irLhv3FwRszinPnDhuHqyXPrQ==
+spektate@^0.1.17:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/spektate/-/spektate-0.1.17.tgz#bd009d2c3f72238e1119d6473b92d7947dbcbd1e"
+  integrity sha512-fOsPdjQMgn19WaQ49+KVcZdGdl8uz/VEvVpcU5/3dYZr3Qtv5EdHfdoCveqRkdS15iYbj9MNHD5/MPH+ckoqHA==
   dependencies:
     axios "^0.19.0"
     azure-storage "^2.10.3"


### PR DESCRIPTION
New version removes unnecessary print statements coming from old spektate package