### PR TITLE
[REFACTOR] spk init command

### DIFF
--- a/src/commands/deployment/dashboard.test.ts
+++ b/src/commands/deployment/dashboard.test.ts
@@ -3,12 +3,12 @@ jest.mock("../../config");
 
 import { Config } from "../../config";
 import { exec } from "../../lib/shell";
+import { validatePrereqs } from "../../lib/validator";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
   logger
 } from "../../logger";
-import { validatePrereqs } from "../init";
 import {
   extractManifestRepositoryInformation,
   getEnvVars,

--- a/src/commands/deployment/dashboard.ts
+++ b/src/commands/deployment/dashboard.ts
@@ -4,8 +4,8 @@ import open = require("open");
 import { Config } from "../../config";
 import { getRepositoryName } from "../../lib/gitutils";
 import { exec } from "../../lib/shell";
+import { validatePrereqs } from "../../lib/validator";
 import { logger } from "../../logger";
-import { validatePrereqs } from "../init";
 
 export interface IIntrospectionManifest {
   githubUsername?: string;

--- a/src/commands/init.decorator.json
+++ b/src/commands/init.decorator.json
@@ -1,0 +1,11 @@
+{
+  "command": "init",
+  "alias": "i",
+  "description": "Initialize the spk tool for the first time.",
+  "options": [
+    {
+      "arg": "-f, --file <config-file-path>",
+      "description": "Path to the config file."
+    }
+  ]
+}

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,15 +1,9 @@
-import fs from "fs";
-import os from "os";
-import * as path from "path";
-import uuid from "uuid/v4";
-import {
-  Config,
-  defaultConfigFile,
-  loadConfiguration,
-  saveConfiguration
-} from "../config";
+import path from "path";
+import uuid from "uuid";
+import { saveConfiguration } from "../config";
+import { createTempDir } from "../lib/ioUtil";
 import { disableVerboseLogging, enableVerboseLogging, logger } from "../logger";
-import { validatePrereqs } from "./init";
+import { execute } from "./init";
 
 beforeAll(() => {
   enableVerboseLogging();
@@ -20,95 +14,45 @@ afterAll(() => {
 });
 
 const mockFileName = "src/commands/mocks/spk-config.yaml";
-describe("Initializing a project to use spk with a config file", () => {
-  test("init command basic file test", async () => {
-    // Create random directory to initialize
-    const randomTmpDir = path.join(os.tmpdir(), uuid());
-    fs.mkdirSync(randomTmpDir);
 
+describe("Test execute function", () => {
+  it("negative test: missing file value", async () => {
+    const exitFn = jest.fn();
+    await execute(
+      {
+        file: undefined
+      },
+      exitFn
+    );
+    expect(exitFn).toBeCalledTimes(1);
+    expect(exitFn.mock.calls).toEqual([[1]]);
+  });
+  it("negative test: invalid file value", async () => {
+    const exitFn = jest.fn();
+    await execute(
+      {
+        file: uuid()
+      },
+      exitFn
+    );
+    expect(exitFn).toBeCalledTimes(1);
+    expect(exitFn.mock.calls).toEqual([[1]]);
+  });
+  it("positive test", async () => {
     process.env.test_name = "my_storage_account";
     process.env.test_key = "my_storage_key";
+    const randomTmpDir = createTempDir();
     const filename = path.resolve(mockFileName);
     await saveConfiguration(filename, randomTmpDir);
-    loadConfiguration(path.join(randomTmpDir, "config.yaml"));
 
-    const config = Config();
-    expect(config.introspection!).toBeDefined();
-    expect(config.introspection!.azure!.account_name).toBe(
-      process.env.test_name
+    const exitFn = jest.fn();
+    await execute(
+      {
+        file: path.join(randomTmpDir, "config.yaml")
+      },
+      exitFn
     );
-    const key = await config.introspection!.azure!.key;
-    expect(key).toBe(process.env.test_key);
-    expect(config.introspection!.azure!.table_name!).toBe(
-      process.env.test_name + "+" + process.env.test_key
-    );
-    logger.info("Able to initialize a basic config file");
-  });
-});
-
-describe("Initializing a project a config file but no env vars", () => {
-  test("init command basic file without env vars", async () => {
-    const filename = path.resolve(mockFileName);
-    process.env.test_name = "";
-    process.env.test_key = "";
-    try {
-      loadConfiguration(filename);
-      // Make sure execution does not get here:
-      expect(true).toBeFalsy();
-    } catch (err) {
-      expect(err).toBeDefined();
-      logger.info(
-        "Error is being thrown on undefined env vars being referenced"
-      );
-    }
-  });
-});
-
-describe("Initializing a project with a non-existent file", () => {
-  test("Non-existent file test", async () => {
-    const filename = path.resolve("./spk-config-test.yaml");
-    try {
-      loadConfiguration(filename);
-      // Make sure execution does not get here:
-      expect(true).toBeFalsy();
-    } catch (e) {
-      expect(e.code).toBe("ENOENT");
-      logger.info("Error is being thrown on trying to use a non-existent file");
-    }
-  });
-});
-
-describe("Writing to default config location", () => {
-  test("Default config location exists", async () => {
-    try {
-      const filename = path.resolve(mockFileName);
-      process.env.test_name = "testStorageName";
-      process.env.test_key = "testStorageKey";
-      loadConfiguration(filename);
-
-      await saveConfiguration(filename);
-      loadConfiguration(defaultConfigFile());
-      expect(Config().azure_devops!).toBeDefined();
-    } catch (e) {
-      logger.error(e);
-      // Make sure execution does not get here:
-      expect(true).toBeFalsy();
-    }
-    logger.info("Able to write to default config location");
-  });
-});
-
-describe("Validating executable prerequisites in spk-config", () => {
-  test("Validate that exectuable boolean matches in spk-config", async () => {
-    // Iterate through an array of non-existent binaries to create a force fail. If fails, then test pass
-    const filename = path.resolve("src/commands/mocks/spk-config.yaml");
-    process.env.test_name = "my_storage_account";
-    process.env.test_key = "my_storage_key";
-    loadConfiguration(filename);
-    const fakeBinaries: string[] = ["foobar"];
-    await validatePrereqs(fakeBinaries, true);
-    expect(Config().infra!).toBeDefined();
-    expect(Config().infra!.checks!).toBeDefined();
-    expect(Config().infra!.checks!.foobar!).toBe(false);
+    expect(exitFn).toBeCalledTimes(1);
+    expect(exitFn.mock.calls).toEqual([[0]]);
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,16 @@ import os from "os";
 import path from "path";
 import shell from "shelljs";
 import uuid from "uuid/v4";
-import { Bedrock, updateVariableWithLocalEnv, write } from "./config";
+import {
+  Bedrock,
+  Config,
+  defaultConfigFile,
+  loadConfiguration,
+  saveConfiguration,
+  updateVariableWithLocalEnv,
+  write
+} from "./config";
+import { createTempDir } from "./lib/ioUtil";
 import { disableVerboseLogging, enableVerboseLogging } from "./logger";
 import { IBedrockFile } from "./types";
 
@@ -126,5 +135,76 @@ describe("Bedrock", () => {
     }
     expect(bedrockConfig).toBeFalsy();
     expect(error).toBeDefined();
+  });
+});
+
+const mockFileName = "src/commands/mocks/spk-config.yaml";
+
+describe("Initializing a project to use spk with a config file", () => {
+  test("init command basic file test", async () => {
+    // Create random directory to initialize
+    const randomTmpDir = createTempDir();
+    process.env.test_name = "my_storage_account";
+    process.env.test_key = "my_storage_key";
+    const filename = path.resolve(mockFileName);
+    await saveConfiguration(filename, randomTmpDir);
+    loadConfiguration(path.join(randomTmpDir, "config.yaml"));
+
+    const config = Config();
+    expect(config.introspection!).toBeDefined();
+    expect(config.introspection!.azure!.account_name).toBe(
+      process.env.test_name
+    );
+    const key = await config.introspection!.azure!.key;
+    expect(key).toBe(process.env.test_key);
+    expect(config.introspection!.azure!.table_name!).toBe(
+      process.env.test_name + "+" + process.env.test_key
+    );
+  });
+});
+
+describe("Initializing a project a config file but no env vars", () => {
+  test("init command basic file without env vars", async () => {
+    const filename = path.resolve(mockFileName);
+    process.env.test_name = "";
+    process.env.test_key = "";
+    try {
+      loadConfiguration(filename);
+      // Make sure execution does not get here:
+      expect(true).toBeFalsy();
+    } catch (err) {
+      expect(err).toBeDefined();
+    }
+  });
+});
+
+describe("Initializing a project with a non-existent file", () => {
+  test("Non-existent file test", async () => {
+    const filename = path.resolve("./spk-config-test.yaml");
+    try {
+      loadConfiguration(filename);
+      // Make sure execution does not get here:
+      expect(true).toBeFalsy();
+    } catch (e) {
+      expect(e.code).toBe("ENOENT");
+    }
+  });
+});
+
+describe("Writing to default config location", () => {
+  test("Default config location exists", async () => {
+    try {
+      const filename = path.resolve(mockFileName);
+      process.env.test_name = "testStorageName";
+      process.env.test_key = "testStorageKey";
+      loadConfiguration(filename);
+
+      await saveConfiguration(filename);
+      loadConfiguration(defaultConfigFile());
+      expect(Config().azure_devops!).toBeDefined();
+    } catch (e) {
+      // Make sure execution does not get here:
+      expect(true).toBeFalsy();
+    }
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,6 @@ import { logger } from "./logger";
 import {
   IAzurePipelinesYaml,
   IBedrockFile,
-  IBedrockFileInfo,
   IConfigYaml,
   IMaintainersFile
 } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { deploymentCommand } from "./commands/deployment";
 import { hldCommand } from "./commands/hld";
 import { infraCommand } from "./commands/infra";
 import { ingressCommand } from "./commands/ingress-route";
-import { initCommandDecorator } from "./commands/init";
+import { commandDecorator as initCommandDecorator } from "./commands/init";
 import { projectCommand } from "./commands/project";
 import { serviceCommand } from "./commands/service";
 import { variableGroupCommand } from "./commands/variable-group";

--- a/src/lib/validator.test.ts
+++ b/src/lib/validator.test.ts
@@ -1,9 +1,13 @@
+import path from "path";
+import { Config, loadConfiguration } from "../config";
 import {
   hasValue,
   isIntegerString,
   isPortNumberString,
-  validateForNonEmptyValue
+  validateForNonEmptyValue,
+  validatePrereqs
 } from "./validator";
+import mock from "mock-fs";
 
 describe("Tests on validator helper functions", () => {
   it("Test hasValue function", () => {
@@ -77,5 +81,44 @@ describe("Tests on validator helper functions", () => {
         })
       ).toBe("");
     });
+  });
+});
+
+const testvalidatePrereqs = (
+  global: boolean,
+  cmd: string,
+  expectedResult: boolean
+) => {
+  const filename = path.resolve("src/commands/mocks/spk-config.yaml");
+  process.env.test_name = "my_storage_account";
+  process.env.test_key = "my_storage_key";
+  loadConfiguration(filename);
+  const fakeBinaries: string[] = [cmd];
+  const result = validatePrereqs(fakeBinaries, global);
+
+  if (global) {
+    const config = Config();
+    expect(config.infra!).toBeDefined();
+    expect(config.infra!.checks).toBeDefined();
+    expect(config.infra!.checks![cmd]!).toBe(expectedResult);
+  } else {
+    expect(result).toBe(expectedResult);
+  }
+};
+
+describe("Validating executable prerequisites in spk-config", () => {
+  test("Validate that exectuable boolean matches in spk-config - global = true", () => {
+    // Iterate through an array of non-existent binaries to create a force fail. If fails, then test pass
+    testvalidatePrereqs(true, "foobar", false);
+  });
+  test("Validate that exectuable boolean matches in spk-config - global = false", () => {
+    // Iterate through an array of non-existent binaries to create a force fail. If fails, then test pass
+    testvalidatePrereqs(false, "foobar", false);
+  });
+  test("positive test - global = true", () => {
+    testvalidatePrereqs(true, "cd", true);
+  });
+  test("positive test - global = false", () => {
+    testvalidatePrereqs(false, "cd", true);
   });
 });

--- a/src/lib/validator.test.ts
+++ b/src/lib/validator.test.ts
@@ -7,7 +7,6 @@ import {
   validateForNonEmptyValue,
   validatePrereqs
 } from "./validator";
-import mock from "mock-fs";
 
 describe("Tests on validator helper functions", () => {
   it("Test hasValue function", () => {

--- a/src/lib/validator.test.ts
+++ b/src/lib/validator.test.ts
@@ -114,10 +114,4 @@ describe("Validating executable prerequisites in spk-config", () => {
     // Iterate through an array of non-existent binaries to create a force fail. If fails, then test pass
     testvalidatePrereqs(false, "foobar", false);
   });
-  test("positive test - global = true", () => {
-    testvalidatePrereqs(true, "cd", true);
-  });
-  test("positive test - global = false", () => {
-    testvalidatePrereqs(false, "cd", true);
-  });
 });

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -1,3 +1,7 @@
+import shelljs from "shelljs";
+import { Config } from "../config";
+import { logger } from "../logger";
+
 /**
  * Values to be validated
  */
@@ -55,4 +59,34 @@ export const validateForNonEmptyValue = (
   validValue: IValidationValue
 ): string => {
   return hasValue(validValue.value) ? "" : validValue.error;
+};
+
+/**
+ * Validates that prerequisites are installed
+ *
+ * @param executables Array of exectuables to check for in PATH
+ */
+export const validatePrereqs = (
+  executables: string[],
+  globalInit: boolean
+): boolean => {
+  const config = Config();
+  config.infra = config.infra || {};
+  config.infra.checks = config.infra.checks || {};
+
+  // Validate executables in PATH
+  for (const i of executables) {
+    if (!shelljs.which(i)) {
+      config.infra.checks[i] = false;
+      if (globalInit === true) {
+        logger.warn(i + " not installed.");
+      } else {
+        logger.error(":no_entry_sign: '" + i + "'" + " not installed");
+        return false;
+      }
+    } else {
+      config.infra.checks[i] = true;
+    }
+  }
+  return true;
 };


### PR DESCRIPTION
Related to https://github.com/microsoft/bedrock/issues/885

1. move command declaration to a JSON file
2. standardized on the function in command ts file
3. use the CommandBuilder's exit function
4. added more tests (hitting over 80% coverage)
5. move `validatePrereqs` function to a lib because it is a helper function. Its tests are moved too. IMO, we should not have helper function in command files.
6. move `config.ts` related tests out of `init.test.ts` and have them under `config.test.ts`

ran sh validations.sh successfully