### PR TITLE
Disable static component creation when disableRouteScaffold

### DIFF
--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -549,9 +549,9 @@ describe("reconcile tests", () => {
     expect(dependencies.createServiceComponent).toHaveBeenCalledTimes(1);
     expect(dependencies.createRingComponent).toHaveBeenCalledTimes(1);
     expect(dependencies.addChartToRing).toHaveBeenCalledTimes(1);
-    expect(dependencies.createStaticComponent).toHaveBeenCalledTimes(1);
 
     // Skipping route generation.
+    expect(dependencies.createStaticComponent).toHaveBeenCalledTimes(0);
     expect(dependencies.createMiddlewareForRing).not.toHaveBeenCalled();
     expect(dependencies.createIngressRouteForRing).not.toHaveBeenCalled();
   });

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -277,12 +277,6 @@ export const reconcileHld = async (
         serviceConfig
       );
 
-      // Create config directory, create static manifest directory.
-      await dependencies.createStaticComponent(
-        dependencies.exec,
-        normalizedRingPathInHld
-      );
-
       // Service explicitly requests no ingress-routes to be generated.
       if (serviceConfig.disableRouteScaffold) {
         logger.info(
@@ -290,6 +284,12 @@ export const reconcileHld = async (
         );
         continue;
       }
+
+      // Create config directory, create static manifest directory.
+      await dependencies.createStaticComponent(
+        dependencies.exec,
+        normalizedRingPathInHld
+      );
 
       // Calculate shared path for both IngressRoute and Middleware
       const ingressVersionAndPath = getFullPathPrefix(


### PR DESCRIPTION
- When a service is `disableRouteScaffold: true`, the static component where the
  IngressRoute and Middleware was place is longer `fab add`ed

fixes https://github.com/microsoft/bedrock/issues/1115