### PR TITLE
Refactoring service build and update pipelines

### DIFF
--- a/docs/bedrock-end-to-end-dx.md
+++ b/docs/bedrock-end-to-end-dx.md
@@ -89,8 +89,8 @@ services:
 
 ```
 
-and adds a `build-update-hld-pipeline.yaml` file in `services/discovery-service`
-to build it.
+and adds a `build-update-hld.yaml` file in `services/discovery-service` to build
+it.
 
 `spk` also includes automation for creating the Azure Devops pipeline in Azure
 itself. To create that, Dag executes:
@@ -110,7 +110,7 @@ to his monorepo:
 ```bash
 $ git add bedrock.yaml
 $ git add maintainers.yaml
-$ git add services/discovery-service/build-update-hld-pipeline.yaml
+$ git add services/discovery-service/build-update-hld.yaml
 $ git commit -m 'Add discovery-service build pipeline'
 $ git push origin HEAD
 ```

--- a/docs/bedrock-end-to-end-dx.md
+++ b/docs/bedrock-end-to-end-dx.md
@@ -89,8 +89,8 @@ services:
 
 ```
 
-and adds a `azure-pipelines.yaml` file in `services/discovery-service` to build
-it.
+and adds a `build-update-hld-pipeline.yaml` file in `services/discovery-service`
+to build it.
 
 `spk` also includes automation for creating the Azure Devops pipeline in Azure
 itself. To create that, Dag executes:
@@ -110,7 +110,7 @@ to his monorepo:
 ```bash
 $ git add bedrock.yaml
 $ git add maintainers.yaml
-$ git add services/discovery-service/azure-pipelines.yaml
+$ git add services/discovery-service/build-update-hld-pipeline.yaml
 $ git commit -m 'Add discovery-service build pipeline'
 $ git push origin HEAD
 ```

--- a/src/commands/hld/init.test.ts
+++ b/src/commands/hld/init.test.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import uuid from "uuid/v4";
+import { HLD_PIPELINE_FILENAME } from "../../lib/constants";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import {
   disableVerboseLogging,
@@ -53,7 +54,7 @@ const testRepoInitialization = async (gitPush: boolean) => {
   expect(fs.existsSync(randomTmpDir)).toBe(true);
 
   // Verify new azure-pipelines created
-  ["manifest-generation.yaml", "component.yaml"]
+  [HLD_PIPELINE_FILENAME, "component.yaml"]
     .map(filename => path.join(randomTmpDir, filename))
     .forEach(filePath => {
       expect(fs.existsSync(filePath)).toBe(true);

--- a/src/commands/hld/init.test.ts
+++ b/src/commands/hld/init.test.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import uuid from "uuid/v4";
-import { HLD_PIPELINE_FILENAME } from "../../lib/constants";
+import { RENDER_HLD_PIPELINE_FILENAME } from "../../lib/constants";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import {
   disableVerboseLogging,
@@ -54,7 +54,7 @@ const testRepoInitialization = async (gitPush: boolean) => {
   expect(fs.existsSync(randomTmpDir)).toBe(true);
 
   // Verify new azure-pipelines created
-  [HLD_PIPELINE_FILENAME, "component.yaml"]
+  [RENDER_HLD_PIPELINE_FILENAME, "component.yaml"]
     .map(filename => path.join(randomTmpDir, filename))
     .forEach(filePath => {
       expect(fs.existsSync(filePath)).toBe(true);

--- a/src/commands/hld/init.ts
+++ b/src/commands/hld/init.ts
@@ -48,7 +48,7 @@ export const commandDecorator = (command: commander.Command): void => {
 };
 
 export const initialize = async (rootProjectPath: string, gitPush: boolean) => {
-  // Create azure-pipelines.yaml for hld repository, if required.
+  // Create manifest-generation.yaml for hld repository, if required.
   logger.info("Initializing bedrock HLD repository.");
 
   generateHldAzurePipelinesYaml(rootProjectPath);

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -6,7 +6,7 @@ import {
 import commander from "commander";
 import { Config } from "../../config";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
-import { BUILD_SCRIPT_URL } from "../../lib/constants";
+import { BUILD_SCRIPT_URL, HLD_PIPELINE_FILENAME } from "../../lib/constants";
 import { getRepositoryName } from "../../lib/gitutils";
 import {
   createPipelineForDefinition,
@@ -130,7 +130,7 @@ export const installHldToManifestPipeline = async (values: ICommandOptions) => {
       values.manifestUrl
     ),
     yamlFileBranch: "master",
-    yamlFilePath: `manifest-generation.yaml`
+    yamlFilePath: HLD_PIPELINE_FILENAME
   } as IAzureRepoPipelineConfig);
 
   try {

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -6,7 +6,10 @@ import {
 import commander from "commander";
 import { Config } from "../../config";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
-import { BUILD_SCRIPT_URL, HLD_PIPELINE_FILENAME } from "../../lib/constants";
+import {
+  BUILD_SCRIPT_URL,
+  RENDER_HLD_PIPELINE_FILENAME
+} from "../../lib/constants";
 import { getRepositoryName } from "../../lib/gitutils";
 import {
   createPipelineForDefinition,
@@ -130,7 +133,7 @@ export const installHldToManifestPipeline = async (values: ICommandOptions) => {
       values.manifestUrl
     ),
     yamlFileBranch: "master",
-    yamlFilePath: HLD_PIPELINE_FILENAME
+    yamlFilePath: RENDER_HLD_PIPELINE_FILENAME
   } as IAzureRepoPipelineConfig);
 
   try {

--- a/src/commands/project/create-variable-group.test.ts
+++ b/src/commands/project/create-variable-group.test.ts
@@ -10,6 +10,7 @@ import {
   isExists as isBedrockFileExists,
   read as readBedrockFile
 } from "../../lib/bedrockYaml";
+import { PROJECT_PIPELINE_FILENAME } from "../../lib/constants";
 import { IAzureDevOpsOpts } from "../../lib/git";
 import * as pipelineVariableGroup from "../../lib/pipelines/variableGroup";
 import {
@@ -289,7 +290,7 @@ describe("updateLifeCyclePipeline", () => {
 
     write(defaultBedrockFileObject, randomTmpDir);
 
-    const hldFilePath = path.join(randomTmpDir, "hld-lifecycle.yaml");
+    const hldFilePath = path.join(randomTmpDir, PROJECT_PIPELINE_FILENAME);
 
     const hldLifeCycleFile: IAzurePipelinesYaml = createTestHldLifecyclePipelineYaml(
       false
@@ -326,7 +327,7 @@ describe("updateLifeCyclePipeline", () => {
 
     write(defaultBedrockFileObject, randomTmpDir);
 
-    const hldFilePath = path.join(randomTmpDir, "hld-lifecycle.yaml");
+    const hldFilePath = path.join(randomTmpDir, PROJECT_PIPELINE_FILENAME);
 
     const hldLifeCycleFile: IAzurePipelinesYaml = createTestHldLifecyclePipelineYaml(
       false

--- a/src/commands/project/create-variable-group.ts
+++ b/src/commands/project/create-variable-group.ts
@@ -9,7 +9,7 @@ import {
   exit as exitCmd,
   validateForRequiredValues
 } from "../../lib/commandBuilder";
-import { PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE } from "../../lib/constants";
+import { PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE, PROJECT_PIPELINE_FILENAME } from "../../lib/constants";
 import { IAzureDevOpsOpts } from "../../lib/git";
 import { addVariableGroup } from "../../lib/pipelines/variableGroup";
 import { hasValue } from "../../lib/validator";
@@ -257,7 +257,7 @@ export const updateLifeCyclePipeline = async (rootProjectPath: string) => {
     throw new Error("Project root path is not valid");
   }
 
-  const fileName: string = "hld-lifecycle.yaml";
+  const fileName: string = PROJECT_PIPELINE_FILENAME;
   const absProjectRoot = path.resolve(rootProjectPath);
 
   // Get bedrock.yaml

--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -1,6 +1,9 @@
 import uuid from "uuid/v4";
 import { Bedrock, Maintainers, write } from "../../config";
-import { SERVICE_PIPELINE_FILENAME } from "../../lib/constants";
+import {
+  PROJECT_PIPELINE_FILENAME,
+  SERVICE_PIPELINE_FILENAME
+} from "../../lib/constants";
 import { createTempDir, getMissingFilenames } from "../../lib/ioUtil";
 import { IBedrockFile, IMaintainersFile } from "../../types";
 import { execute, initialize } from "./init";
@@ -10,7 +13,7 @@ const CREATED_FILES = [
   ".gitignore",
   "bedrock.yaml",
   "maintainers.yaml",
-  "hld-lifecycle.yaml"
+  PROJECT_PIPELINE_FILENAME
 ];
 
 describe("Initializing a blank/new bedrock repository", () => {

--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -24,7 +24,7 @@ describe("Initializing a blank/new bedrock repository", () => {
     // ensure service specific files do not get created
     const unexpected = getMissingFilenames(randomTmpDir, [
       "Dockerfile",
-      "azure-pipelines.yaml"
+      "build-update-hld-pipeline.yaml"
     ]);
     expect(unexpected.length).toBe(2);
   });

--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -1,5 +1,6 @@
 import uuid from "uuid/v4";
 import { Bedrock, Maintainers, write } from "../../config";
+import { SERVICE_PIPELINE_FILENAME } from "../../lib/constants";
 import { createTempDir, getMissingFilenames } from "../../lib/ioUtil";
 import { IBedrockFile, IMaintainersFile } from "../../types";
 import { execute, initialize } from "./init";
@@ -24,7 +25,7 @@ describe("Initializing a blank/new bedrock repository", () => {
     // ensure service specific files do not get created
     const unexpected = getMissingFilenames(randomTmpDir, [
       "Dockerfile",
-      "build-update-hld-pipeline.yaml"
+      SERVICE_PIPELINE_FILENAME
     ]);
     expect(unexpected.length).toBe(2);
   });

--- a/src/commands/project/pipeline.ts
+++ b/src/commands/project/pipeline.ts
@@ -12,10 +12,11 @@ import {
   validateForRequiredValues
 } from "../../lib/commandBuilder";
 import {
+  BUILD_SCRIPT_URL,
   PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE,
-  PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE
+  PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE,
+  PROJECT_PIPELINE_FILENAME
 } from "../../lib/constants";
-import { BUILD_SCRIPT_URL } from "../../lib/constants";
 import {
   getOriginUrl,
   getRepositoryName,
@@ -148,14 +149,14 @@ const createPipeline = async (
   devopsClient: IBuildApi
 ): Promise<BuildDefinition> => {
   const definition = definitionForAzureRepoPipeline({
-    branchFilters: ["master"], // I believe this is intentional. Our pipelines are triggered only by merges into the master branch.
+    branchFilters: ["master"], // Pipelines are triggered only by merges into the master branch.
     maximumConcurrentBuilds: 1,
     pipelineName: values.pipelineName!,
     repositoryName: values.repoName!,
     repositoryUrl: values.repoUrl!,
     variables: requiredPipelineVariables(values.buildScriptUrl!),
-    yamlFileBranch: "master", // I believe this is intentional. Our pipelines are triggered only by merges into the master branch.
-    yamlFilePath: "hld-lifecycle.yaml" // TOFIX: hardcoded?
+    yamlFileBranch: "master", // Pipeline is defined in master
+    yamlFilePath: PROJECT_PIPELINE_FILENAME // Pipeline definition lives in root directory.
   });
 
   try {

--- a/src/commands/project/pipeline.ts
+++ b/src/commands/project/pipeline.ts
@@ -149,7 +149,7 @@ const createPipeline = async (
   devopsClient: IBuildApi
 ): Promise<BuildDefinition> => {
   const definition = definitionForAzureRepoPipeline({
-    branchFilters: ["master"], // Pipelines are triggered only by merges into the master branch.
+    branchFilters: ["master"], // hld reconcile pipeline is triggered only by merges into the master branch.
     maximumConcurrentBuilds: 1,
     pipelineName: values.pipelineName!,
     repositoryName: values.repoName!,

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -6,6 +6,7 @@ import { Bedrock } from "../../config";
 import * as config from "../../config";
 import * as bedrockYaml from "../../lib/bedrockYaml";
 import { DEFAULT_CONTENT as BedrockMockedContent } from "../../lib/bedrockYaml";
+import { SERVICE_PIPELINE_FILENAME } from "../../lib/constants";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import { createTempDir, removeDir } from "../../lib/ioUtil";
 import {

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -72,7 +72,7 @@ const validateDirNFiles = (
   expect(fs.existsSync(serviceDirPath)).toBe(true);
 
   // Verify new azure-pipelines created
-  const filepaths = ["azure-pipelines.yaml", "Dockerfile"].map(filename =>
+  const filepaths = [SERVICE_PIPELINE_FILENAME, "Dockerfile"].map(filename =>
     path.join(serviceDirPath, filename)
   );
 

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -51,6 +51,7 @@ const mockValues: ICommandValues = {
   packagesDir: "",
   pathPrefix: "",
   pathPrefixMajorVersion: "",
+  ringNames: [],
   variableGroups: []
 };
 
@@ -99,6 +100,18 @@ describe("Test fetchValues function", () => {
     const result = fetchValues(mocked);
     expect(result.middlewaresArray).toEqual(["mid1", "mid2"]);
   });
+  it("Postive test: with bedrock rings", () => {
+    const mockedBedrockFileConfig = { ...BedrockMockedContent };
+    mockedBedrockFileConfig.rings = {
+      master: {},
+      qa: {}
+    };
+    jest.spyOn(config, "Bedrock").mockReturnValueOnce(mockedBedrockFileConfig);
+    const mocked = getMockValues();
+    mocked.ringNames = ["master", "qa"];
+    const result = fetchValues(mocked);
+    expect(result.ringNames).toEqual(["master", "qa"]);
+  });
   it("Postive test", () => {
     const mocked = getMockValues();
     jest.spyOn(config, "Bedrock").mockReturnValueOnce(BedrockMockedContent);
@@ -106,7 +119,6 @@ describe("Test fetchValues function", () => {
     expect(result).toEqual(mocked);
   });
 });
-
 describe("Test execute function", () => {
   it("Negative test: without service name", async () => {
     const exitFn = jest.fn();

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -171,7 +171,7 @@ export const createService = async (
   shelljs.mkdir("-p", newServiceDir);
 
   // Create azure pipelines yaml in directory
-  await generateServiceBuildAndUpdatePipelineYaml(
+  generateServiceBuildAndUpdatePipelineYaml(
     rootProjectPath,
     values.ringNames,
     serviceName,

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -174,7 +174,7 @@ export const createService = async (
   generateServiceBuildAndUpdatePipelineYaml(
     rootProjectPath,
     values.ringNames,
-    values.displayName ?? serviceName, // displayName takes priority over serviceName (which could be '.')
+    values.displayName ? values.displayName : serviceName, // displayName takes priority over serviceName (which could be '.')
     newServiceDir,
     values.variableGroups
   );

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -174,7 +174,7 @@ export const createService = async (
   generateServiceBuildAndUpdatePipelineYaml(
     rootProjectPath,
     values.ringNames,
-    serviceName,
+    values.displayName ?? serviceName, // displayName takes priority over serviceName (which could be '.')
     newServiceDir,
     values.variableGroups
   );

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -170,11 +170,28 @@ export const createService = async (
 
   shelljs.mkdir("-p", newServiceDir);
 
+  const pipelineServiceName = values.displayName
+    ? values.displayName
+    : serviceName; // displayName takes priority over serviceName (which could be '.')
+  // Sanity check
+  if (
+    pipelineServiceName === "." ||
+    pipelineServiceName === "./" ||
+    pipelineServiceName === "./."
+  ) {
+    logger.error(
+      `Cannot create service pipeline due to serviceName being '.'. Please include a displayName if you are trying to create a service in your project root directory.`
+    );
+    throw new Error(
+      "Cannot create service pipeline due to serviceName being '.'. Please include a displayName if you are trying to create a service in your project root directory."
+    );
+  }
+
   // Create azure pipelines yaml in directory
   generateServiceBuildAndUpdatePipelineYaml(
     rootProjectPath,
     values.ringNames,
-    values.displayName ? values.displayName : serviceName, // displayName takes priority over serviceName (which could be '.')
+    pipelineServiceName,
     newServiceDir,
     values.variableGroups
   );

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -173,9 +173,12 @@ export const createService = async (
   shelljs.mkdir("-p", newServiceDir);
 
   // Create azure pipelines yaml in directory
-  await generateStarterAzurePipelinesYaml(rootProjectPath, newServiceDir, {
-    variableGroups: values.variableGroups
-  });
+  await generateServiceBuildAndUpdatePipelineYaml(
+    rootProjectPath,
+    serviceName,
+    newServiceDir,
+    values.variableGroups
+  );
 
   // Create empty .gitignore file in directory
   generateGitIgnoreFile(newServiceDir, "");

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -16,7 +16,7 @@ import {
   addNewServiceToMaintainersFile,
   generateDockerfile,
   generateGitIgnoreFile,
-  generateStarterAzurePipelinesYaml
+  generateServiceBuildAndUpdatePipelineYaml
 } from "../../lib/fileutils";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import { isPortNumberString } from "../../lib/validator";

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -45,6 +45,7 @@ export interface ICommandOptions {
 export interface ICommandValues extends ICommandOptions {
   k8sPort: number;
   middlewaresArray: string[];
+  ringNames: string[];
   variableGroups: string[];
 }
 
@@ -53,10 +54,9 @@ export const fetchValues = (opts: ICommandOptions) => {
     throw new Error("value for --k8s-service-port is not a valid port number");
   }
 
-  let variableGroups: string[] = [];
-
   const bedrock = Bedrock();
-  variableGroups = bedrock.variableGroups || [];
+  const variableGroups = bedrock.variableGroups ?? [];
+  const rings = Object.keys(bedrock.rings);
 
   let middlewaresArray: string[] = [];
   if (opts.middlewares && opts.middlewares.trim()) {
@@ -81,6 +81,7 @@ export const fetchValues = (opts: ICommandOptions) => {
     packagesDir: opts.packagesDir,
     pathPrefix: opts.pathPrefix,
     pathPrefixMajorVersion: opts.pathPrefixMajorVersion,
+    ringNames: rings,
     variableGroups
   };
 
@@ -146,10 +147,7 @@ export const commandDecorator = (command: commander.Command): void => {
  *
  * @param rootProjectPath
  * @param serviceName
- * @param packagesDir
- * @param gitPush
- * @param k8sBackendPort
- * @param opts
+ * @param values
  */
 export const createService = async (
   rootProjectPath: string,
@@ -175,6 +173,7 @@ export const createService = async (
   // Create azure pipelines yaml in directory
   await generateServiceBuildAndUpdatePipelineYaml(
     rootProjectPath,
+    values.ringNames,
     serviceName,
     newServiceDir,
     values.variableGroups

--- a/src/commands/service/pipeline.ts
+++ b/src/commands/service/pipeline.ts
@@ -7,7 +7,7 @@ import commander from "commander";
 import path from "path";
 import { Config } from "../../config";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
-import { BUILD_SCRIPT_URL } from "../../lib/constants";
+import { BUILD_SCRIPT_URL, SERVICE_PIPELINE_FILENAME } from "../../lib/constants";
 import {
   getOriginUrl,
   getRepositoryName,
@@ -79,23 +79,10 @@ export const commandDecorator = (command: commander.Command) => {
 /**
  * Install a pipeline for the service in an azure devops org.
  *
-<<<<<<< HEAD
  * @param serviceName Name of the service this pipeline belongs to;
  *        this is only used when `packagesDir` is defined as a means
  *        to locate the azure-pipelines.yaml file
  * @param values Values from commander
-=======
- * @param serviceName Name of the service this pipeline belongs to; this is only used when `packagesDir` is defined as a means to locate the build-update-hld-pipeline.yaml file
- * @param orgName
- * @param personalAccessToken
- * @param pipelineName
- * @param repositoryName
- * @param repositoryUrl
- * @param project
- * @param packagesDir The directory containing the services for a mono-repo. If undefined; implies that we are operating on a standard service repository
- * @param buildScriptUrl Build Script URL
- * @param exitFn
->>>>>>> Renaming service pipelines from azure-pipelines.yaml to build-update-hld-pipeline.yaml
  */
 export const installBuildUpdatePipeline = async (
   serviceName: string,
@@ -114,9 +101,9 @@ export const installBuildUpdatePipeline = async (
     // if a packages dir is supplied, its a mono-repo
     const yamlFilePath = values.packagesDir
       ? // if a packages dir is supplied, concat <packages-dir>/<service-name>
-        path.join(values.packagesDir, serviceName, "azure-pipelines.yaml")
+        path.join(values.packagesDir, serviceName, SERVICE_PIPELINE_FILENAME)
       : // if no packages dir, then just concat with the service directory.
-        path.join(serviceName, "azure-pipelines.yaml");
+        path.join(serviceName, SERVICE_PIPELINE_FILENAME);
 
     const definition = definitionForAzureRepoPipeline({
       branchFilters: ["master"],

--- a/src/commands/service/pipeline.ts
+++ b/src/commands/service/pipeline.ts
@@ -79,10 +79,23 @@ export const commandDecorator = (command: commander.Command) => {
 /**
  * Install a pipeline for the service in an azure devops org.
  *
+<<<<<<< HEAD
  * @param serviceName Name of the service this pipeline belongs to;
  *        this is only used when `packagesDir` is defined as a means
  *        to locate the azure-pipelines.yaml file
  * @param values Values from commander
+=======
+ * @param serviceName Name of the service this pipeline belongs to; this is only used when `packagesDir` is defined as a means to locate the build-update-hld-pipeline.yaml file
+ * @param orgName
+ * @param personalAccessToken
+ * @param pipelineName
+ * @param repositoryName
+ * @param repositoryUrl
+ * @param project
+ * @param packagesDir The directory containing the services for a mono-repo. If undefined; implies that we are operating on a standard service repository
+ * @param buildScriptUrl Build Script URL
+ * @param exitFn
+>>>>>>> Renaming service pipelines from azure-pipelines.yaml to build-update-hld-pipeline.yaml
  */
 export const installBuildUpdatePipeline = async (
   serviceName: string,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,8 @@
 export const BUILD_SCRIPT_URL =
   "https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh";
 
+export const HLD_PIPELINE_FILENAME = "manifest-generation.yaml";
+
 export const PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE =
   "Please run `spk project init` command before running this command to initialize the project.";
 
@@ -9,3 +11,7 @@ export const PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE =
 
 export const PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE =
   "Please run `spk project cvg` command before running this command to create a variable group.";
+
+export const PROJECT_PIPELINE_FILENAME = "hld-lifecycle.yaml";
+
+export const SERVICE_PIPELINE_FILENAME = "build-update-hld.yaml";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,6 @@
 export const BUILD_SCRIPT_URL =
   "https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh";
 
-export const HLD_PIPELINE_FILENAME = "manifest-generation.yaml";
-
 export const PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE =
   "Please run `spk project init` command before running this command to initialize the project.";
 
@@ -13,6 +11,8 @@ export const PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE =
   "Please run `spk project cvg` command before running this command to create a variable group.";
 
 export const PROJECT_PIPELINE_FILENAME = "hld-lifecycle.yaml";
+
+export const RENDER_HLD_PIPELINE_FILENAME = "manifest-generation.yaml";
 
 export const SERVICE_PIPELINE_FILENAME = "build-update-hld.yaml";
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,3 +15,5 @@ export const PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE =
 export const PROJECT_PIPELINE_FILENAME = "hld-lifecycle.yaml";
 
 export const SERVICE_PIPELINE_FILENAME = "build-update-hld.yaml";
+
+export const VM_IMAGE = "ubuntu-latest";

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -15,7 +15,10 @@ import os from "os";
 import path from "path";
 import shelljs from "shelljs";
 import uuid from "uuid/v4";
-import { SERVICE_PIPELINE_FILENAME } from "../lib/constants";
+import {
+  PROJECT_PIPELINE_FILENAME,
+  SERVICE_PIPELINE_FILENAME
+} from "../lib/constants";
 import { disableVerboseLogging, enableVerboseLogging, logger } from "../logger";
 import {
   createTestHldAzurePipelinesYaml,
@@ -62,7 +65,7 @@ describe("generateHldLifecyclePipelineYaml", () => {
 
   it("should not do anything if hld-lifecycle.yaml exists", async () => {
     const mockFsOptions = {
-      [`${targetDirectory}/hld-lifecycle.yaml`]: "existing pipeline"
+      [`${targetDirectory}/${PROJECT_PIPELINE_FILENAME}`]: "existing pipeline"
     };
     mockFs(mockFsOptions);
 
@@ -71,7 +74,7 @@ describe("generateHldLifecyclePipelineYaml", () => {
   });
 
   it("should generate the hld-lifecycle.yaml if one does not exist", async () => {
-    const expectedFilePath = `${targetDirectory}/hld-lifecycle.yaml`;
+    const expectedFilePath = `${targetDirectory}/${PROJECT_PIPELINE_FILENAME}`;
 
     generateHldLifecyclePipelineYaml(targetDirectory);
     expect(writeSpy).toBeCalledWith(

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -15,6 +15,7 @@ import os from "os";
 import path from "path";
 import shelljs from "shelljs";
 import uuid from "uuid/v4";
+import { SERVICE_PIPELINE_FILENAME } from "../lib/constants";
 import { disableVerboseLogging, enableVerboseLogging, logger } from "../logger";
 import {
   createTestHldAzurePipelinesYaml,
@@ -287,10 +288,7 @@ describe("starterAzurePipelines", () => {
     const serializedYaml = yaml.safeDump(starter, {
       lineWidth: Number.MAX_SAFE_INTEGER
     });
-    const pipelinesPath = path.join(
-      randomDirPath,
-      "build-update-hld-pipeline.yaml"
-    );
+    const pipelinesPath = path.join(randomDirPath, SERVICE_PIPELINE_FILENAME);
     fs.writeFileSync(pipelinesPath, serializedYaml);
     const deserializedYaml = yaml.safeLoad(
       fs.readFileSync(pipelinesPath, "utf8")
@@ -340,7 +338,7 @@ describe("starterAzurePipelines", () => {
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
         fs.readFileSync(
-          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          path.join(servicePath, SERVICE_PIPELINE_FILENAME),
           "utf8"
         )
       );
@@ -376,7 +374,7 @@ describe("starterAzurePipelines", () => {
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
         fs.readFileSync(
-          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          path.join(servicePath, SERVICE_PIPELINE_FILENAME),
           "utf8"
         )
       );
@@ -423,7 +421,7 @@ describe("starterAzurePipelines", () => {
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
         fs.readFileSync(
-          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          path.join(servicePath, SERVICE_PIPELINE_FILENAME),
           "utf8"
         )
       );

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -29,7 +29,7 @@ import {
   generateGitIgnoreFile,
   generateHldAzurePipelinesYaml,
   generateHldLifecyclePipelineYaml,
-  generateStarterAzurePipelinesYaml,
+  generateServiceBuildAndUpdatePipelineYaml,
   starterAzurePipelines
 } from "./fileutils";
 
@@ -287,7 +287,10 @@ describe("starterAzurePipelines", () => {
     const serializedYaml = yaml.safeDump(starter, {
       lineWidth: Number.MAX_SAFE_INTEGER
     });
-    const pipelinesPath = path.join(randomDirPath, "azure-pipelines.yaml");
+    const pipelinesPath = path.join(
+      randomDirPath,
+      "build-update-hld-pipeline.yaml"
+    );
     fs.writeFileSync(pipelinesPath, serializedYaml);
     const deserializedYaml = yaml.safeLoad(
       fs.readFileSync(pipelinesPath, "utf8")
@@ -317,7 +320,7 @@ describe("starterAzurePipelines", () => {
     }
   });
 
-  test("that all services receive an azure-pipelines.yaml and the correct paths have been inserted", async () => {
+  test("that all services receive an build-update-hld-pipeline.yaml and the correct paths have been inserted", async () => {
     // Create service directories
     const servicePaths = ["a", "b", "c"].map(serviceDir => {
       const servicePath = path.join(randomDirPath, "packages", serviceDir);
@@ -326,14 +329,20 @@ describe("starterAzurePipelines", () => {
     });
 
     for (const servicePath of servicePaths) {
-      await generateStarterAzurePipelinesYaml(randomDirPath, servicePath);
+      await generateServiceBuildAndUpdatePipelineYaml(
+        randomDirPath,
+        servicePath
+      );
 
       // file should exist
       expect(fs.existsSync(servicePath)).toBe(true);
 
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
-        fs.readFileSync(path.join(servicePath, "azure-pipelines.yaml"), "utf8")
+        fs.readFileSync(
+          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          "utf8"
+        )
       );
       const hasCorrectIncludes = azureYaml.trigger!.paths!.include!.includes(
         "./" + path.relative(randomDirPath, servicePath)
@@ -342,7 +351,7 @@ describe("starterAzurePipelines", () => {
     }
   });
 
-  test("that all services receive an azure-pipelines.yaml with the correct paths and single variable group have been inserted", async () => {
+  test("that all services receive an build-update-hld-pipeline.yaml with the correct paths and single variable group have been inserted", async () => {
     // Create service directories
     const servicePaths = ["a", "b", "c"].map(serviceDir => {
       const servicePath = path.join(randomDirPath, "packages", serviceDir);
@@ -353,16 +362,23 @@ describe("starterAzurePipelines", () => {
     const variableGroups = [uuid()];
 
     for (const servicePath of servicePaths) {
-      await generateStarterAzurePipelinesYaml(randomDirPath, servicePath, {
-        variableGroups
-      });
+      await generateServiceBuildAndUpdatePipelineYaml(
+        randomDirPath,
+        servicePath,
+        {
+          variableGroups
+        }
+      );
 
       // file should exist
       expect(fs.existsSync(servicePath)).toBe(true);
 
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
-        fs.readFileSync(path.join(servicePath, "azure-pipelines.yaml"), "utf8")
+        fs.readFileSync(
+          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          "utf8"
+        )
       );
 
       const hasCorrectIncludes = azureYaml.trigger!.paths!.include!.includes(
@@ -380,7 +396,7 @@ describe("starterAzurePipelines", () => {
     }
   });
 
-  test("that all services receive an azure-pipelines.yaml with the correct paths and two variable group have been inserted", async () => {
+  test("that all services receive an build-update-hld-pipeline.yaml with the correct paths and two variable group have been inserted", async () => {
     // Create service directories
     const servicePaths = ["a", "b", "c"].map(serviceDir => {
       const servicePath = path.join(randomDirPath, "packages", serviceDir);
@@ -393,16 +409,23 @@ describe("starterAzurePipelines", () => {
     const variableGroups = [uuid(), uuid()];
 
     for (const servicePath of servicePaths) {
-      await generateStarterAzurePipelinesYaml(randomDirPath, servicePath, {
-        variableGroups
-      });
+      await generateServiceBuildAndUpdatePipelineYaml(
+        randomDirPath,
+        servicePath,
+        {
+          variableGroups
+        }
+      );
 
       // file should exist
       expect(fs.existsSync(servicePath)).toBe(true);
 
       // pipeline triggers should include the relative path to the service
       const azureYaml: IAzurePipelinesYaml = yaml.safeLoad(
-        fs.readFileSync(path.join(servicePath, "azure-pipelines.yaml"), "utf8")
+        fs.readFileSync(
+          path.join(servicePath, "build-update-hld-pipeline.yaml"),
+          "utf8"
+        )
       );
 
       const hasCorrectIncludes = azureYaml.trigger!.paths!.include!.includes(

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -16,6 +16,7 @@ import path from "path";
 import shelljs from "shelljs";
 import uuid from "uuid/v4";
 import {
+  HLD_PIPELINE_FILENAME,
   PROJECT_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME
 } from "../lib/constants";
@@ -100,7 +101,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   it("should not do anything if file exist", async () => {
     const mockFsOptions = {
-      [`${targetDirectory}/manifest-generation.yaml`]: "existing pipeline"
+      [`${targetDirectory}/${HLD_PIPELINE_FILENAME}`]: "existing pipeline"
     };
     mockFs(mockFsOptions);
 
@@ -110,7 +111,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   it("should generate the file if one does not exist", async () => {
     const absTargetPath = path.resolve(targetDirectory);
-    const expectedFilePath = `${absTargetPath}/manifest-generation.yaml`;
+    const expectedFilePath = `${absTargetPath}/${HLD_PIPELINE_FILENAME}`;
 
     generateHldAzurePipelinesYaml(targetDirectory);
     expect(writeSpy).toBeCalledWith(

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -283,10 +283,12 @@ describe("serviceBuildUpdatePipeline", () => {
   test("that the value of the file is the same after (de)serialization", async () => {
     const serviceName = "mycoolservice";
     const servicePath = "./mycoolservice";
+    const ringBranches = ["master", "qa", "test"];
     const variableGroups = ["foo", "bar"];
     const starter = await serviceBuildAndUpdatePipeline(
       serviceName,
       servicePath,
+      ringBranches,
       variableGroups
     );
     const serializedYaml = yaml.safeDump(starter, {
@@ -327,11 +329,13 @@ describe("serviceBuildUpdatePipeline", () => {
       }
     );
 
+    const ringBranches = ["master", "qa", "test"];
     const variableGroups = [uuid(), uuid()];
 
     for (const serviceReference of serviceReferences) {
       await generateServiceBuildAndUpdatePipelineYaml(
         randomDirPath,
+        ringBranches,
         serviceReference.serviceName,
         serviceReference.servicePath,
         variableGroups

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -16,8 +16,8 @@ import path from "path";
 import shelljs from "shelljs";
 import uuid from "uuid/v4";
 import {
-  HLD_PIPELINE_FILENAME,
   PROJECT_PIPELINE_FILENAME,
+  RENDER_HLD_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
   VM_IMAGE
 } from "../lib/constants";
@@ -162,7 +162,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   it("should not do anything if file exist", async () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${HLD_PIPELINE_FILENAME}`]: "existing pipeline"
+      [`${targetDirectory}/${RENDER_HLD_PIPELINE_FILENAME}`]: "existing pipeline"
     };
     mockFs(mockFsOptions);
 
@@ -172,7 +172,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   it("should generate the file if one does not exist", async () => {
     const absTargetPath = path.resolve(targetDirectory);
-    const expectedFilePath = `${absTargetPath}/${HLD_PIPELINE_FILENAME}`;
+    const expectedFilePath = `${absTargetPath}/${RENDER_HLD_PIPELINE_FILENAME}`;
 
     generateHldAzurePipelinesYaml(targetDirectory);
     expect(writeSpy).toBeCalledWith(

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { promisify } from "util";
 import { logger } from "../logger";
 import { IAzurePipelinesYaml, IMaintainersFile, IUser } from "../types";
+import { SERVICE_PIPELINE_FILENAME } from "../lib/constants";
 
 // Helper to concat list of script commands to a multi line string
 const generateYamlScript = (lines: string[]): string => lines.join("\n");
@@ -23,7 +24,7 @@ export const generateServiceBuildAndUpdatePipelineYaml = async (
 ) => {
   const absProjectRoot = path.resolve(projectRoot);
   const absServicePath = path.resolve(servicePath);
-  const pipelineFilename = `build-update-hld-pipeline.yaml`;
+  const pipelineFilename = SERVICE_PIPELINE_FILENAME;
 
   logger.info(`Generating starter ${pipelineFilename} in ${absServicePath}`);
 
@@ -312,7 +313,7 @@ export const starterAzurePipelines = async (opts: {
     const spkServiceBuildPipelineCmd =
       "spk service install-build-pipeline " + packagesOption + serviceName;
     logger.info(
-      `Generated build-update-hld-pipeline.yaml for service in path '${relPath}'. Commit and push this file to master before attempting to deploy via the command '${spkServiceBuildPipelineCmd}'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
+      `Generated ${SERVICE_PIPELINE_FILENAME} for service in path '${relPath}'. Commit and push this file to master before attempting to deploy via the command '${spkServiceBuildPipelineCmd}'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
     );
   }
 

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -3,7 +3,7 @@ import yaml from "js-yaml";
 import path from "path";
 import { promisify } from "util";
 import {
-  HLD_PIPELINE_FILENAME,
+  RENDER_HLD_PIPELINE_FILENAME,
   PROJECT_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
   VM_IMAGE
@@ -83,7 +83,7 @@ export const serviceBuildAndUpdatePipeline = (
     : "./" + relServicePath;
 
   // tslint:disable: object-literal-sort-keys
-  const piplineYaml: IAzurePipelinesYaml = {
+  const pipelineYaml: IAzurePipelinesYaml = {
     trigger: {
       branches: { include: ringBranches },
       paths: { include: [relativeServicePathFormatted] } // Only building for a single service's path.
@@ -261,7 +261,7 @@ export const serviceBuildAndUpdatePipeline = (
     `Generated ${SERVICE_PIPELINE_FILENAME} for service in path '${relativeServicePathFormatted}'. Commit and push this file to master before attempting to deploy via the command '${spkServiceBuildPipelineCmd}'; before running the pipeline ensure the following environment variables are available to your project variable groups: ${requiredPipelineVariables}`
   );
 
-  return piplineYaml;
+  return pipelineYaml;
 };
 
 /**
@@ -275,19 +275,19 @@ export const generateHldAzurePipelinesYaml = (targetDirectory: string) => {
 
   const azurePipelinesYamlPath = path.join(
     absTargetPath,
-    HLD_PIPELINE_FILENAME
+    RENDER_HLD_PIPELINE_FILENAME
   );
 
   if (fs.existsSync(azurePipelinesYamlPath)) {
     logger.warn(
-      `Existing ${HLD_PIPELINE_FILENAME} found at ${azurePipelinesYamlPath}, skipping generation.`
+      `Existing ${RENDER_HLD_PIPELINE_FILENAME} found at ${azurePipelinesYamlPath}, skipping generation.`
     );
 
     return;
   }
   const hldYaml = manifestGenerationPipelineYaml();
   logger.info(
-    `Writing ${HLD_PIPELINE_FILENAME} file to ${azurePipelinesYamlPath}`
+    `Writing ${RENDER_HLD_PIPELINE_FILENAME} file to ${azurePipelinesYamlPath}`
   );
 
   const requiredPipelineVariables = [
@@ -296,7 +296,7 @@ export const generateHldAzurePipelinesYaml = (targetDirectory: string) => {
   ].join(", ");
 
   logger.info(
-    `Generated ${HLD_PIPELINE_FILENAME}. Commit and push this file to master before attempting to deploy via the command 'spk hld install-manifest-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
+    `Generated ${RENDER_HLD_PIPELINE_FILENAME}. Commit and push this file to master before attempting to deploy via the command 'spk hld install-manifest-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
   );
 
   fs.writeFileSync(azurePipelinesYamlPath, hldYaml, "utf8");
@@ -321,7 +321,7 @@ export const generateDefaultHldComponentYaml = (targetDirectory: string) => {
 
   const componentYaml = defaultComponentYaml();
   logger.info(
-    `Writing ${HLD_PIPELINE_FILENAME} file to ${fabrikateComponentPath}`
+    `Writing ${RENDER_HLD_PIPELINE_FILENAME} file to ${fabrikateComponentPath}`
   );
 
   fs.writeFileSync(fabrikateComponentPath, componentYaml, "utf8");

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -1,10 +1,9 @@
 import fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
-import { promisify } from "util";
 import {
-  RENDER_HLD_PIPELINE_FILENAME,
   PROJECT_PIPELINE_FILENAME,
+  RENDER_HLD_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
   VM_IMAGE
 } from "../lib/constants";

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -2,9 +2,12 @@ import fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
 import { promisify } from "util";
+import {
+  PROJECT_PIPELINE_FILENAME,
+  SERVICE_PIPELINE_FILENAME
+} from "../lib/constants";
 import { logger } from "../logger";
 import { IAzurePipelinesYaml, IMaintainersFile, IUser } from "../types";
-import { SERVICE_PIPELINE_FILENAME } from "../lib/constants";
 
 // Helper to concat list of script commands to a multi line string
 const generateYamlScript = (lines: string[]): string => lines.join("\n");
@@ -503,21 +506,26 @@ const manifestGenerationPipelineYaml = () => {
  */
 export const generateHldLifecyclePipelineYaml = async (projectRoot: string) => {
   logger.info(
-    `Generating hld lifecycle pipeline hld-lifecycle.yaml in ${projectRoot}`
+    `Generating hld lifecycle pipeline ${PROJECT_PIPELINE_FILENAME} in ${projectRoot}`
   );
 
-  const azurePipelinesYamlPath = path.join(projectRoot, "hld-lifecycle.yaml");
+  const azurePipelinesYamlPath = path.join(
+    projectRoot,
+    PROJECT_PIPELINE_FILENAME
+  );
 
   if (fs.existsSync(azurePipelinesYamlPath)) {
     logger.warn(
-      `Existing hld-lifecycle.yaml found at ${azurePipelinesYamlPath}, skipping generation`
+      `Existing ${PROJECT_PIPELINE_FILENAME} found at ${azurePipelinesYamlPath}, skipping generation`
     );
 
     return;
   }
 
   const lifecycleYaml = hldLifecyclePipelineYaml();
-  logger.info(`Writing hld-lifecycle.yaml file to ${azurePipelinesYamlPath}`);
+  logger.info(
+    `Writing ${PROJECT_PIPELINE_FILENAME} file to ${azurePipelinesYamlPath}`
+  );
   fs.writeFileSync(azurePipelinesYamlPath, lifecycleYaml, "utf8");
 
   const requiredPipelineVariables = [
@@ -526,7 +534,7 @@ export const generateHldLifecyclePipelineYaml = async (projectRoot: string) => {
   ].join(", ");
 
   logger.info(
-    `Generated hld-lifecycle.yaml. Commit and push this file to master before attempting to deploy via the command 'spk project install-lifecycle-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
+    `Generated ${PROJECT_PIPELINE_FILENAME}. Commit and push this file to master before attempting to deploy via the command 'spk project install-lifecycle-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
   );
 };
 

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -19,12 +19,14 @@ const generateYamlScript = (lines: string[]): string => lines.join("\n");
  * One pipeline should exist for each service.
  *
  * @param projectRoot Full path to the root of the project (where the bedrock.yaml file exists)
+ * @param ringBranches Branches to trigger builds off of. Should be all the defined rings for this service.
  * @param serviceName
  * @param servicePath Full path to service direcory
  * @param variableGroups Azure DevOps variable group names
  */
 export const generateServiceBuildAndUpdatePipelineYaml = async (
   projectRoot: string,
+  ringBranches: string[],
   serviceName: string,
   servicePath: string,
   variableGroups: string[]
@@ -48,6 +50,7 @@ export const generateServiceBuildAndUpdatePipelineYaml = async (
     const starterYaml = await serviceBuildAndUpdatePipeline(
       serviceName,
       path.relative(absProjectRoot, absServicePath),
+      ringBranches,
       variableGroups
     );
     // Write
@@ -65,11 +68,13 @@ export const generateServiceBuildAndUpdatePipelineYaml = async (
  *
  * @param serviceName
  * @param relServicePath
+ * @param ringBranches
  * @param variableGroups
  */
 export const serviceBuildAndUpdatePipeline = async (
   serviceName: string,
   relServicePath: string,
+  ringBranches: string[],
   variableGroups?: string[]
 ): Promise<IAzurePipelinesYaml> => {
   const relativeServicePathFormatted = relServicePath.startsWith("./")
@@ -79,7 +84,7 @@ export const serviceBuildAndUpdatePipeline = async (
   // tslint:disable: object-literal-sort-keys
   const starter: IAzurePipelinesYaml = {
     trigger: {
-      branches: { include: ["master"] }, // Only building for master branch
+      branches: { include: ringBranches },
       paths: { include: [relativeServicePathFormatted] } // Only building for a single service's path.
     },
     variables: [...(variableGroups ?? []).map(group => ({ group }))],

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -3,6 +3,7 @@ import yaml from "js-yaml";
 import path from "path";
 import { promisify } from "util";
 import {
+  HLD_PIPELINE_FILENAME,
   PROJECT_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME
 } from "../lib/constants";
@@ -334,19 +335,19 @@ export const generateHldAzurePipelinesYaml = (targetDirectory: string) => {
 
   const azurePipelinesYamlPath = path.join(
     absTargetPath,
-    "manifest-generation.yaml"
+    HLD_PIPELINE_FILENAME
   );
 
   if (fs.existsSync(azurePipelinesYamlPath)) {
     logger.warn(
-      `Existing manifest-generation.yaml found at ${azurePipelinesYamlPath}, skipping generation`
+      `Existing ${HLD_PIPELINE_FILENAME} found at ${azurePipelinesYamlPath}, skipping generation`
     );
 
     return;
   }
   const hldYaml = manifestGenerationPipelineYaml();
   logger.info(
-    `Writing manifest-generation.yaml file to ${azurePipelinesYamlPath}`
+    `Writing ${HLD_PIPELINE_FILENAME} file to ${azurePipelinesYamlPath}`
   );
 
   const requiredPipelineVariables = [
@@ -355,7 +356,7 @@ export const generateHldAzurePipelinesYaml = (targetDirectory: string) => {
   ].join(", ");
 
   logger.info(
-    `Generated manifest-generation.yaml. Commit and push this file to master before attempting to deploy via the command 'spk hld install-manifest-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
+    `Generated ${HLD_PIPELINE_FILENAME}. Commit and push this file to master before attempting to deploy via the command 'spk hld install-manifest-pipeline'; before running the pipeline ensure the following environment variables are available to your pipeline: ${requiredPipelineVariables}`
   );
 
   fs.writeFileSync(azurePipelinesYamlPath, hldYaml, "utf8");
@@ -380,7 +381,7 @@ export const generateDefaultHldComponentYaml = (targetDirectory: string) => {
 
   const componentYaml = defaultComponentYaml();
   logger.info(
-    `Writing manifest-generation.yaml file to ${fabrikateComponentPath}`
+    `Writing ${HLD_PIPELINE_FILENAME} file to ${fabrikateComponentPath}`
   );
 
   fs.writeFileSync(fabrikateComponentPath, componentYaml, "utf8");

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -10,6 +10,182 @@ import {
 // Helper to concat list of script commands to a multi line string
 const generateYamlScript = (lines: string[]): string => lines.join("\n");
 
+export const createTestServiceBuildAndUpdatePipelineYaml = (
+  asString = true,
+  serviceName: string = "my-service",
+  relativeServicePathFormatted: string = "./my-service",
+  ringBranches: string[] = ["master", "qa", "test"],
+  variableGroups: string[] = []
+): IAzurePipelinesYaml | string => {
+  // tslint:disable: object-literal-sort-keys
+  const data: IAzurePipelinesYaml = {
+    trigger: {
+      branches: { include: ringBranches },
+      paths: { include: [relativeServicePathFormatted] } // Only building for a single service's path.
+    },
+    variables: [...(variableGroups ?? []).map(group => ({ group }))],
+    stages: [
+      {
+        // Build stage
+        stage: "build",
+        jobs: [
+          {
+            job: "run_build_push_acr",
+            pool: {
+              vmImage: VM_IMAGE
+            },
+            steps: [
+              {
+                script: generateYamlScript([
+                  `echo "az login --service-principal --username $(SP_APP_ID) --password $(SP_PASS) --tenant $(SP_TENANT)"`,
+                  `az login --service-principal --username "$(SP_APP_ID)" --password "$(SP_PASS)" --tenant "$(SP_TENANT)"`
+                ]),
+                displayName: "Azure Login"
+              },
+              {
+                script: generateYamlScript([
+                  `export BUILD_REPO_NAME=$(echo $(Build.Repository.Name)-${serviceName} | tr '[:upper:]' '[:lower:]')`,
+                  `tag_name="$BUILD_REPO_NAME:$(Build.SourceBranchName)-$(Build.BuildNumber)"`,
+                  `commitId=$(Build.SourceVersion)`,
+                  `commitId=$(echo "\${commitId:0:7}")`,
+                  `service=$(Build.Repository.Name)`,
+                  `service=\${service##*/}`,
+                  `echo "Downloading SPK"`,
+                  `curl https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh > build.sh`,
+                  `chmod +x build.sh`,
+                  `. ./build.sh --source-only`,
+                  `get_spk_version`,
+                  `download_spk`,
+                  `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p1 $(Build.BuildId) --image-tag $tag_name --commit-id $commitId --service $service`
+                ]),
+                displayName:
+                  "If configured, update Spektate storage with build pipeline",
+                condition:
+                  "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))"
+              },
+              {
+                script: generateYamlScript([
+                  `export BUILD_REPO_NAME=$(echo $(Build.Repository.Name)-${serviceName} | tr '[:upper:]' '[:lower:]')`,
+                  `echo "Image Name: $BUILD_REPO_NAME"`,
+                  `cd ${relativeServicePathFormatted}`,
+                  `echo "az acr build -r $(ACR_NAME) --image $BUILD_REPO_NAME:$(Build.SourceBranchName)-$(Build.BuildNumber) ."`,
+                  `az acr build -r $(ACR_NAME) --image $BUILD_REPO_NAME:$(Build.SourceBranchName)-$(Build.BuildNumber) .`
+                ]),
+                displayName: "ACR Build and Publish"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        // Update HLD Stage
+        stage: "hld_update",
+        dependsOn: "build",
+        condition:
+          "and(succeeded('build'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/DEPLOY/'),eq(variables['Build.SourceBranchName'],'master')))",
+        jobs: [
+          {
+            job: "update_image_tag",
+            pool: {
+              vmImage: VM_IMAGE
+            },
+            steps: [
+              {
+                script: generateYamlScript([
+                  `# Download build.sh`,
+                  `curl $BEDROCK_BUILD_SCRIPT > build.sh`,
+                  `chmod +x ./build.sh`
+                ]),
+                displayName: "Download bedrock bash scripts",
+                env: {
+                  BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)"
+                }
+              },
+              {
+                script: generateYamlScript([
+                  `export SERVICE_NAME_LOWER=$(echo ${serviceName} | tr '[:upper:]' '[:lower:]')`,
+                  `export BUILD_REPO_NAME=$(echo $(Build.Repository.Name)-$SERVICE_NAME_LOWER | tr '[:upper:]' '[:lower:]')`,
+                  `export BRANCH_NAME=DEPLOY/$BUILD_REPO_NAME-$(Build.SourceBranchName)-$(Build.BuildNumber)`,
+                  `# --- From https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/release.sh`,
+                  `. build.sh --source-only`,
+                  ``,
+                  `# Initialization`,
+                  `verify_access_token`,
+                  `init`,
+                  `helm init`,
+                  ``,
+                  `# Fabrikate`,
+                  `get_fab_version`,
+                  `download_fab`,
+                  ``,
+                  `# Clone HLD repo`,
+                  `git_connect`,
+                  `# --- End Script`,
+                  ``,
+                  `# Update HLD`,
+                  `git checkout -b "$BRANCH_NAME"`,
+                  `../fab/fab set --subcomponent $SERVICE_NAME_LOWER image.tag=$(Build.SourceBranchName)-$(Build.BuildNumber)`,
+                  `echo "GIT STATUS"`,
+                  `git status`,
+                  `echo "GIT ADD (git add -A)"`,
+                  `git add -A`,
+                  ``,
+                  `# Set git identity`,
+                  `git config user.email "admin@azuredevops.com"`,
+                  `git config user.name "Automated Account"`,
+                  ``,
+                  `# Commit changes`,
+                  `echo "GIT COMMIT"`,
+                  `git commit -m "Updating $SERVICE_NAME_LOWER image tag to $(Build.SourceBranchName)-$(Build.BuildNumber)."`,
+                  ``,
+                  `# Git Push`,
+                  `git_push`,
+                  ``,
+                  `# Open PR via az repo cli`,
+                  `echo 'az extension add --name azure-devops'`,
+                  `az extension add --name azure-devops`,
+                  ``,
+                  `echo 'az repos pr create --description "Updating $SERVICE_NAME_LOWER to $(Build.SourceBranchName)-$(Build.BuildNumber)."'`,
+                  `response=$(az repos pr create --description "Updating $SERVICE_NAME_LOWER to $(Build.SourceBranchName)-$(Build.BuildNumber).")`,
+                  `pr_id=$(echo $response | jq -r '.pullRequestId')`,
+                  ``,
+                  ``,
+                  `# Update introspection storage with this information, if applicable`,
+                  `if [ -z "$(INTROSPECTION_ACCOUNT_NAME)" -o -z "$(INTROSPECTION_ACCOUNT_KEY)" -o -z "$(INTROSPECTION_TABLE_NAME)" -o -z "$(INTROSPECTION_PARTITION_KEY)" ]; then`,
+                  `echo "Introspection variables are not defined. Skipping..."`,
+                  `else`,
+                  `latest_commit=$(git rev-parse --short HEAD)`,
+                  `tag_name="$BUILD_REPO_NAME:$(Build.SourceBranchName)-$(Build.BuildNumber)"`,
+                  `echo "Downloading SPK"`,
+                  `curl https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh > build.sh`,
+                  `chmod +x build.sh`,
+                  `. ./build.sh --source-only`,
+                  `get_spk_version`,
+                  `download_spk`,
+                  `./spk/spk deployment create  -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p2 $(Build.BuildId) --hld-commit-id $latest_commit --env $BRANCH_NAME --image-tag $tag_name --pr $pr_id`,
+                  `fi`
+                ]),
+                displayName:
+                  "Download Fabrikate, Update HLD, Push changes, Open PR, and if configured, push to Spektate storage",
+                env: {
+                  ACCESS_TOKEN_SECRET: "$(PAT)",
+                  AZURE_DEVOPS_EXT_PAT: "$(PAT)",
+                  REPO: "$(HLD_REPO)"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+  // tslint:enable: object-literal-sort-keys
+
+  return asString
+    ? yaml.safeDump(data, { lineWidth: Number.MAX_SAFE_INTEGER })
+    : data;
+};
+
 export const createTestMaintainersYaml = (
   asString = true
 ): IMaintainersFile | string => {

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -1,4 +1,5 @@
 import yaml from "js-yaml";
+import { VM_IMAGE } from "../lib/constants";
 import {
   IAzurePipelinesYaml,
   IBedrockFile,
@@ -96,7 +97,7 @@ export const createTestHldLifecyclePipelineYaml = (
     },
     variables: [],
     pool: {
-      vmImage: "ubuntu-latest"
+      vmImage: VM_IMAGE
     },
     steps: [
       {
@@ -187,7 +188,7 @@ export const createTestHldAzurePipelinesYaml = (
       }
     },
     pool: {
-      vmImage: "Ubuntu-16.04"
+      vmImage: VM_IMAGE
     },
     steps: [
       {

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -12,7 +12,7 @@ validate_directory () {
     #Get first arg then shift over to get array arg
     actual_files=( $(find $1 -maxdepth 1 -type f) ); shift
     # actual_files=("$1"/*); shift
-    local expected_files=( "$@" ) #"${2[@]}" #("build-update-hld-pipeline.yaml" "Dockerfile" )
+    local expected_files=( "$@" ) #"${2[@]}" #("build-update-hld.yaml" "Dockerfile" )
 
     # Get the base filenames for comparison
     actual_base_files=()
@@ -52,7 +52,7 @@ validate_directory () {
 
 validate_service () {
     echo "Checking directory `$1`"
-    local files=( ".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
+    local files=( ".gitignore" "build-update-hld.yaml" "Dockerfile" )
     for i in "${files[@]}"
     do
         :

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -12,7 +12,7 @@ validate_directory () {
     #Get first arg then shift over to get array arg
     actual_files=( $(find $1 -maxdepth 1 -type f) ); shift
     # actual_files=("$1"/*); shift
-    local expected_files=( "$@" ) #"${2[@]}" #("azure-pipelines.yaml" "Dockerfile" )
+    local expected_files=( "$@" ) #"${2[@]}" #("build-update-hld-pipeline.yaml" "Dockerfile" )
 
     # Get the base filenames for comparison
     actual_base_files=()
@@ -52,7 +52,7 @@ validate_directory () {
 
 validate_service () {
     echo "Checking directory `$1`"
-    local files=( ".gitignore" "azure-pipelines.yaml" "Dockerfile" )
+    local files=( ".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
     for i in "${files[@]}"
     do
         :

--- a/tests/introspection-validations.sh
+++ b/tests/introspection-validations.sh
@@ -196,7 +196,7 @@ variable_group_variable_create $variable_group_id $AZDO_ORG_URL $AZDO_PROJECT "T
 
 spk service create $FrontEnd -d $services_dir >> $TEST_WORKSPACE/log.txt
 directory_to_check="$services_full_dir/$FrontEnd"
-file_we_expect=(".gitignore" "azure-pipelines.yaml" "Dockerfile" )
+file_we_expect=(".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
 validate_directory $directory_to_check "${file_we_expect[@]}"
 
 spk service create $BackEnd -d $services_dir >> $TEST_WORKSPACE/log.txt

--- a/tests/introspection-validations.sh
+++ b/tests/introspection-validations.sh
@@ -196,7 +196,7 @@ variable_group_variable_create $variable_group_id $AZDO_ORG_URL $AZDO_PROJECT "T
 
 spk service create $FrontEnd -d $services_dir >> $TEST_WORKSPACE/log.txt
 directory_to_check="$services_full_dir/$FrontEnd"
-file_we_expect=(".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
+file_we_expect=(".gitignore" "build-update-hld.yaml" "Dockerfile" )
 validate_directory $directory_to_check "${file_we_expect[@]}"
 
 spk service create $BackEnd -d $services_dir >> $TEST_WORKSPACE/log.txt

--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -158,7 +158,7 @@ variable_group_exists $AZDO_ORG_URL $AZDO_PROJECT $vg_name "fail"
 
 spk service create $FrontEnd -d $services_dir >> $TEST_WORKSPACE/log.txt
 directory_to_check="$services_full_dir/$FrontEnd"
-file_we_expect=(".gitignore" "azure-pipelines.yaml" "Dockerfile" )
+file_we_expect=(".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
 validate_directory $directory_to_check "${file_we_expect[@]}"
 
 spk service create $BackEnd -d $services_dir >> $TEST_WORKSPACE/log.txt

--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -158,7 +158,7 @@ variable_group_exists $AZDO_ORG_URL $AZDO_PROJECT $vg_name "fail"
 
 spk service create $FrontEnd -d $services_dir >> $TEST_WORKSPACE/log.txt
 directory_to_check="$services_full_dir/$FrontEnd"
-file_we_expect=(".gitignore" "build-update-hld-pipeline.yaml" "Dockerfile" )
+file_we_expect=(".gitignore" "build-update-hld.yaml" "Dockerfile" )
 validate_directory $directory_to_check "${file_we_expect[@]}"
 
 spk service create $BackEnd -d $services_dir >> $TEST_WORKSPACE/log.txt


### PR DESCRIPTION
Closes https://github.com/microsoft/bedrock/issues/907 and https://github.com/microsoft/bedrock/issues/801

Also moving pipeline definition file names into constants file.

Should work in conjunction with https://github.com/microsoft/bedrock/issues/904 to ensure image tags have proper names if `spk service create .` is called.