### PR TITLE
Add access.yaml file for application repository to HLD

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+export const ACCESS_FILENAME = "access.yaml";
+
 export const BUILD_SCRIPT_URL =
   "https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh";
 

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -16,6 +16,7 @@ import path from "path";
 import shelljs from "shelljs";
 import uuid from "uuid/v4";
 import {
+  ACCESS_FILENAME,
   PROJECT_PIPELINE_FILENAME,
   RENDER_HLD_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
@@ -31,6 +32,7 @@ import {
 import { IAzurePipelinesYaml, IMaintainersFile } from "../types";
 import {
   addNewServiceToMaintainersFile,
+  generateAccessYaml,
   generateDefaultHldComponentYaml,
   generateDockerfile,
   generateGitIgnoreFile,
@@ -51,6 +53,44 @@ afterAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe("generateAccessYaml", () => {
+  const targetDirectory = "hld-repository";
+  const serviceDirectory = "my-service";
+  const writeSpy = jest.spyOn(fs, "writeFileSync");
+
+  beforeEach(() => {
+    mockFs({
+      "hld-repository": {
+        "my-service": {}
+      }
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it("should generate the access.yaml in the filepath.", async () => {
+    const absTargetPath = path.resolve(
+      path.join(targetDirectory, serviceDirectory)
+    );
+    const expectedFilePath = path.join(absTargetPath, ACCESS_FILENAME);
+    const gitRepoUrl =
+      "https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019";
+
+    generateAccessYaml(absTargetPath, gitRepoUrl);
+
+    expect(writeSpy).toBeCalledWith(
+      expectedFilePath,
+      yaml.safeDump({
+        gitRepoUrl: "ACCESS_TOKEN_SECRET"
+      }),
+      "utf8"
+    );
+    expect(writeSpy).toBeCalled();
+  });
 });
 
 describe("generateServiceBuildAndUpdatePipelineYaml", () => {

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -29,7 +29,7 @@ import {
   createTestMaintainersYaml,
   createTestServiceBuildAndUpdatePipelineYaml
 } from "../test/mockFactory";
-import { IAzurePipelinesYaml, IMaintainersFile } from "../types";
+import { IAccessYaml, IAzurePipelinesYaml, IMaintainersFile } from "../types";
 import {
   addNewServiceToMaintainersFile,
   generateAccessYaml,
@@ -80,13 +80,14 @@ describe("generateAccessYaml", () => {
     const gitRepoUrl =
       "https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019";
 
+    const accessYaml: IAccessYaml = {};
+    accessYaml[gitRepoUrl] = "ACCESS_TOKEN_SECRET";
+
     generateAccessYaml(absTargetPath, gitRepoUrl);
 
     expect(writeSpy).toBeCalledWith(
       expectedFilePath,
-      yaml.safeDump({
-        gitRepoUrl: "ACCESS_TOKEN_SECRET"
-      }),
+      yaml.safeDump(accessYaml),
       "utf8"
     );
     expect(writeSpy).toBeCalled();

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -2,13 +2,42 @@ import fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
 import {
+  ACCESS_FILENAME,
   PROJECT_PIPELINE_FILENAME,
   RENDER_HLD_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
   VM_IMAGE
 } from "../lib/constants";
 import { logger } from "../logger";
-import { IAzurePipelinesYaml, IMaintainersFile, IUser } from "../types";
+import {
+  IAccessYaml,
+  IAzurePipelinesYaml,
+  IMaintainersFile,
+  IUser
+} from "../types";
+
+/**
+ * Create an access.yaml file for fabrikate authorization. Should only be used by spk hld reconcile, which is an idempotent operation.
+ * @param accessYamlPath
+ * @param gitRepoUrl
+ */
+export const generateAccessYaml = (
+  accessYamlPath: string,
+  gitRepoUrl: string
+) => {
+  const accessYaml: IAccessYaml = {
+    gitRepoUrl: "ACCESS_TOKEN_SECRET"
+  };
+
+  const filePath = path.resolve(path.join(accessYamlPath, ACCESS_FILENAME));
+
+  // Always overwrite what exists.
+  fs.writeFileSync(
+    filePath,
+    yaml.safeDump(accessYaml, { lineWidth: Number.MAX_SAFE_INTEGER }),
+    "utf8"
+  );
+};
 
 /**
  * Concatenates all lines into a single string and injects `set -e` to the top

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -25,8 +25,9 @@ export const generateAccessYaml = (
   accessYamlPath: string,
   gitRepoUrl: string
 ) => {
-  const accessYaml: IAccessYaml = {};
-  accessYaml[gitRepoUrl] = "ACCESS_TOKEN_SECRET";
+  const accessYaml: IAccessYaml = {
+    [gitRepoUrl]: "ACCESS_TOKEN_SECRET"
+  };
 
   const filePath = path.resolve(path.join(accessYamlPath, ACCESS_FILENAME));
 

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -25,9 +25,8 @@ export const generateAccessYaml = (
   accessYamlPath: string,
   gitRepoUrl: string
 ) => {
-  const accessYaml: IAccessYaml = {
-    gitRepoUrl: "ACCESS_TOKEN_SECRET"
-  };
+  const accessYaml: IAccessYaml = {};
+  accessYaml[gitRepoUrl] = "ACCESS_TOKEN_SECRET";
 
   const filePath = path.resolve(path.join(accessYamlPath, ACCESS_FILENAME));
 

--- a/src/lib/gitutils.test.ts
+++ b/src/lib/gitutils.test.ts
@@ -222,11 +222,32 @@ describe("getOriginUrl", () => {
 
     expect(originUrlResponse).toEqual(originUrl);
     expect(exec).toHaveBeenCalledTimes(1);
-    expect(exec).toHaveBeenCalledWith("git", [
-      "config",
-      "--get",
-      "remote.origin.url"
-    ]);
+    expect(exec).toHaveBeenCalledWith(
+      "git",
+      ["config", "--get", "remote.origin.url"],
+      { cwd: "." }
+    );
+  });
+
+  it("should call exec with the proper git arguments", async () => {
+    const originUrl = "foo";
+    const repoPath = "/repo/path";
+
+    when(exec as jest.Mock)
+      .calledWith("git", ["config", "--get", "remote.origin.url"], {
+        cwd: repoPath
+      })
+      .mockReturnValue(originUrl);
+
+    const originUrlResponse = await getOriginUrl(repoPath);
+
+    expect(originUrlResponse).toEqual(originUrl);
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith(
+      "git",
+      ["config", "--get", "remote.origin.url"],
+      { cwd: repoPath }
+    );
   });
 
   it("should return an error when exec throws an error", async () => {

--- a/src/lib/gitutils.ts
+++ b/src/lib/gitutils.ts
@@ -109,14 +109,19 @@ export const pushBranch = async (branchName: string): Promise<void> => {
 
 /**
  * Gets the origin url.
+ * @param absRepositoryPath The Absolute Path to the Repository to fetch the origin
  */
-export const getOriginUrl = async (): Promise<string> => {
+export const getOriginUrl = async (
+  absRepositoryPath?: string
+): Promise<string> => {
   try {
-    const originUrl = await exec("git", [
-      "config",
-      "--get",
-      "remote.origin.url"
-    ]);
+    const repositoryPath =
+      absRepositoryPath !== undefined ? absRepositoryPath : ".";
+    const originUrl = await exec(
+      "git",
+      ["config", "--get", "remote.origin.url"],
+      { cwd: repositoryPath }
+    );
 
     const safeLoggingUrl = safeGitUrlForLogging(originUrl);
     logger.debug(`Got git origin url ${safeLoggingUrl}`);

--- a/src/lib/gitutils.ts
+++ b/src/lib/gitutils.ts
@@ -112,15 +112,13 @@ export const pushBranch = async (branchName: string): Promise<void> => {
  * @param absRepositoryPath The Absolute Path to the Repository to fetch the origin
  */
 export const getOriginUrl = async (
-  absRepositoryPath?: string
+  absRepositoryPath = "."
 ): Promise<string> => {
   try {
-    const repositoryPath =
-      absRepositoryPath !== undefined ? absRepositoryPath : ".";
     const originUrl = await exec(
       "git",
       ["config", "--get", "remote.origin.url"],
-      { cwd: repositoryPath }
+      { cwd: absRepositoryPath }
     );
 
     const safeLoggingUrl = safeGitUrlForLogging(originUrl);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -220,3 +220,7 @@ interface IBedrockFileInfo {
   exist: boolean;
   hasVariableGroups: boolean;
 }
+
+export interface IAccessYaml {
+  [gitRepositoryUrl: string]: string;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/bedrock/issues/956

- adds access.yaml file containing map of app repository: ACCESS_TOKEN to HLD
- modified getGitOrigin to accept an optional path
- tests for reconcile