### PR TITLE
RFC1123 Compliant DNS Routes

### DIFF
--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -755,6 +755,10 @@ describe("normalizedName", () => {
       "fabrikam-frontend-cartservice"
     );
   });
+
+  it("replaces non-(alphanumeric|dash) with dashes", () => {
+    expect(normalizedName("foo-!@#.#$%")).toBe("foo--------");
+  });
 });
 
 describe("execAndLog", () => {

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -10,6 +10,7 @@ import { assertIsStringWithContent } from "../../lib/assertions";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { generateAccessYaml } from "../../lib/fileutils";
 import { tryGetGitOrigin } from "../../lib/gitutils";
+import * as dns from "../../lib/net/dns";
 import { TraefikIngressRoute } from "../../lib/traefik/ingress-route";
 import {
   ITraefikMiddleware,
@@ -74,11 +75,13 @@ export interface IReconcileDependencies {
   createMiddlewareForRing: typeof createMiddlewareForRing;
 }
 
+/**
+ * Normalizes the provided service name to a DNS-1123 and Fabrikate command safe
+ * name.
+ * All non-alphanumerics and non-dashes are converted to dashes
+ */
 export const normalizedName = (name: string): string => {
-  return name
-    .toLowerCase()
-    .replace(/\//g, "-")
-    .replace(/\./g, "-");
+  return dns.replaceIllegalCharacters(name).replace(/\./g, "-");
 };
 
 export const execute = async (

--- a/src/lib/net/dns.test.ts
+++ b/src/lib/net/dns.test.ts
@@ -1,0 +1,73 @@
+import * as dns from "./dns";
+
+describe("containsValidCharacters", () => {
+  test("alphanumerics, dots, and dashes pass", () => {
+    expect(dns.containsValidCharacters(".string-starting.with-dot")).toBe(true);
+    expect(dns.containsValidCharacters("-string.starting-with-dash")).toBe(
+      true
+    );
+    expect(dns.containsValidCharacters("string-starting.with.dot")).toBe(true);
+    expect(dns.containsValidCharacters("string-ending.with.dot.")).toBe(true);
+    expect(dns.containsValidCharacters("string-ending.with.dash-")).toBe(true);
+    expect(dns.containsValidCharacters("string-with.with.char-x")).toBe(true);
+  });
+
+  test("non alphanumerics, non-dots, non-dashes fail", () => {
+    expect(dns.containsValidCharacters("string-with a-space")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-!")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-@")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-#")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-$")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-%")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-^")).toBe(false);
+    expect(dns.containsValidCharacters("string-with-&")).toBe(false);
+  });
+});
+
+describe("isValid", () => {
+  test("valid DNS pass", () => {
+    expect(dns.isValid("foo.com")).toBe(true);
+    expect(dns.isValid("foo.bar.baz.123.com")).toBe(true);
+    expect(dns.isValid("1.foo.bar.123")).toBe(true);
+  });
+
+  test("invalid DNS fail", () => {
+    expect(dns.isValid("$foo.com")).toBe(false);
+    expect(dns.isValid("!foo.bar.baz.123.com")).toBe(false);
+    expect(dns.isValid("%1.foo.bar.123")).toBe(false);
+    expect(dns.isValid("foo.com%")).toBe(false);
+    expect(dns.isValid("foo.bar.baz.123.com!")).toBe(false);
+    expect(dns.isValid("1.foo.bar.123#")).toBe(false);
+    expect(dns.isValid("foo/com%")).toBe(false);
+    expect(dns.isValid("foo.bar#!@#baz.123.com")).toBe(false);
+    expect(dns.isValid("1.foo*&bar.123")).toBe(false);
+  });
+});
+
+describe("replaceIllegalCharacters", () => {
+  test("all characters become lowercase", () => {
+    expect(dns.replaceIllegalCharacters("ABC")).toBe("abc");
+  });
+  test("all non-alphanumerics become dashes", () => {
+    expect(dns.replaceIllegalCharacters("a!a@a#a$a%a^a&a*a")).toBe(
+      "a-a-a-a-a-a-a-a-a"
+    );
+  });
+});
+
+describe("assertIsValid", () => {
+  test("does not throw when valid", () => {
+    expect(() => dns.assertIsValid("foo", "foo.bar.com")).not.toThrow();
+    expect(() => dns.assertIsValid("foo", "foo.bar-com")).not.toThrow();
+  });
+
+  test("throws when invalid", () => {
+    expect(() => dns.assertIsValid("foo", "-foo")).toThrow();
+    expect(() => dns.assertIsValid("foo", "_foo")).toThrow();
+    expect(() => dns.assertIsValid("foo", "foo-")).toThrow();
+    expect(() => dns.assertIsValid("foo", "foo_")).toThrow();
+    expect(() => dns.assertIsValid("foo", "invalid#dns$name")).toThrow();
+    expect(() => dns.assertIsValid("foo", "invalid/dns/name")).toThrow();
+    expect(() => dns.assertIsValid("foo", "invalid@dns%name")).toThrow();
+  });
+});

--- a/src/lib/net/dns.ts
+++ b/src/lib/net/dns.ts
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+// DNS helper functions
+//
+// Use these functions for sanitization and validation of DNS names and DNS name
+// segments.
+////////////////////////////////////////////////////////////////////////////////
+
+export const validDnsRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+
+/**
+ * Returns if the dns string `segment` is composed only of DNS compliant
+ * characters.
+ * Passing this does not make the `segment` a valid DNS name -- use isValid()
+ * for that functionality.
+ *
+ * @param segment the string to validate contains only DNS compliant characters
+ */
+export const containsValidCharacters = (segment: string): boolean => {
+  return !!segment.match(/^[0-9a-z-.]+$/);
+};
+
+/**
+ * Returns if the `dns` string provided is a valid DNS-1123 name.
+ *
+ * @param dns string to validate is a DNS compliant string
+ */
+export const isValid = (dns: string): boolean => {
+  return !!dns.match(validDnsRegex);
+};
+
+/**
+ * Makes the provided `dns` string contain only DNS-1123 compliant characters.
+ *
+ * - All characters are converted to lower case
+ * - All non-alphanumerics, non-dashes ('-'), and non-dots ('.') are converted
+ *   to dashes ('-')
+ *
+ * @param dns the dns string to replace all illegal characters from
+ */
+export const replaceIllegalCharacters = (dns: string): string => {
+  return dns.toLowerCase().replace(/[^0-9a-z-.]/g, "-");
+};
+
+/**
+ * Asserts that the provided `dns` is a valid RFC1123 name/value.
+ * @throws {Error} when `dns` is not RFC1123 compliant
+ *
+ * @params fieldName the name of thing being validated, used to create Error
+ *         message
+ * @params dns to validate
+ */
+export function assertIsValid(
+  fieldName: string,
+  dns: string
+): asserts dns is string {
+  if (!isValid(dns)) {
+    throw Error(
+      `Invalid ${fieldName} '${dns}' provided for Traefik IngressRoute. Must be RFC1123 compliant and match regex: ${validDnsRegex}`
+    );
+  }
+}

--- a/src/lib/traefik/ingress-route.test.ts
+++ b/src/lib/traefik/ingress-route.test.ts
@@ -1,4 +1,4 @@
-import uuid from "uuid/v4";
+import uuid = require("uuid/v4");
 import { TraefikIngressRoute } from "./ingress-route";
 
 describe("TraefikIngressRoute", () => {
@@ -158,5 +158,36 @@ describe("TraefikIngressRoute", () => {
     expect(routeWithRing.spec.routes[0].match).toBe(
       "PathPrefix(`/version/and/Path`) && Headers(`Ring`, `prod`)"
     );
+  });
+
+  test("does not throw when meta.name and spec.routes[].services[].name is valid", () => {
+    expect(() =>
+      TraefikIngressRoute("valid-service", "valid-ring", 80, "v1")
+    ).not.toThrow();
+    expect(() =>
+      TraefikIngressRoute("valid-service", "valid-ring", 80, "v1", {
+        k8sBackend: "my.valid.service"
+      })
+    ).not.toThrow();
+  });
+
+  test("throws when meta.name is invalid", () => {
+    expect(() =>
+      TraefikIngressRoute("-invalid-serivce&name", "valid-ring", 80, "v1")
+    ).toThrow();
+    expect(() =>
+      TraefikIngressRoute("valid-service-name", "invalid-ring-!@#", 80, "v1")
+    ).toThrow();
+  });
+
+  test("throws when spec.routes[].services[].name is invalid", () => {
+    expect(() =>
+      TraefikIngressRoute("-invalid-service", "valid-ring", 80, "v1")
+    ).toThrow();
+    expect(() =>
+      TraefikIngressRoute("valid-service", "valid-ring", 80, "v1", {
+        k8sBackend: "-invalid"
+      })
+    ).toThrow();
   });
 });

--- a/src/lib/traefik/ingress-route.ts
+++ b/src/lib/traefik/ingress-route.ts
@@ -1,3 +1,5 @@
+import * as dns from "../net/dns";
+
 type TraefikEntryPoints = Array<"web" | "web-secure">; // web === 80; web-secure === 443;
 
 /**
@@ -46,6 +48,9 @@ interface ITraefikIngressRoute {
  *
  * If `ringName` is an empty string, the header match rule is not included.
  *
+ * @throws {Error} when meta.name or any spec.routes[].service[].name are not
+ *                 RFC1123 compliant
+ *
  * @param serviceName name of the service to create the IngressRoute for
  * @param ringName name of the ring to which the service belongs
  * @param opts options to specify the manifest namespace, IngressRoute entryPoints, pathPrefix, backend service, and version
@@ -73,6 +78,10 @@ export const TraefikIngressRoute = (
 
   const backendService =
     k8sBackend && ringName ? `${k8sBackend}-${ringName}` : name;
+
+  // validate fields
+  dns.assertIsValid("metadata.name", name);
+  dns.assertIsValid("spec.routes[].services[].name", backendService);
 
   return {
     apiVersion: "traefik.containo.us/v1alpha1",


### PR DESCRIPTION
- `spk hld reconcile` now generates RFC1123 compliant parameters for the
  generated Treafik IngressRoutes.
- `TraefikIngressRoute()` now throws when any combination of `ring`
  `serviceName` or `k8sBackend` generate a non RFC1123 compliant DNS name.

fixes https://github.com/microsoft/bedrock/issues/1103