### PR TITLE
Private Helm Git Repo Repository Support

### DIFF
--- a/guides/auth-private-helm-repos.md
+++ b/guides/auth-private-helm-repos.md
@@ -1,0 +1,82 @@
+# Private Helm/Git Repositories -- Authorization/PAT For HLD to Materialized Pipeline
+
+An operator may want to store their Helm charts in a different repository than
+their application code. In this scenario, the operators Helm chart git
+repository will most likely be private; making the ability to clone it in the
+HLD-to-Materialized pipeline an issue. To facilitate the ability to clone the
+Helm chart repository, we can piggy back off the ability for
+[Fabrikate to consume env variables consuming personal access tokens (PATs)](https://github.com/microsoft/fabrikate/blob/master/docs/auth.md).
+
+## Utilizing The Default PAT (ACCESS_TOKEN_SECRET)
+
+By default, all services created via `spk service create` with the the
+`--helm-config-*` family of options will be setup to consume the environment
+variable `ACCESS_TOKEN_SECRET` -- The PAT used to clone the application
+repository in the HLD-to-Materialized pipeline. So if the PAT used to setup your
+HLD-to-Materialized pipeline has full read access to the Azure DevOps
+organizations your Helm git repositories are stored, the pipeline is all set to
+clone the Helm charts by default.
+
+## Making The Pipeline Aware of Custom Environment Variables
+
+In order to tell the pipeline that it needs to utilize a PAT stored in a user
+defined environment variable in the HLD-to-Materialized pipeline, the
+environment variable name -- not the PAT itself -- needs to be tracked in the
+`bedrock.yaml`. This environment variable will be used to clone the `https` git
+URI for the Helm chart git repository.
+
+Visit https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables
+for more information on how to add a variables to your pipeline.
+
+### Setting Up At Service Create Time
+
+If you already have a environment variable name in mind you want to consume or
+already have it available in your pipeline before you create your service, you
+can make it aware of it via the `--helm-config-access-token-variable` flag in
+the `spk service create` command.
+
+```sh
+spk service create my-service \
+  --helm-config-git https://dev.azure.com/my-org/my-project/_git/my-repo \
+  --helm-config-branch master \
+  --helm-config-path my-service-helm-chart \
+  --helm-config-access-token-variable MY_ENV_VAR
+```
+
+**Note**: it is important that the git URI you pass is an `https` URI and does
+NOT contain a username in it. By default, the clone URIs that the Azure DevOps
+creates presents in the UI contain your username in them (eg.
+`https://<my-username>@dev.azure.com/my-org/my-project/_git/my-repo`). Fabrikate
+will not inject the PAT if the username is there as the value contained in place
+of the username can be a PAT itself.
+
+`MY_ENV_VAR` will be tracked in the service definition in your `bedrock.yaml`:
+
+```yaml
+rings:
+  master:
+    isDefault: true
+services:
+  ./my-service:
+    displayName: ""
+    helm:
+      chart:
+        accessTokenVariable: MY_ENV_VAR # Note: this is where the environment variable gets tracked
+        branch: master
+        git: "https://dev.azure.com/my-org/my-project/_git/my-repo" # Note: it is important that the HTTPS URI does NOT contain your username
+        path: my-service-helm-chart
+    k8sBackend: ""
+    k8sBackendPort: 80
+    middlewares: []
+    pathPrefix: ""
+    pathPrefixMajorVersion: ""
+variableGroups:
+  - my-var-group
+```
+
+### Updating/Changing The Environment Variable
+
+If you want to change the the environment variable used after creating your
+service, simply change the value of `accessTokenVariable` in your `bedrock.yaml`
+to the target environment variable (and ensure that the environment variable
+exists in your HLD-to-Materialized pipeline).

--- a/src/commands/service/create.decorator.json
+++ b/src/commands/service/create.decorator.json
@@ -14,6 +14,11 @@
       "defaultValue": ""
     },
     {
+      "arg": "-g, --helm-config-git <helm-git>",
+      "description": "bedrock helm chart configuration git repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one.",
+      "defaultValue": ""
+    },
+    {
       "arg": "-b, --helm-config-branch <helm-branch>",
       "description": "bedrock custom helm chart configuration branch. --helm-chart-* and --helm-config-* are exclusive; you may only use one.",
       "defaultValue": ""
@@ -24,9 +29,9 @@
       "defaultValue": ""
     },
     {
-      "arg": "-g, --helm-config-git <helm-git>",
-      "description": "bedrock helm chart configuration git repository. --helm-chart-* and --helm-config-* are exclusive; you may only use one.",
-      "defaultValue": ""
+      "arg": "--helm-config-access-token-variable <env-variable>",
+      "description": "An environment variable which will contain the value of PAT to access the git repository specified in --helm-config-git",
+      "defaultValue": "ACCESS_TOKEN_SECRET"
     },
     {
       "arg": "-d, --packages-dir <dir>",

--- a/src/commands/service/create.md
+++ b/src/commands/service/create.md
@@ -2,6 +2,17 @@
 
 Add a new service into this initialized spk project repository.
 
+## Example
+
+  ```bash
+  spk service create . \ 
+    --display-name $app_name \
+    --helm-config-path $path_to_chart_in_repo \
+    --helm-config-git $helm_repo_url \ # Needs to start with https and not contain user name 
+    --helm-config-branch master \
+    --helm-chart-access-token-variable $ENV_VAR_NAME
+  ```
+ 
 ## Note
 
 - `--helm-chart-*` and `--helm-config-*` settings are exclusive. **You may only
@@ -10,13 +21,11 @@ Add a new service into this initialized spk project repository.
     repository, you can specify an environment variable in your
     HLD-to-Materialized pipeline containing your a PAT to authenticate with via
     the `--helm-chart-access-token-variable` option.
-    - For more information, checkout the
-      [git authentication guide](../../../guides/auth-private-helm-repos.md)
 - `--middlewares`, `--k8s-backend-port`, `--path-prefix`,
   `--path-prefix-major-version`, and `--k8s-backend` are all used to configure
   the generated Traefik2 IngressRoutes. ie.
   ```sh
-  spk service create my-example-documents-service
+  spk service create my-example-documents-service \
     --middlewares middleware \
     --k8s-backend-port 3001 \
     --k8s-backend docs-service \

--- a/src/commands/service/create.md
+++ b/src/commands/service/create.md
@@ -1,4 +1,4 @@
-## Descripton
+## Description
 
 Add a new service into this initialized spk project repository.
 
@@ -6,12 +6,25 @@ Add a new service into this initialized spk project repository.
 
 - `--helm-chart-*` and `--helm-config-*` settings are exclusive. **You may only
   use one.**
+  - If the git repository referenced in `--helm-config-git` is a private
+    repository, you can specify an environment variable in your
+    HLD-to-Materialized pipeline containing your a PAT to authenticate with via
+    the `--helm-chart-access-token-variable` option.
+    - For more information, checkout the
+      [git authentication guide](../../../guides/auth-private-helm-repos.md)
 - `--middlewares`, `--k8s-backend-port`, `--path-prefix`,
   `--path-prefix-major-version`, and `--k8s-backend` are all used to configure
   the generated Traefik2 IngressRoutes. ie.
-  `spk service create my-example-documents-service --middlewares middlewareA --k8s-backend-port 3001 --k8s-backend docs-service --path-prefix documents --path-prefix-major-version v2`
-  will result in an IngressRoute that looks like:
+  ```sh
+  spk service create my-example-documents-service
+    --middlewares middleware \
+    --k8s-backend-port 3001 \
+    --k8s-backend docs-service \
+    --path-prefix documents \
+    --path-prefix-major-version v2
   ```
+  will result in an IngressRoute that looks like:
+  ```yaml
   apiVersion: traefik.containo.us/v1alpha1
   kind: IngressRoute
   metadata:
@@ -19,7 +32,7 @@ Add a new service into this initialized spk project repository.
   spec:
     routes:
       - kind: Rule
-        match: 'PathPrefix(`/v2/documents`) && Headers(`Ring`, `master`)'
+        match: "PathPrefix(`/v2/documents`) && Headers(`Ring`, `master`)"
         middlewares:
           - name: my-example-documents-service-master
           - name: middlewareA

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -45,6 +45,7 @@ const mockValues: ICommandValues = {
   gitPush: false,
   helmChartChart: "",
   helmChartRepository: "",
+  helmConfigAccessTokenVariable: "ACCESS_TOKEN_SECRET",
   helmConfigBranch: "",
   helmConfigGit: "",
   helmConfigPath: "",
@@ -268,6 +269,7 @@ describe("Adding a service to a repo directory", () => {
     values.packagesDir = "";
     values.k8sPort = 1337;
     values.displayName = "my-service-name";
+    values.helmConfigAccessTokenVariable = "SOME_ENV_VAR";
     const serviceName = ".";
 
     logger.info(
@@ -291,6 +293,9 @@ describe("Adding a service to a repo directory", () => {
     expect(newService).toBeDefined();
     expect(newService.k8sBackendPort).toBe(values.k8sPort);
     expect(newService.displayName).toBe(values.displayName);
+    expect((newService.helm.chart as any).accessTokenVariable).toBe(
+      values.helmConfigAccessTokenVariable
+    );
   });
 
   test("New directory is created under root directory with required service files.", async () => {

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -31,17 +31,18 @@ export interface ICommandOptions {
   gitPush: boolean;
   helmChartChart: string;
   helmChartRepository: string;
+  helmConfigAccessTokenVariable: string;
   helmConfigBranch: string;
   helmConfigGit: string;
   helmConfigPath: string;
   k8sBackend: string;
+  k8sBackendPort: string;
   maintainerEmail: string;
   maintainerName: string;
   middlewares: string;
   packagesDir: string;
   pathPrefix: string;
   pathPrefixMajorVersion: string;
-  k8sBackendPort: string;
 }
 
 export interface ICommandValues extends ICommandOptions {
@@ -70,6 +71,7 @@ export const fetchValues = (opts: ICommandOptions) => {
     gitPush: opts.gitPush,
     helmChartChart: opts.helmChartChart,
     helmChartRepository: opts.helmChartRepository,
+    helmConfigAccessTokenVariable: opts.helmConfigAccessTokenVariable,
     helmConfigBranch: opts.helmConfigBranch,
     helmConfigGit: opts.helmConfigGit,
     helmConfigPath: opts.helmConfigPath,
@@ -287,6 +289,7 @@ export const createService = async (
         }
       : {
           chart: {
+            accessTokenVariable: values.helmConfigAccessTokenVariable,
             branch: values.helmConfigBranch,
             git: values.helmConfigGit,
             path: values.helmConfigPath

--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -23,10 +23,12 @@ import {
  * Should only be used by spk hld reconcile, which is an idempotent operation, but will not overwrite existing access.yaml keys
  * @param accessYamlPath
  * @param gitRepoUrl
+ * @param accessTokenEnvVar the environment variable to which will contain the PAT
  */
 export const generateAccessYaml = (
   accessYamlPath: string,
-  gitRepoUrl: string
+  gitRepoUrl: string,
+  accessTokenEnvVar: string = "ACCESS_TOKEN_SECRET"
 ) => {
   const filePath = path.resolve(path.join(accessYamlPath, ACCESS_FILENAME));
   let accessYaml: IAccessYaml | undefined;
@@ -36,10 +38,13 @@ export const generateAccessYaml = (
       `Existing ${ACCESS_FILENAME} found at ${filePath}, loading and updating, if needed.`
     );
     accessYaml = yaml.load(fs.readFileSync(filePath, "utf8")) as IAccessYaml;
-    accessYaml = { [gitRepoUrl]: "ACCESS_TOKEN_SECRET", ...accessYaml }; // Keep any existing configurations. Do not overwrite what's in `gitRepoUrl`.
+    accessYaml = {
+      [gitRepoUrl]: accessTokenEnvVar,
+      ...accessYaml // Keep any existing configurations. Do not overwrite what's in `gitRepoUrl`.
+    };
   } else {
     accessYaml = {
-      [gitRepoUrl]: "ACCESS_TOKEN_SECRET"
+      [gitRepoUrl]: accessTokenEnvVar
     };
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -27,6 +27,7 @@ export interface IHelmConfig {
     | ({
         git: string; // git url to clone (eg; https://github.com/helm/charts.git)
         path: string; // path in the git repo to the directory containing the Chart.yaml (eg; incubator/zookeeper)
+        accessTokenVariable?: string; // environment variable containing a personal access token to authenticate against the git repository
       } & (
         | {
             sha: string; // sha to checkout (eg; 4e61eb234b0ac38956efc1b52a0455a43dba026f)


### PR DESCRIPTION
This PR adds the ability to specify an environment variable
`accessTokenVariable` per service tracked in `bedrock.yaml`. This env variable
will automatically be injected into `access.yaml` as a the holder of a PAT to
use while cloning the value specified in `--helm-config-git` in `hld reconcile`.

closes https://github.com/microsoft/bedrock/issues/914