### PR TITLE
Exit on invalid DNS user input

### DIFF
--- a/src/commands/ring/create.test.ts
+++ b/src/commands/ring/create.test.ts
@@ -4,6 +4,7 @@ import {
 } from "../../lib/bedrockYaml";
 import * as fileUtils from "../../lib/fileutils";
 import { createTempDir } from "../../lib/ioUtil";
+import * as dns from "../../lib/net/dns";
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 import { IBedrockFile } from "../../types";
 import { checkDependencies, execute } from "./create";
@@ -60,9 +61,19 @@ describe("test execute function and logic", () => {
     expect(exitFn).toBeCalledTimes(1);
     expect(exitFn.mock.calls).toEqual([[1]]);
   });
+  it("test execute function: invalid ring input", async () => {
+    const exitFn = jest.fn();
+    jest.spyOn(dns, "assertIsValid");
+    await execute("-not!dns@compliant%", "someprojectpath", exitFn);
+    expect(dns.assertIsValid).toHaveReturnedTimes(0); // should never return because it throws
+    expect(exitFn).toBeCalledTimes(1);
+    expect(exitFn.mock.calls).toEqual([[1]]);
+  });
   it("test execute function: missing project path", async () => {
     const exitFn = jest.fn();
+    jest.spyOn(dns, "assertIsValid");
     await execute("ring", "", exitFn);
+    expect(dns.assertIsValid).toHaveReturnedTimes(1);
     expect(exitFn).toBeCalledTimes(1);
     expect(exitFn.mock.calls).toEqual([[1]]);
   });

--- a/src/commands/ring/create.ts
+++ b/src/commands/ring/create.ts
@@ -10,6 +10,7 @@ import {
   PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE
 } from "../../lib/constants";
 import { updateTriggerBranchesForServiceBuildAndUpdatePipeline } from "../../lib/fileutils";
+import * as dns from "../../lib/net/dns";
 import { hasValue } from "../../lib/validator";
 import { logger } from "../../logger";
 import { IBedrockFile, IBedrockFileInfo } from "../../types";
@@ -35,6 +36,7 @@ export const execute = async (
   try {
     logger.info(`Project path: ${projectPath}`);
 
+    dns.assertIsValid("<ring-name>", ringName);
     checkDependencies(projectPath, ringName);
 
     // Add ring to bedrock.yaml

--- a/src/lib/net/dns.ts
+++ b/src/lib/net/dns.ts
@@ -55,7 +55,7 @@ export function assertIsValid(
 ): asserts dns is string {
   if (!isValid(dns)) {
     throw Error(
-      `Invalid ${fieldName} '${dns}' provided for Traefik IngressRoute. Must be RFC1123 compliant and match regex: ${validDnsRegex}`
+      `Invalid ${fieldName} '${dns}' provided. Must be RFC1123 compliant and match regex: ${validDnsRegex}`
     );
   }
 }


### PR DESCRIPTION
- `spk service create` and `spk ring create` now log an error and exit when any
  arguments are inputted which are not RFC1123 compliant.
  - The checks only occur when the input has been explicitly passed by the user
    (i.e. not `undefined` or `""`)

fixes https://github.com/microsoft/bedrock/issues/1128