### PR TITLE
Fixed Broken getRemoteUrl Test

### DIFF
--- a/src/commands/service/create-revision.test.ts
+++ b/src/commands/service/create-revision.test.ts
@@ -250,7 +250,7 @@ describe("Create pull request", () => {
 describe("test getRemoteUrl function", () => {
   it("sanity test: get original url", async done => {
     const res = await getRemoteUrl(undefined);
-    expect(res.startsWith("https://github.com/CatalystCode/spk")).toBe(true);
+    expect(!!res.match(/CatalystCode\/spk/i)).toBe(true);
     done();
   });
   it("sanity test", async done => {


### PR DESCRIPTION
Fixed a broken test that didn't work if you cloned the repository via SSH (as it
expected https). Have loosened it to do a pattern match instead.