### PR TITLE
[HOUSEKEEPING] infra commands

### DIFF
--- a/src/commands/infra/generate.test.ts
+++ b/src/commands/infra/generate.test.ts
@@ -5,11 +5,7 @@ import simpleGit from "simple-git/promise";
 import { loadConfigurationFromLocalEnv, readYaml } from "../../config";
 import { safeGitUrlForLogging } from "../../lib/gitutils";
 import { removeDir } from "../../lib/ioUtil";
-import {
-  disableVerboseLogging,
-  enableVerboseLogging,
-  logger
-} from "../../logger";
+import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 import { IInfraConfigYaml } from "../../types";
 import {
   checkRemoteGitExist,
@@ -28,6 +24,12 @@ import {
   validateTemplateSources
 } from "./generate";
 import * as generate from "./generate";
+import {
+  DEFAULT_VAR_VALUE,
+  DEFINITION_YAML,
+  getSourceFolderNameFromURL,
+  spkTemplatesPath
+} from "./infra_common";
 import * as infraCommon from "./infra_common";
 
 interface IGitTestData {
@@ -94,8 +96,8 @@ describe("fetch execute function", () => {
 describe("test validateRemoteSource function", () => {
   it("positive test", async () => {
     jest
-      .spyOn(infraCommon, "repoCloneRegex")
-      .mockReturnValueOnce(Promise.resolve("sourceFolder"));
+      .spyOn(infraCommon, "getSourceFolderNameFromURL")
+      .mockReturnValueOnce("sourceFolder");
     jest
       .spyOn(generate, "checkRemoteGitExist")
       .mockReturnValueOnce(Promise.resolve());
@@ -109,8 +111,8 @@ describe("test validateRemoteSource function", () => {
   });
   it("positive test: with Error refusing to merge unrelated histories", async () => {
     jest
-      .spyOn(infraCommon, "repoCloneRegex")
-      .mockReturnValueOnce(Promise.resolve("sourceFolder"));
+      .spyOn(infraCommon, "getSourceFolderNameFromURL")
+      .mockReturnValueOnce("sourceFolder");
     jest
       .spyOn(generate, "checkRemoteGitExist")
       .mockReturnValueOnce(Promise.resolve());
@@ -130,8 +132,8 @@ describe("test validateRemoteSource function", () => {
   });
   it("positive test: with Error Authentication failed", async () => {
     jest
-      .spyOn(infraCommon, "repoCloneRegex")
-      .mockReturnValueOnce(Promise.resolve("sourceFolder"));
+      .spyOn(infraCommon, "getSourceFolderNameFromURL")
+      .mockReturnValueOnce("sourceFolder");
     jest
       .spyOn(generate, "checkRemoteGitExist")
       .mockReturnValueOnce(Promise.resolve());
@@ -149,8 +151,8 @@ describe("test validateRemoteSource function", () => {
   });
   it("negative test: with unknown Error", async () => {
     jest
-      .spyOn(infraCommon, "repoCloneRegex")
-      .mockReturnValueOnce(Promise.resolve("sourceFolder"));
+      .spyOn(infraCommon, "getSourceFolderNameFromURL")
+      .mockReturnValueOnce("sourceFolder");
     jest
       .spyOn(generate, "checkRemoteGitExist")
       .mockReturnValueOnce(Promise.resolve());
@@ -178,7 +180,6 @@ describe("test validateRemoteSource function", () => {
 describe("test retryRemoteValidate function", () => {
   it("positive test", async () => {
     jest.spyOn(fsExtra, "removeSync").mockReturnValueOnce();
-    jest.spyOn(generate, "createGenerated").mockReturnValue();
     jest.spyOn(generate, "gitClone").mockReturnValueOnce(Promise.resolve());
     jest.spyOn(generate, "gitFetchPull").mockReturnValueOnce(Promise.resolve());
     jest.spyOn(generate, "gitCheckout").mockReturnValueOnce(Promise.resolve());
@@ -186,7 +187,6 @@ describe("test retryRemoteValidate function", () => {
   });
   it("negative test", async () => {
     jest.spyOn(fsExtra, "removeSync").mockReturnValueOnce();
-    jest.spyOn(generate, "createGenerated").mockReturnValue();
     jest
       .spyOn(generate, "gitClone")
       .mockReturnValueOnce(Promise.reject(new Error("error")));
@@ -478,8 +478,8 @@ const getMockedDataForGitTests = async (
   }
 
   // Converting source name to storable folder name
-  const sourceFolder = await infraCommon.repoCloneRegex(source);
-  const sourcePath = path.join(infraCommon.spkTemplatesPath, sourceFolder);
+  const sourceFolder = getSourceFolderNameFromURL(source);
+  const sourcePath = path.join(spkTemplatesPath, sourceFolder);
   const safeLoggingUrl = safeGitUrlForLogging(source);
 
   return {
@@ -589,9 +589,7 @@ describe("Validate remote git source", () => {
   test("Validating that a git source is cloned to .spk/templates", async () => {
     jest
       .spyOn(generate, "checkRemoteGitExist")
-      .mockImplementationOnce(async () => {
-        return;
-      });
+      .mockReturnValueOnce(Promise.resolve());
     jest.spyOn(generate, "gitFetchPull").mockReturnValueOnce(Promise.resolve());
     jest.spyOn(generate, "gitCheckout").mockReturnValueOnce(Promise.resolve());
 
@@ -617,26 +615,8 @@ describe("Validate remote git source", () => {
 
 jest.spyOn(generate, "gitClone").mockReturnValue(Promise.resolve());
 jest.spyOn(generate, "createGenerated").mockReturnValue();
-
-jest.spyOn(generate, "checkTfvars").mockImplementation(
-  (generatedPath: string, tfvarsFilename: string): Promise<void> => {
-    logger.info(`checkTfvars function mocked.`);
-    return new Promise(resolve => {
-      resolve();
-    });
-  }
-);
-
-jest
-  .spyOn(generate, "writeTfvarsFile")
-  .mockImplementation(
-    (spkTfvars: string[], generatedPath: string, tfvarsFilename: string) => {
-      logger.info(`writeTfvarsFile function mocked.`);
-      return new Promise(resolve => {
-        resolve();
-      });
-    }
-  );
+jest.spyOn(generate, "checkTfvars").mockReturnValue();
+jest.spyOn(generate, "writeTfvarsFile").mockReturnValue();
 
 describe("Validate replacement of variables between parent and leaf definitions", () => {
   test("Validating that leaf definitions take precedence when generating multi-cluster definitions", async () => {
@@ -644,42 +624,42 @@ describe("Validate replacement of variables between parent and leaf definitions"
     const mockProjectPath = "src/commands/infra/mocks/discovery-service/west";
     const finalArray = [
       'acr_enabled = "true"',
-      'address_space = "<insert value>"',
-      'agent_vm_count = "<insert value>"',
-      'agent_vm_size = "<insert value>"',
+      `address_space = "${DEFAULT_VAR_VALUE}"`,
+      `agent_vm_count = "${DEFAULT_VAR_VALUE}"`,
+      `agent_vm_size = "${DEFAULT_VAR_VALUE}"`,
       'cluster_name = "discovery-service-west"',
-      'dns_prefix = "<insert value>"',
-      'flux_recreate = "<insert value>"',
-      'kubeconfig_recreate = "<insert value>"',
+      `dns_prefix = "${DEFAULT_VAR_VALUE}"`,
+      `flux_recreate = "${DEFAULT_VAR_VALUE}"`,
+      `kubeconfig_recreate = "${DEFAULT_VAR_VALUE}"`,
       'gc_enabled = "true"',
       'gitops_poll_interval = "5m"',
-      'gitops_ssh_url = "<insert value>"',
+      `gitops_ssh_url = "${DEFAULT_VAR_VALUE}"`,
       'gitops_url_branch = "master"',
-      'gitops_ssh_key = "<insert value>"',
-      'gitops_path = "<insert value>"',
-      'keyvault_name = "<insert value>"',
-      'keyvault_resource_group = "<insert value>"',
-      'resource_group_name = "<insert value>"',
-      'ssh_public_key = "<insert value>"',
-      'service_principal_id = "<insert value>"',
-      'service_principal_secret = "<insert value>"',
-      'subnet_prefixes = "<insert value>"',
-      'vnet_name = "<insert value>"',
-      'subnet_name = "<insert value>"',
+      `gitops_ssh_key = "${DEFAULT_VAR_VALUE}"`,
+      `gitops_path = "${DEFAULT_VAR_VALUE}"`,
+      `keyvault_name = "${DEFAULT_VAR_VALUE}"`,
+      `keyvault_resource_group = "${DEFAULT_VAR_VALUE}"`,
+      `resource_group_name = "${DEFAULT_VAR_VALUE}"`,
+      `ssh_public_key = "${DEFAULT_VAR_VALUE}"`,
+      `service_principal_id = "${DEFAULT_VAR_VALUE}"`,
+      `service_principal_secret = "${DEFAULT_VAR_VALUE}"`,
+      `subnet_prefixes = "${DEFAULT_VAR_VALUE}"`,
+      `vnet_name = "${DEFAULT_VAR_VALUE}"`,
+      `subnet_name = "${DEFAULT_VAR_VALUE}"`,
       'network_plugin = "azure"',
       'network_policy = "azure"',
       'oms_agent_enabled = "false"',
       'enable_acr = "false"',
-      'acr_name = "<insert value>"'
+      `acr_name = "${DEFAULT_VAR_VALUE}"`
     ];
     const parentData = readYaml<IInfraConfigYaml>(
-      path.join(mockParentPath, "definition.yaml")
+      path.join(mockParentPath, DEFINITION_YAML)
     );
     const parentInfraConfig: IInfraConfigYaml | undefined = parentData
       ? loadConfigurationFromLocalEnv(parentData)
       : undefined;
     const leafData = readYaml<IInfraConfigYaml>(
-      path.join(mockProjectPath, "definition.yaml")
+      path.join(mockProjectPath, DEFINITION_YAML)
     );
     const leafInfraConfig: IInfraConfigYaml | undefined = leafData
       ? loadConfigurationFromLocalEnv(leafData)
@@ -697,7 +677,7 @@ describe("Validate spk.tfvars file", () => {
   test("Validating that a spk.tfvars is generated and has appropriate format", async () => {
     const mockProjectPath = "src/commands/infra/mocks/discovery-service";
     const data = readYaml<IInfraConfigYaml>(
-      path.join(mockProjectPath, `definition.yaml`)
+      path.join(mockProjectPath, DEFINITION_YAML)
     );
     const infraConfig = loadConfigurationFromLocalEnv(data);
     const spkTfvarsObject = generateTfvars(infraConfig.variables);
@@ -709,7 +689,7 @@ describe("Validate backend.tfvars file", () => {
   test("Validating that a backend.tfvars is generated and has appropriate format", async () => {
     const mockProjectPath = "src/commands/infra/mocks/discovery-service";
     const data = readYaml<IInfraConfigYaml>(
-      path.join(mockProjectPath, `definition.yaml`)
+      path.join(mockProjectPath, DEFINITION_YAML)
     );
     const infraConfig = loadConfigurationFromLocalEnv(data);
     const backendTfvarsObject = generateTfvars(infraConfig.backend);

--- a/src/commands/infra/infra_common.test.ts
+++ b/src/commands/infra/infra_common.test.ts
@@ -1,0 +1,26 @@
+import { getSourceFolderNameFromURL } from "./infra_common";
+
+describe("test getSourceFolderNameFromURL function", () => {
+  it("positive test with http .com domain", () => {
+    const result = getSourceFolderNameFromURL("http://github.com/bedrock/SPK");
+    expect(result).toBe("_bedrock_spk");
+  });
+  it("positive test with http .net domain", () => {
+    const result = getSourceFolderNameFromURL("http://github.net/bedrock/SPK");
+    expect(result).toBe("_bedrock_spk");
+  });
+  it("positive test with ssh", () => {
+    const result = getSourceFolderNameFromURL(
+      "git@github.com:microsoft/bedrock.git"
+    );
+    expect(result).toBe("_microsoft_bedrock_git");
+  });
+  it("positive test with any string", () => {
+    const result = getSourceFolderNameFromURL("microsoft/bedrock.git");
+    expect(result).toBe("microsoft_bedrock_git");
+  });
+  it("positive test with empty string", () => {
+    const result = getSourceFolderNameFromURL(""); // this will not happen in real world.
+    expect(result).toBe("");
+  });
+});

--- a/src/commands/infra/infra_common.ts
+++ b/src/commands/infra/infra_common.ts
@@ -1,16 +1,36 @@
 import * as os from "os";
 import path from "path";
-import simpleGit from "simple-git/promise";
+import url from "url";
 
-export const spkTemplatesPath = path.join(os.homedir(), ".spk/templates");
-const git = simpleGit();
+export const spkTemplatesPath = path.join(os.homedir(), ".spk", "templates");
 
-export const repoCloneRegex = async (source: string): Promise<string> => {
-  const httpReg = /^(.*?)\.com/;
+export const DEFINITION_YAML = "definition.yaml";
+export const VARIABLES_TF = "variables.tf";
+export const BACKEND_TFVARS = "backend.tfvars";
+export const TERRAFORM_TFVARS = "terraform.tfvars";
+export const SPK_TFVARS = "spk.tfvars";
+export const DEFAULT_VAR_VALUE = "<insert value>";
+
+/**
+ * Returns a source folder name for a given git URL.
+ *
+ * @param source git source URL
+ */
+export const getSourceFolderNameFromURL = (source: string): string => {
   const punctuationReg = /[^\w\s]/g;
-  const sourceFolder = source
-    .replace(httpReg, "")
+
+  const oUrl = url.parse(source); // does not throw any exception. even when source is an empty string
+  if (oUrl.hostname) {
+    return (oUrl.pathname || "").replace(punctuationReg, "_").toLowerCase();
+  }
+  // no hostname e.g. git@github.com:microsoft/bedrock.git
+  const idx = source.indexOf(":");
+  if (idx === -1) {
+    // do not have :
+    return source.replace(punctuationReg, "_").toLowerCase();
+  }
+  return source
+    .substring(idx)
     .replace(punctuationReg, "_")
     .toLowerCase();
-  return sourceFolder;
 };

--- a/src/commands/infra/scaffold.test.ts
+++ b/src/commands/infra/scaffold.test.ts
@@ -11,22 +11,25 @@ import {
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 import { validateRemoteSource } from "./generate";
 import * as generate from "./generate";
-import * as infraCommon from "./infra_common";
 import {
   BACKEND_TFVARS,
+  DEFAULT_VAR_VALUE,
+  DEFINITION_YAML,
+  TERRAFORM_TFVARS,
+  VARIABLES_TF
+} from "./infra_common";
+import * as infraCommon from "./infra_common";
+import {
   constructSource,
   copyTfTemplate,
-  DEFINITION_YAML,
   execute,
   generateClusterDefinition,
   ICommandOptions,
   parseVariablesTf,
   removeTemplateFiles,
-  TERRAFORM_TFVARS,
   validateBackendTfvars,
   validateValues,
-  validateVariablesTf,
-  VARIABLES_TF
+  validateVariablesTf
 } from "./scaffold";
 import * as scaffold from "./scaffold";
 
@@ -223,7 +226,7 @@ describe("test execute function", () => {
     expect(exitFn.mock.calls).toEqual([[1]]);
   });
   it("missing opt ", async () => {
-    (validateRemoteSource as jest.Mock).mockReturnValue(true);
+    (validateRemoteSource as jest.Mock).mockReturnValueOnce(true);
     const exitFn = jest.fn();
     try {
       await execute(mockYaml, EMPTY_VALS, exitFn);
@@ -237,8 +240,8 @@ describe("test execute function", () => {
   it("positive test", async () => {
     (validateRemoteSource as jest.Mock).mockReturnValueOnce(true);
     jest
-      .spyOn(infraCommon, "repoCloneRegex")
-      .mockReturnValueOnce(Promise.resolve("sourceFolder"));
+      .spyOn(infraCommon, "getSourceFolderNameFromURL")
+      .mockReturnValueOnce("sourceFolder");
     jest
       .spyOn(generate, "validateRemoteSource")
       .mockReturnValueOnce(Promise.resolve());
@@ -313,7 +316,7 @@ describe("Validate generation of sample scaffold definition", () => {
     expect(def.name).toBe("test-scaffold");
 
     const variables = def.variables as { [key: string]: string };
-    expect(variables.resource_group_name).toBe("<insert value>");
+    expect(variables.resource_group_name).toBe(DEFAULT_VAR_VALUE);
 
     const backend = def.backend as { [key: string]: string };
     expect(backend.key).toBe("tfstate-azure-simple");

--- a/src/commands/infra/scaffold.ts
+++ b/src/commands/infra/scaffold.ts
@@ -8,14 +8,16 @@ import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { logger } from "../../logger";
 import { IConfigYaml } from "../../types";
 import { ISourceInformation, validateRemoteSource } from "./generate";
-import * as infraCommon from "./infra_common";
+import {
+  BACKEND_TFVARS,
+  DEFAULT_VAR_VALUE,
+  DEFINITION_YAML,
+  getSourceFolderNameFromURL,
+  spkTemplatesPath,
+  TERRAFORM_TFVARS,
+  VARIABLES_TF
+} from "./infra_common";
 import decorator from "./scaffold.decorator.json";
-
-export const DEFINITION_YAML = "definition.yaml";
-export const VARIABLES_TF = "variables.tf";
-export const BACKEND_TFVARS = "backend.tfvars";
-export const TERRAFORM_TFVARS = "terraform.tfvars";
-export const DEFAULT_VAR_VALUE = "<insert value>";
 
 export interface ICommandOptions {
   name: string;
@@ -78,15 +80,15 @@ export const execute = async (
       template: opts.template,
       version: opts.version
     };
-    const sourceFolder = await infraCommon.repoCloneRegex(opts.source);
-    const sourcePath = path.join(infraCommon.spkTemplatesPath, sourceFolder);
+    const sourceFolder = getSourceFolderNameFromURL(opts.source);
+    const sourcePath = path.join(spkTemplatesPath, sourceFolder);
     await validateRemoteSource(scaffoldDefinition);
     await copyTfTemplate(
       path.join(sourcePath, opts.template),
       opts.name,
       false
     );
-    validateVariablesTf(path.join(sourcePath, opts.template, "variables.tf"));
+    validateVariablesTf(path.join(sourcePath, opts.template, VARIABLES_TF));
     await scaffold(opts);
     removeTemplateFiles(opts.name);
     await exitFn(0);


### PR DESCRIPTION
1. rewrote infra_common.repoCloneRegex
  a. rename it to getSourceFolderNameFromURL
  b. make it more robust as briefly mentioned in slack
      i. handle different domain in URL
      ii. handle non URL
  c. add unit tests
2. Consolidate all constants string in infra_common.ts
3. Simplify and remove redundant mocks in unit tests
