### PR TITLE
Fix broken cd in pipeline

### DIFF
--- a/src/lib/fileutils.ts
+++ b/src/lib/fileutils.ts
@@ -136,6 +136,9 @@ export const serviceBuildAndUpdatePipeline = (
   variableGroups?: string[]
 ): AzurePipelinesYaml => {
   const relativeServicePathFormatted = sanitizeTriggerPath(relServicePath);
+  const relativeServiceForDockerfile = relServicePath.startsWith("./")
+    ? relServicePath
+    : "./" + relServicePath;
 
   const pipelineYaml: AzurePipelinesYaml = {
     trigger: {
@@ -206,7 +209,7 @@ export const serviceBuildAndUpdatePipeline = (
                   `export IMAGE_TAG=${IMAGE_TAG}`,
                   `export IMAGE_NAME=$BUILD_REPO_NAME:$IMAGE_TAG`,
                   `echo "Image Name: $IMAGE_NAME"`,
-                  `cd ${relativeServicePathFormatted}`,
+                  `cd ${relativeServiceForDockerfile}`,
                   `echo "az acr build -r $(ACR_NAME) --image $IMAGE_NAME ."`,
                   `az acr build -r $(ACR_NAME) --image $IMAGE_NAME .`
                 ]),

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -23,6 +23,12 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
   ringBranches: string[] = ["master", "qa", "test"],
   variableGroups: string[] = []
 ): AzurePipelinesYaml | string => {
+  const relativeServiceForDockerfile = relativeServicePathFormatted.startsWith(
+    "./"
+  )
+    ? relativeServicePathFormatted
+    : "./" + relativeServicePathFormatted;
+
   const data: AzurePipelinesYaml = {
     trigger: {
       branches: { include: ringBranches },
@@ -90,7 +96,7 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
                   `export IMAGE_TAG=${IMAGE_TAG}`,
                   `export IMAGE_NAME=$BUILD_REPO_NAME:$IMAGE_TAG`,
                   `echo "Image Name: $IMAGE_NAME"`,
-                  `cd ${sanitizeTriggerPath(relativeServicePathFormatted)}`,
+                  `cd ${relativeServiceForDockerfile}`,
                   `echo "az acr build -r $(ACR_NAME) --image $IMAGE_NAME ."`,
                   `az acr build -r $(ACR_NAME) --image $IMAGE_NAME .`
                 ]),


### PR DESCRIPTION
Fixes https://github.com/microsoft/bedrock/issues/1191 by changing the `cd` invocation back to its original form - leaves the triggers the way they were.