### PR TITLE
Spk deployment validate fix for verifying storage account credentials

### DIFF
--- a/src/commands/deployment/validate.test.ts
+++ b/src/commands/deployment/validate.test.ts
@@ -8,7 +8,6 @@ import {
   deleteSelfTestData,
   execute,
   isValidConfig,
-  isValidStorageAccount,
   runSelfTest,
   writeSelfTestData
 } from "./validate";
@@ -130,9 +129,6 @@ describe("test execute function", () => {
     jest
       .spyOn(validate, "isValidConfig")
       .mockReturnValueOnce(Promise.resolve());
-    jest
-      .spyOn(validate, "isValidStorageAccount")
-      .mockReturnValueOnce(Promise.resolve());
     const exitFn = jest.fn();
     await execute(
       {
@@ -146,9 +142,6 @@ describe("test execute function", () => {
   it("positive test with self test set", async () => {
     jest
       .spyOn(validate, "isValidConfig")
-      .mockReturnValueOnce(Promise.resolve());
-    jest
-      .spyOn(validate, "isValidStorageAccount")
       .mockReturnValueOnce(Promise.resolve());
     jest.spyOn(validate, "runSelfTest").mockReturnValueOnce(Promise.resolve());
     const exitFn = jest.fn();
@@ -350,56 +343,6 @@ describe("Validate missing deployment.pipeline configuration", () => {
       }
     };
     await expect(isValidConfig(config)).rejects.toThrow();
-  });
-});
-
-describe("Validate storage account", () => {
-  test("non-existing storage account", async () => {
-    const config: IConfigYaml = {
-      introspection: {
-        azure: {
-          account_name: "non-existing-account-name",
-          key: Promise.resolve(undefined)
-        }
-      }
-    };
-    await expect(isValidStorageAccount(config)).rejects.toThrow();
-  });
-
-  test("existing storage account no keys", async () => {
-    const config: IConfigYaml = {
-      introspection: {
-        azure: {
-          account_name: "epi-test-no-keys",
-          key: Promise.resolve(undefined)
-        }
-      }
-    };
-    await expect(isValidStorageAccount(config)).rejects.toThrow();
-  });
-
-  it("existing storage account with valid key", async () => {
-    const config: IConfigYaml = {
-      introspection: {
-        azure: {
-          account_name: "epi-test",
-          key: Promise.resolve("mock access key2")
-        }
-      }
-    };
-    await isValidStorageAccount(config);
-  });
-
-  test("existing storage account with invalid key", async () => {
-    const config: IConfigYaml = {
-      introspection: {
-        azure: {
-          account_name: "epi-test",
-          key: Promise.resolve("mock access key3")
-        }
-      }
-    };
-    await expect(isValidStorageAccount(config)).rejects.toThrow();
   });
 });
 

--- a/src/commands/deployment/validate.ts
+++ b/src/commands/deployment/validate.ts
@@ -33,7 +33,6 @@ export const execute = async (
   try {
     const config = Config();
     await isValidConfig(config);
-    await isValidStorageAccount(config);
 
     if (opts.selfTest) {
       await runSelfTest(config);
@@ -101,25 +100,9 @@ export const isValidConfig = async (config: IConfigYaml) => {
       "Validation failed. Missing configuration: " + missingConfig.join(" ")
     );
     throw new Error("missing configuration in spk configuration");
+  } else {
+    logger.info("Configuration validation: SUCCEEDED");
   }
-};
-
-/**
- * Check is the configured storage account is valid
- */
-export const isValidStorageAccount = async (config: IConfigYaml) => {
-  const key = await config.introspection!.azure!.key;
-  const isValid = await validateStorageAccount(
-    config.introspection!.azure!.resource_group!,
-    config.introspection!.azure!.account_name!,
-    key!
-  );
-
-  if (!isValid) {
-    throw new Error("Storage account validation failed.");
-  }
-
-  logger.info("Storage account validation passed.");
 };
 
 /**


### PR DESCRIPTION
- Closes https://github.com/microsoft/bedrock/issues/952
- No longer need to verify storage account using tenant ID and Sub ID
- To test run `spk deployment validate`