### PR TITLE
Additional fixes to issue 789

### DIFF
--- a/src/lib/commandBuilder.test.ts
+++ b/src/lib/commandBuilder.test.ts
@@ -1,5 +1,6 @@
 import commander from "commander";
 import { watchFile } from "fs";
+import { createLogger } from "winston";
 jest.mock("fs");
 import { logger } from "../logger";
 import {
@@ -140,7 +141,24 @@ describe("Tests Command Builder's exit function", () => {
       cb({ size: 100 });
     });
     const exitFn = jest.fn();
-    await exitCmd(logger, exitFn, 1).then(() => {
+    await exitCmd(logger, exitFn, 1, 100).then(() => {
+      expect(exitFn).toBeCalledTimes(1);
+      expect(exitFn.mock.calls).toEqual([[1]]);
+      done();
+    });
+  });
+  it("calling exit function without file transport", async done => {
+    const exitFn = jest.fn();
+    await exitCmd(
+      createLogger({
+        defaultMeta: { service: "spk" },
+        level: "info",
+        transports: []
+      }),
+      exitFn,
+      1,
+      100
+    ).then(() => {
       expect(exitFn).toBeCalledTimes(1);
       expect(exitFn.mock.calls).toEqual([[1]]);
       done();

--- a/src/lib/commandBuilder.ts
+++ b/src/lib/commandBuilder.ts
@@ -121,7 +121,8 @@ export const validateForRequiredValues = (
 export const exit = (
   log: Logger,
   exitFn: (status: number) => void,
-  statusCode: number
+  statusCode: number,
+  timeout = 10000
 ): Promise<void> => {
   return new Promise(resolve => {
     const hasFileLogger = log.transports.some(t => {
@@ -144,6 +145,13 @@ export const exit = (
     if (!hasFileLogger) {
       exitFn(statusCode);
       resolve();
+    } else {
+      // this is to handle the case when nothing to be written to spk.log
+      // handle fs.watchFile callback will not be execute.
+      setTimeout(() => {
+        exitFn(statusCode);
+        resolve();
+      }, timeout); // 10 seconds should be enough
     }
   });
 };


### PR DESCRIPTION
related https://github.com/microsoft/bedrock/issues/789

the pull request https://github.com/CatalystCode/spk/pull/273 to fix issue https://github.com/microsoft/bedrock/issues/789 is incomplete because we assume the commandline write to spk.log and this is not true. Example for `spk deployment get`, there are nothing written to the log and hence command line does not terminate.

Since we are unable to tell whether there are content to be written to log file or not, we set a length timeout (enough for content to be flush to log file) and then terminate