### PR TITLE
Generated pipelines now fail on any non-zero exit

### DIFF
--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -37,6 +37,7 @@ import {
   generateHldAzurePipelinesYaml,
   generateHldLifecyclePipelineYaml,
   generateServiceBuildAndUpdatePipelineYaml,
+  generateYamlScript,
   serviceBuildAndUpdatePipeline
 } from "./fileutils";
 
@@ -425,23 +426,30 @@ describe("serviceBuildUpdatePipeline", () => {
       );
       expect(hasCorrectIncludes).toBe(true);
 
-      let hasCorrecctVariableGroup1: boolean = false;
-      let hasCorrecctVariableGroup2: boolean = false;
+      let hasCorrectVariableGroup1: boolean = false;
+      let hasCorrectVariableGroup2: boolean = false;
       for (const [key, value] of Object.entries(azureYaml.variables!)) {
         const item: { group: string } = value as { group: string };
 
         if (item.group === variableGroups[0]) {
-          hasCorrecctVariableGroup1 = true;
+          hasCorrectVariableGroup1 = true;
         }
 
         if (item.group === variableGroups[1]) {
-          hasCorrecctVariableGroup2 = true;
+          hasCorrectVariableGroup2 = true;
         }
       }
 
       expect(hasCorrectIncludes).toBe(true);
-      expect(hasCorrecctVariableGroup1).toBe(true);
-      expect(hasCorrecctVariableGroup2).toBe(true);
+      expect(hasCorrectVariableGroup1).toBe(true);
+      expect(hasCorrectVariableGroup2).toBe(true);
     }
+  });
+});
+
+describe("generateYamlScript", () => {
+  test("'set -e' is injected as the first line", async () => {
+    const generated = generateYamlScript(["foo", "bar", "baz"]);
+    expect(generated.startsWith("set -e\n")).toBe(true);
   });
 });

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -10,8 +10,14 @@ import {
 import { logger } from "../logger";
 import { IAzurePipelinesYaml, IMaintainersFile, IUser } from "../types";
 
-// Helper to concat list of script commands to a multi line string
-const generateYamlScript = (lines: string[]): string => lines.join("\n");
+/**
+ * Concatenates all lines into a single string and injects `set -e` to the top
+ * of it
+ *
+ * @param lines lines of script to execute
+ */
+export const generateYamlScript = (lines: string[]): string =>
+  ["set -e", ...lines].join("\n");
 
 /**
  * Creates the service multistage build and update image tag pipeline.
@@ -20,7 +26,7 @@ const generateYamlScript = (lines: string[]): string => lines.join("\n");
  * @param projectRoot Full path to the root of the project (where the bedrock.yaml file exists)
  * @param ringBranches Branches to trigger builds off of. Should be all the defined rings for this service.
  * @param serviceName
- * @param servicePath Full path to service direcory
+ * @param servicePath Full path to service directory
  * @param variableGroups Azure DevOps variable group names
  */
 export const generateServiceBuildAndUpdatePipelineYaml = (

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -1,14 +1,12 @@
 import yaml from "js-yaml";
 import { VM_IMAGE } from "../lib/constants";
+import { generateYamlScript } from "../lib/fileutils";
 import {
   IAzurePipelinesYaml,
   IBedrockFile,
   IHelmConfig,
   IMaintainersFile
 } from "../types";
-
-// Helper to concat list of script commands to a multi line string
-const generateYamlScript = (lines: string[]): string => lines.join("\n");
 
 export const createTestServiceBuildAndUpdatePipelineYaml = (
   asString = true,


### PR DESCRIPTION
- `generateYamlScript` now prepends outputted scripts with `set -e` to ensure
  that any executed commands exit with exit code 0.

partial fix https://github.com/microsoft/bedrock/issues/908