### PR TITLE
Adding buildId and buildNumber to PRs opened by pipelines

### DIFF
--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -266,8 +266,8 @@ export const serviceBuildAndUpdatePipeline = (
                   `echo 'az extension add --name azure-devops'`,
                   `az extension add --name azure-devops`,
                   ``,
-                  `echo 'az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}."'`,
-                  `response=$(az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}.")`,
+                  `echo 'az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"'`,
+                  `response=$(az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)")`,
                   `pr_id=$(echo $response | jq -r '.pullRequestId')`,
                   ``,
                   ``,
@@ -605,8 +605,8 @@ const hldLifecyclePipelineYaml = () => {
           `echo 'az extension add --name azure-devops'`,
           `az extension add --name azure-devops`,
           ``,
-          `echo 'az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)."'`,
-          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)."`
+          `echo 'az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"'`,
+          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"`
         ]),
         displayName:
           "Download Fabrikate and SPK, Update HLD, Push changes, Open PR",

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -149,8 +149,8 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
                   `echo 'az extension add --name azure-devops'`,
                   `az extension add --name azure-devops`,
                   ``,
-                  `echo 'az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}."'`,
-                  `response=$(az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}.")`,
+                  `echo 'az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"'`,
+                  `response=$(az repos pr create --description "Updating $SERVICE_NAME_LOWER to ${IMAGE_TAG}." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)")`,
                   `pr_id=$(echo $response | jq -r '.pullRequestId')`,
                   ``,
                   ``,
@@ -337,8 +337,8 @@ export const createTestHldLifecyclePipelineYaml = (
           `az extension add --name azure-devops`,
 
           ``,
-          `echo 'az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)."'`,
-          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)."`
+          `echo 'az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"'`,
+          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"`
         ]),
         displayName:
           "Download Fabrikate and SPK, Update HLD, Push changes, Open PR",


### PR DESCRIPTION
Closes: https://github.com/microsoft/bedrock/issues/944

![Screen Shot 2020-02-07 at 4 24 09 PM](https://user-images.githubusercontent.com/20913254/74075238-4fd60600-49c6-11ea-9d84-6343c92d2edd.png)
![Screen Shot 2020-02-07 at 4 24 13 PM](https://user-images.githubusercontent.com/20913254/74075239-506e9c80-49c6-11ea-987c-ec5d5ca3bc08.png)

Screenshots show updated pull requests page, though wording has been changed to:
`PR created by: fabrikam.acme.frontend-pipeline with buildId: 261 and buildNumber: 20200208.1`