### PR TITLE
[Test] Add validation for infra spk.tfvars file from generated repo

### DIFF
--- a/tests/infra-validations.sh
+++ b/tests/infra-validations.sh
@@ -233,5 +233,8 @@ git checkout $pr_id
 file_we_expect=("variables.tf" "main.tf" "backend.tfvars" "spk.tfvars")
 validate_directory "$TEST_WORKSPACE/$infra_generated_dir/$infra_hld_project-generated/$infra_region" "${file_we_expect[@]}" >> $TEST_WORKSPACE/log.txt
 echo "PR for generated repo validated."
-
+# Validate the contents of the definition.yaml
+spkVars_test=$'rg_name = "test-rg"\nrg_location = "west us2"\n'
+validate_file "$TEST_WORKSPACE/$infra_generated_dir/$infra_hld_project-generated/$infra_region/spk.tfvars" $spkVars_test >> $TEST_WORKSPACE/log.txt
+echo "SPK.tfvars file in the generated repo validated."
 echo "Successfully reached the end of the infrastructure validations script."


### PR DESCRIPTION
- Closes https://github.com/microsoft/bedrock/issues/973
- A quick test for integration test to validate spk.tfvars file to assure PR for generated repo correctly configured the file.
- Should we do a more adequate test? Output the terraform plan and run a verification. The ticket will need to be updated