### PR TITLE
Fix normalized name 

### DIFF
--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -741,6 +741,15 @@ describe("normalizedName", () => {
     expect(normalizedName("fabrikam.frontend")).toBe("fabrikam-frontend");
   });
 
+  it("can handle multiple occurences of invalid characters", () => {
+    expect(normalizedName("fabrikam.frontend.foo")).toBe(
+      "fabrikam-frontend-foo"
+    );
+    expect(normalizedName("fabrikam/frontend/foo")).toBe(
+      "fabrikam-frontend-foo"
+    );
+  });
+
   it("can handle combinations of slashes and periods and caps in a name", () => {
     expect(normalizedName("Fabrikam.frontend/CartService")).toBe(
       "fabrikam-frontend-cartservice"

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -77,8 +77,8 @@ export interface IReconcileDependencies {
 export const normalizedName = (name: string): string => {
   return name
     .toLowerCase()
-    .replace("/", "-")
-    .replace(".", "-");
+    .replace(/\//g, "-")
+    .replace(/\./g, "-");
 };
 
 export const execute = async (


### PR DESCRIPTION
Fixes an issue in which normalized name was only replaced the first instance of an invalid character, instead of all instances of instances of the invalid character, and adds a test