### PR TITLE
[HOUSEKEEPING] tslint errors; unused variable and avoid usage of any

### DIFF
--- a/src/commands/deployment/validate.test.ts
+++ b/src/commands/deployment/validate.test.ts
@@ -40,12 +40,6 @@ jest.spyOn(storage, "isStorageAccountNameAvailable").mockImplementation(
 );
 
 let mockedDB: any[] = [];
-const mockTableInfo: deploymenttable.IDeploymentTable = {
-  accountKey: "test",
-  accountName: "test",
-  partitionKey: "test",
-  tableName: "test"
-};
 
 jest.spyOn(deploymenttable, "findMatchingDeployments").mockImplementation(
   (

--- a/src/commands/infra/generate.test.ts
+++ b/src/commands/infra/generate.test.ts
@@ -683,16 +683,18 @@ describe("Validate replacement of variables between parent and leaf definitions"
     const parentData = readYaml<IInfraConfigYaml>(
       path.join(mockParentPath, "definition.yaml")
     );
-    const parentInfraConfig: any = loadConfigurationFromLocalEnv(
-      parentData || {}
-    );
+    const parentInfraConfig: IInfraConfigYaml | undefined = parentData
+      ? loadConfigurationFromLocalEnv(parentData)
+      : undefined;
     const leafData = readYaml<IInfraConfigYaml>(
       path.join(mockProjectPath, "definition.yaml")
     );
-    const leafInfraConfig: any = loadConfigurationFromLocalEnv(leafData || {});
-    const finalDefinition = await dirIteration(
-      parentInfraConfig.variables,
-      leafInfraConfig.variables
+    const leafInfraConfig: IInfraConfigYaml | undefined = leafData
+      ? loadConfigurationFromLocalEnv(leafData)
+      : undefined;
+    const finalDefinition = dirIteration(
+      parentInfraConfig ? parentInfraConfig.variables : undefined,
+      leafInfraConfig ? leafInfraConfig.variables : undefined
     );
     const combinedSpkTfvarsObject = generateTfvars(finalDefinition);
     expect(combinedSpkTfvarsObject).toStrictEqual(finalArray);

--- a/src/commands/infra/generate.ts
+++ b/src/commands/infra/generate.ts
@@ -491,7 +491,7 @@ export const generateConfig = async (
  * @param templatePath Path to the versioned Terraform template
  */
 export const singleDefinitionGeneration = async (
-  infraConfig: any,
+  infraConfig: IInfraConfigYaml,
   parentDirectory: string,
   childDirectory: string,
   templatePath: string
@@ -520,9 +520,9 @@ export const singleDefinitionGeneration = async (
  * @param leafObject leaf definition object
  */
 export const dirIteration = (
-  parentObject: { [key: string]: any } | undefined,
-  leafObject: { [key: string]: any } | undefined
-): { [key: string]: any } => {
+  parentObject: { [key: string]: string } | undefined,
+  leafObject: { [key: string]: string } | undefined
+): { [key: string]: string } => {
   if (!parentObject) {
     return !leafObject ? {} : deepClone(leafObject);
   }

--- a/src/commands/infra/scaffold.test.ts
+++ b/src/commands/infra/scaffold.test.ts
@@ -2,7 +2,7 @@ jest.mock("./generate");
 
 import fs from "fs";
 import path from "path";
-import uuid = require("uuid");
+import uuid from "uuid";
 import {
   createTempDir,
   getMissingFilenames,

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export const readYaml = <T>(filepath: string): T => {
  */
 export const loadConfigurationFromLocalEnv = <T>(configObj: T): T => {
   const iterate = (obj: any) => {
-    if (obj != null && obj !== undefined) {
+    if (obj !== null && obj !== undefined) {
       for (const [key, value] of Object.entries(obj)) {
         obj[key] = updateVariableWithLocalEnv(value as string);
         if (typeof obj[key] === "object") {

--- a/src/lib/pipelines/variableGroup.ts
+++ b/src/lib/pipelines/variableGroup.ts
@@ -1,5 +1,4 @@
 import { DefinitionResourceReference } from "azure-devops-node-api/interfaces/BuildInterfaces";
-import { AzureKeyVaultVariableValue } from "azure-devops-node-api/interfaces/ReleaseInterfaces";
 import {
   AzureKeyVaultVariableGroupProviderData,
   VariableGroup,

--- a/src/lib/traefik/ingress-route.test.ts
+++ b/src/lib/traefik/ingress-route.test.ts
@@ -1,5 +1,4 @@
 import uuid from "uuid/v4";
-import { logger } from "../../logger";
 import { TraefikIngressRoute } from "./ingress-route";
 
 describe("TraefikIngressRoute", () => {


### PR DESCRIPTION
1. remove unused variables and imports
2. avoid usage of `any` type
3. tslint warning/error