### PR TITLE
Always regnenerate ring components

### DIFF
--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -418,7 +418,7 @@ describe("reconcile tests", () => {
     expect(dependencies.createIngressRouteForRing).not.toHaveBeenCalled();
   });
 
-  it("does not create a ring, if one already exists", async () => {
+  it("will re-write rings, even if they exist", async () => {
     bedrockYaml.rings = {};
 
     await reconcileHld(
@@ -429,10 +429,10 @@ describe("reconcile tests", () => {
       "./path/to/app"
     );
 
-    expect(dependencies.createRingComponent).not.toHaveBeenCalled();
-    expect(dependencies.createStaticComponent).not.toHaveBeenCalled();
-    expect(dependencies.createMiddlewareForRing).not.toHaveBeenCalled();
-    expect(dependencies.createIngressRouteForRing).not.toHaveBeenCalled();
+    expect(dependencies.createRingComponent).toHaveBeenCalled();
+    expect(dependencies.createStaticComponent).toHaveBeenCalled();
+    expect(dependencies.createMiddlewareForRing).toHaveBeenCalled();
+    expect(dependencies.createIngressRouteForRing).toHaveBeenCalled();
   });
 
   it("does not create service components if the service path is `.`, and a display name does not exist", async () => {

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -63,8 +63,6 @@ export interface IReconcileDependencies {
 
   writeFile: (path: string, contents: string) => void;
 
-  test: (option: shelljs.TestOptions, path: string) => boolean;
-
   getGitOrigin: (path?: string) => Promise<string>;
 
   generateAccessYaml: (
@@ -170,7 +168,6 @@ export const execute = async (
       exec: execAndLog,
       generateAccessYaml,
       getGitOrigin: tryGetGitOrigin,
-      test: shelljs.test,
       writeFile: writeFileSync
     };
 

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -263,23 +263,9 @@ export const reconcileHld = async (
 
     // Create ring components.
     const svcPathInHld = path.join(absRepositoryInHldPath, serviceName);
-
-    // If the ring component already exists, we do not attempt to create it.
-    const ringsToCreate = Object.keys(managedRings)
-      .map(ring => {
-        return { ring, ringPathInHld: path.join(svcPathInHld, ring) };
-      })
-      .filter(({ ring, ringPathInHld }) => {
-        const alreadyExists =
-          dependencies.test("-e", ringPathInHld) && // path exists
-          dependencies.test("-d", ringPathInHld); // path is a directory
-        if (alreadyExists) {
-          logger.info(
-            `Ring component: ${ring} already exists, skipping ring generation.`
-          );
-        }
-        return !alreadyExists;
-      });
+    const ringsToCreate = Object.keys(managedRings).map(ring => {
+      return { ring, ringPathInHld: path.join(svcPathInHld, ring) };
+    });
 
     // Will only loop over _existing_ rings in bedrock.yaml - does not cover the deletion case, ie: i remove a ring from bedrock.yaml
     for (const { ring, ringPathInHld } of ringsToCreate) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/bedrock/issues/1011

Existing behavior for `spk` dictated that the `spk hld reconcile` would not re-generate ring components - ever. However, this caused us to end up with (possibly) broken manifest resources, occasionally ie if the user had made a mistake in bedrock.yaml, then the ingress route or the outputted middleware could have been incorrect, and they would never be re-generated without deleting the service component or the ring component in the HLD.

This change reverses that logic - we should always regenerate ring components