### PR TITLE
[HOUSEKEEPING] making cmd line option args consistency

### DIFF
--- a/docs/commands/data.json
+++ b/docs/commands/data.json
@@ -142,7 +142,7 @@
         "defaultValue": ""
       },
       {
-        "arg": "-o, --output <output-format>",
+        "arg": "-O, --output <output-format>",
         "description": "Output the information one of the following: normal, wide, JSON",
         "defaultValue": "normal"
       },
@@ -258,12 +258,12 @@
         "defaultValue": ""
       },
       {
-        "arg": "-p, --personal-access-token <personal-access-token>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Personal Access Token",
         "defaultValue": ""
       },
       {
-        "arg": "-o, --org-name <org-name>",
+        "arg": "-o, --org-name <organization-name>",
         "description": "Organization Name for Azure DevOps",
         "defaultValue": ""
       },
@@ -314,7 +314,7 @@
         "required": false
       },
       {
-        "arg": "-o, --output <path to create generated folder>",
+        "arg": "-O, --output <path to create generated folder>",
         "description": "Location of the generated directory that will be generated",
         "required": false
       }
@@ -384,7 +384,7 @@
         "required": true
       },
       {
-        "arg": "--org-name <organization-name>",
+        "arg": "-o, --org-name <organization-name>",
         "description": "Azure DevOps organization name; falls back to azure_devops.org in spk config.",
         "required": true
       },
@@ -394,7 +394,7 @@
         "required": true
       },
       {
-        "arg": "--personal-access-token <personal-access-token>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Azure DevOps Personal access token; falls back to azure_devops.access_token in spk config.",
         "required": true
       }
@@ -426,12 +426,12 @@
         "required": true
       },
       {
-        "arg": "-p, --personal-access-token <personal-access-token>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Personal Access Token",
         "required": true
       },
       {
-        "arg": "-o, --org-name <org-name>",
+        "arg": "-o, --org-name <organization-name>",
         "description": "Organization Name for Azure DevOps",
         "required": true
       },
@@ -483,12 +483,12 @@
         "required": true
       },
       {
-        "arg": "--personal-access-token <pat>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Personal access token associated with your Azure DevOps token; falls back to azure_devops.access_token in your spk config",
         "required": true
       },
       {
-        "arg": "--org-name <organization-name>",
+        "arg": "-o, --org-name <organization-name>",
         "description": "Your Azure DevOps organization name; falls back to azure_devops.org in your spk config",
         "required": true
       },
@@ -593,12 +593,12 @@
         "defaultValue": ""
       },
       {
-        "arg": "-p, --personal-access-token <personal-access-token>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Personal Access Token",
         "defaultValue": ""
       },
       {
-        "arg": "-o, --org-name <org-name>",
+        "arg": "-o, --org-name <organization-name>",
         "description": "Organization Name for Azure DevOps",
         "defaultValue": ""
       },
@@ -648,7 +648,7 @@
         "description": "Azure DevOps project name; falls back to azure_devops.project in spk config"
       },
       {
-        "arg": "-t, --personal-access-token <personal-access-token>",
+        "arg": "-a, --personal-access-token <personal-access-token>",
         "description": "Personal access token associated with the Azure DevOps org; falls back to azure_devops.access_token in spk config"
       }
     ]

--- a/guides/service-introspection.md
+++ b/guides/service-introspection.md
@@ -88,7 +88,7 @@ Options:
   -i, --image-tag <image-tag>          Filter by a container image tag
   -e, --env <environment>              Filter by environment name
   -s, --service <service-name>         Filter by service name
-  -o, --output <output-format>         Output the information in one of the following formats: normal, wide, JSON
+  -O, --output <output-format>         Output the information in one of the following formats: normal, wide, JSON
   -w, --watch                          Watch the deployments for a live view
   -h, --help                           Usage information
 ```

--- a/guides/variable-group.md
+++ b/guides/variable-group.md
@@ -57,9 +57,9 @@ spk variable-group create|c [options]
 
 Options:
   -f, --file <file>                     Path to the yaml file that contains variable group manifest
-  -o, --org-name <org>                  Azure DevOps organization name; falls back to azure_devops.org in spk config
+  -o, --org-name <organization-name>    Azure DevOps organization name; falls back to azure_devops.org in spk config
   -p, --project <project>               Azure DevOps project name; falls back to azure_devops.project in spk config
-  -t, --personal-access-token <token>   Personal access token from Azure DevOps org; falls back to azure_devops.access_token in spk config
+  -a, --personal-access-token <personal-access-token>   Personal access token from Azure DevOps org; falls back to azure_devops.access_token in spk config
 ```
 
 Variable Group Yaml Manifest File Format

--- a/src/commands/deployment/get.decorator.json
+++ b/src/commands/deployment/get.decorator.json
@@ -39,7 +39,7 @@
       "defaultValue": ""
     },
     {
-      "arg": "-o, --output <output-format>",
+      "arg": "-O, --output <output-format>",
       "description": "Output the information one of the following: normal, wide, JSON",
       "defaultValue": "normal"
     },

--- a/src/commands/hld/pipeline.decorator.json
+++ b/src/commands/hld/pipeline.decorator.json
@@ -9,12 +9,12 @@
       "defaultValue": ""
     },
     {
-      "arg": "-p, --personal-access-token <personal-access-token>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Personal Access Token",
       "defaultValue": ""
     },
     {
-      "arg": "-o, --org-name <org-name>",
+      "arg": "-o, --org-name <organization-name>",
       "description": "Organization Name for Azure DevOps",
       "defaultValue": ""
     },

--- a/src/commands/infra/generate.decorator.json
+++ b/src/commands/infra/generate.decorator.json
@@ -9,7 +9,7 @@
       "required": false
     },
     {
-      "arg": "-o, --output <path to create generated folder>",
+      "arg": "-O, --output <path to create generated folder>",
       "description": "Location of the generated directory that will be generated",
       "required": false
     }

--- a/src/commands/project/create-variable-group.decorator.json
+++ b/src/commands/project/create-variable-group.decorator.json
@@ -29,7 +29,7 @@
       "required": true
     },
     {
-      "arg": "--org-name <organization-name>",
+      "arg": "-o, --org-name <organization-name>",
       "description": "Azure DevOps organization name; falls back to azure_devops.org in spk config.",
       "required": true
     },
@@ -39,7 +39,7 @@
       "required": true
     },
     {
-      "arg": "--personal-access-token <personal-access-token>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Azure DevOps Personal access token; falls back to azure_devops.access_token in spk config.",
       "required": true
     }

--- a/src/commands/project/pipeline.decorator.json
+++ b/src/commands/project/pipeline.decorator.json
@@ -9,12 +9,12 @@
       "required": true
     },
     {
-      "arg": "-p, --personal-access-token <personal-access-token>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Personal Access Token",
       "required": true
     },
     {
-      "arg": "-o, --org-name <org-name>",
+      "arg": "-o, --org-name <organization-name>",
       "description": "Organization Name for Azure DevOps",
       "required": true
     },

--- a/src/commands/service/create-revision.decorator.json
+++ b/src/commands/service/create-revision.decorator.json
@@ -22,12 +22,12 @@
       "required": true
     },
     {
-      "arg": "--personal-access-token <pat>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Personal access token associated with your Azure DevOps token; falls back to azure_devops.access_token in your spk config",
       "required": true
     },
     {
-      "arg": "--org-name <organization-name>",
+      "arg": "-o, --org-name <organization-name>",
       "description": "Your Azure DevOps organization name; falls back to azure_devops.org in your spk config",
       "required": true
     },

--- a/src/commands/service/pipeline.decorator.json
+++ b/src/commands/service/pipeline.decorator.json
@@ -9,12 +9,12 @@
       "defaultValue": ""
     },
     {
-      "arg": "-p, --personal-access-token <personal-access-token>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Personal Access Token",
       "defaultValue": ""
     },
     {
-      "arg": "-o, --org-name <org-name>",
+      "arg": "-o, --org-name <organization-name>",
       "description": "Organization Name for Azure DevOps",
       "defaultValue": ""
     },

--- a/src/commands/variable-group/create.decorator.json
+++ b/src/commands/variable-group/create.decorator.json
@@ -16,7 +16,7 @@
       "description": "Azure DevOps project name; falls back to azure_devops.project in spk config"
     },
     {
-      "arg": "-t, --personal-access-token <personal-access-token>",
+      "arg": "-a, --personal-access-token <personal-access-token>",
       "description": "Personal access token associated with the Azure DevOps org; falls back to azure_devops.access_token in spk config"
     }
   ]

--- a/tests/single-app-repo-validation.sh
+++ b/tests/single-app-repo-validation.sh
@@ -98,7 +98,7 @@ pipeline_exists $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name
 echo "hld_dir $hld_dir"
 echo "hld_repo_url $hld_repo_url"
 echo "manifest_repo_url $manifest_repo_url"
-spk hld install-manifest-pipeline -o $AZDO_ORG -d $AZDO_PROJECT -p $ACCESS_TOKEN_SECRET -r $hld_dir -u $hld_repo_url -m $manifest_repo_url >> $TEST_WORKSPACE/log.txt
+spk hld install-manifest-pipeline --org-name $AZDO_ORG -d $AZDO_PROJECT --personal-access-token $ACCESS_TOKEN_SECRET -r $hld_dir -u $hld_repo_url -m $manifest_repo_url >> $TEST_WORKSPACE/log.txt
 
 # Verify hld to manifest pipeline was created
 pipeline_created=$(az pipelines show --name $hld_to_manifest_pipeline_name --org $AZDO_ORG_URL --p $AZDO_PROJECT)
@@ -165,7 +165,7 @@ frontend_pipeline_name="$frontend_repo_dir-pipeline"
 pipeline_exists $AZDO_ORG_URL $AZDO_PROJECT $frontend_pipeline_name
 
 # Create a pipeline since the code exists in remote repo
-spk service install-build-pipeline -o $AZDO_ORG -r $frontend_repo_dir -u $frontend_repo_url -d $AZDO_PROJECT -p $ACCESS_TOKEN_SECRET -n $frontend_pipeline_name . >> $TEST_WORKSPACE/log.txt
+spk service install-build-pipeline --org-name $AZDO_ORG -r $frontend_repo_dir -u $frontend_repo_url -d $AZDO_PROJECT --personal-access-token $ACCESS_TOKEN_SECRET -n $frontend_pipeline_name . >> $TEST_WORKSPACE/log.txt
 
 # Verify frontend service pipeline was created
 pipeline_created=$(az pipelines show --name $frontend_pipeline_name --org $AZDO_ORG_URL --p $AZDO_PROJECT)

--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -145,7 +145,7 @@ pipeline_exists $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name
 echo "hld_dir $hld_dir"
 echo "hld_repo_url $hld_repo_url"
 echo "manifest_repo_url $manifest_repo_url"
-spk hld install-manifest-pipeline -o $AZDO_ORG -d $AZDO_PROJECT -p $ACCESS_TOKEN_SECRET -u https://$hld_repo_url -m https://$manifest_repo_url >> $TEST_WORKSPACE/log.txt
+spk hld install-manifest-pipeline --org-name $AZDO_ORG -d $AZDO_PROJECT --personal-access-token $ACCESS_TOKEN_SECRET -u https://$hld_repo_url -m https://$manifest_repo_url >> $TEST_WORKSPACE/log.txt
 
 # Verify hld to manifest pipeline was created
 pipeline_created=$(az pipelines show --name $hld_to_manifest_pipeline_name --org $AZDO_ORG_URL --p $AZDO_PROJECT)
@@ -281,7 +281,7 @@ frontend_pipeline_name="$FrontEnd-pipeline"
 pipeline_exists $AZDO_ORG_URL $AZDO_PROJECT $frontend_pipeline_name
 
 # Create a pipeline since the code exists in remote repo
-spk service install-build-pipeline -o $AZDO_ORG -u $remote_repo_url -d $AZDO_PROJECT -l $services_dir -p $ACCESS_TOKEN_SECRET -n $frontend_pipeline_name -v $FrontEnd  >> $TEST_WORKSPACE/log.txt
+spk service install-build-pipeline --org-name $AZDO_ORG -u $remote_repo_url -d $AZDO_PROJECT -l $services_dir --personal-access-token $ACCESS_TOKEN_SECRET -n $frontend_pipeline_name -v $FrontEnd  >> $TEST_WORKSPACE/log.txt
 
 # Verify frontend service pipeline was created
 pipeline_created=$(az pipelines show --name $frontend_pipeline_name --org $AZDO_ORG_URL --p $AZDO_PROJECT)


### PR DESCRIPTION
Related to https://github.com/microsoft/bedrock/issues/1050

first series of fix on making aliases for all commands consistent

-a for --personal-access-token because -p is used for --project
-o for --org-name and have -O for --output
