### PR TITLE
Dev Tools Upgrades

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,15 @@
 module.exports = {
   root: true,
+  env: {
+    node: true,
+  },
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended"
-  ]
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "prettier/@typescript-eslint",
+  ],
 };

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,10 +6,10 @@ pr:
 
 strategy:
   matrix:
-    node_10_x:
-      node_version: 10.x
     node_12_x:
       node_version: 12.x
+    node_13_x:
+      node_version: 13.x
   maxParallel: 2
 
 pool:
@@ -55,7 +55,7 @@ steps:
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/junit.xml' 
+      testResultsFiles: '**/junit.xml'
     condition: and(eq(variables['Agent.JobStatus'], 'Succeeded'), endsWith(variables['Agent.JobName'], 'node_12_x'))
 
   - task: PublishPipelineArtifact@1
@@ -67,7 +67,7 @@ steps:
   - bash: |
       [ -z "$COVERAGE_VARIANCE" ] && { echo "Missing COVERAGE_VARIANCE variable"; exit 1; }
       echo "Code coverage variance value is: $COVERAGE_VARIANCE"
-    displayName: 'Build quality pre-validation'  
+    displayName: 'Build quality pre-validation'
     failOnStderr: true
     env:
         COVERAGE_VARIANCE: $(COVERAGE_VARIANCE)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "shx rm -rf dist && webpack && pkg -t node12-linux-x64,node12-macos-x64,node12-win-x64 dist/spk.js && shx mv spk-{linux,macos,win.exe} dist",
     "build-cmd-docs": "ts-node tools/generateDoc.ts",
     "lint": "eslint 'src/**/*.ts{,x}'",
-    "lint-fix": "tslint --fix 'src/**/*.ts{,x}'",
+    "lint-fix": "eslint --fix 'src/**/*.ts{,x}'",
+    "format": "prettier --write 'src/**/*.ts{,x}'",
     "test": "jest --rootDir src --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --coverageReporters=html",
     "test-watch": "jest --watchAll",
     "postinstall": "cd node_modules/azure-devops-node-api && git apply ../../patches/001-azure-devops-node.patch || true",
@@ -29,24 +30,25 @@
     "@types/node-emoji": "^1.8.1",
     "@types/shelljs": "^0.8.5",
     "@types/uuid": "^3.4.5",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.24.0",
+    "@typescript-eslint/parser": "^2.24.0",
     "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
     "husky": ">=1",
-    "jest": "^24.9.0",
-    "jest-junit": "^9.0.0",
+    "jest": "^25.1.0",
+    "jest-junit": "^10.0.0",
     "jest-when": "^2.7.0",
-    "lint-staged": ">=8",
+    "lint-staged": ">=10",
     "mock-fs": "^4.10.2",
     "nyc": "^14.1.1",
     "pkg": "^4.4.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.1",
     "shx": "^0.3.2",
-    "ts-jest": "^24.2.0",
-    "ts-loader": "^6.2.1",
-    "ts-node": "^8.5.4",
+    "ts-jest": "^25.2.1",
+    "ts-loader": "^6.2.2",
+    "ts-node": "^8.8.1",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.7.4",
+    "typescript": "^3.8.3",
     "url-loader": "^3.0.0",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.9"
@@ -60,10 +62,10 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,css,json,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ],
+    "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"
   },
   "dependencies": {
     "@azure/arm-containerregistry": "^7.0.0",

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -84,11 +84,11 @@ export const Command = (
   }
 
   // Catch-all for unknown commands
-  cmd.on("command:*", calledCmd => {
+  cmd.on("command:*", (calledCmd) => {
     logger.error(`Unknown command "${calledCmd}"`);
     cmd.outputHelp();
   });
-  cmd.on("option:*", unknownOption => {
+  cmd.on("option:*", (unknownOption) => {
     logger.error(`Unknown option "${unknownOption}"`);
   });
 
@@ -96,7 +96,7 @@ export const Command = (
     command: cmd,
     description,
     name: name.toLowerCase(),
-    subCommands
+    subCommands,
   });
 };
 
@@ -125,7 +125,7 @@ const decrementArgv = (argv: string[]): string[] => {
 export const executeCommand = (cmd: Command, argv: string[]): void => {
   const targetCommandName = argv.slice(2, 3)[0];
   const targetCommand = cmd.subCommands.find(
-    sc => sc.name === targetCommandName
+    (sc) => sc.name === targetCommandName
   );
 
   // If the the next argument matches against a sub-command, recur into it.

--- a/src/commands/deployment/create.test.ts
+++ b/src/commands/deployment/create.test.ts
@@ -27,7 +27,7 @@ const MOCKED_VALS: CommandOptions = {
   pr: undefined,
   repository: undefined,
   service: undefined,
-  tableName: undefined
+  tableName: undefined,
 };
 
 const getMockedValues = (withKeyValue = false): CommandOptions => {
@@ -72,7 +72,7 @@ describe("test execute function", () => {
         commitId: uuid(),
         imageTag: uuid(),
         p1: uuid(),
-        service: uuid()
+        service: uuid(),
       })
     );
     const exitFn = jest.fn();
@@ -122,7 +122,7 @@ describe("test execute function", () => {
         imageTag: uuid(),
         p1: uuid(),
         p2: uuid(),
-        service: uuid()
+        service: uuid(),
       })
     );
     const exitFn = jest.fn();
@@ -165,7 +165,7 @@ describe("test execute function", () => {
         p1: uuid(),
         p2: uuid(),
         p3: uuid(),
-        service: uuid()
+        service: uuid(),
       })
     );
     const exitFn = jest.fn();
@@ -205,7 +205,7 @@ describe("test execute function", () => {
         p1: uuid(),
         p2: uuid(),
         p3: uuid(),
-        service: uuid()
+        service: uuid(),
       })
     );
     const exitFn = jest.fn();

--- a/src/commands/deployment/create.ts
+++ b/src/commands/deployment/create.ts
@@ -4,7 +4,7 @@ import {
   DeploymentTable,
   updateACRToHLDPipeline,
   updateHLDToManifestPipeline,
-  updateManifestCommitId
+  updateManifestCommitId,
 } from "../../lib/azure/deploymenttable";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { hasValue } from "../../lib/validator";
@@ -121,7 +121,7 @@ export const execute = async (
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       partitionKey: opts.partitionKey!,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      tableName: opts.tableName!
+      tableName: opts.tableName!,
     };
 
     if (hasValue(opts.p1)) {

--- a/src/commands/deployment/dashboard.test.ts
+++ b/src/commands/deployment/dashboard.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
 jest.mock("open");
 import open from "open";
 jest.mock("../../config");
@@ -7,14 +9,14 @@ import { validatePrereqs } from "../../lib/validator";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import {
   execute,
   extractManifestRepositoryInformation,
   getEnvVars,
   launchDashboard,
-  validateValues
+  validateValues,
 } from "./dashboard";
 import * as dashboard from "./dashboard";
 
@@ -30,20 +32,20 @@ afterAll(() => {
 
 const mockConfig = (): void => {
   (Config as jest.Mock).mockReturnValueOnce({
-    "azure_devops": {
-      "access_token": uuid(),
+    azure_devops: {
+      access_token: uuid(),
       org: uuid(),
-      project: uuid()
+      project: uuid(),
     },
     introspection: {
       azure: {
-        "account_name": uuid(),
+        account_name: uuid(),
         key: uuid(),
-        "partition_key": uuid(),
-        "source_repo_access_token": "test_token",
-        "table_name": uuid()
-      }
-    }
+        partition_key: uuid(),
+        source_repo_access_token: "test_token",
+        table_name: uuid(),
+      },
+    },
   });
 };
 
@@ -53,7 +55,7 @@ describe("Test validateValues function", () => {
     try {
       validateValues(config, {
         port: "abc",
-        removeAll: false
+        removeAll: false,
       });
       expect(true).toBe(false);
     } catch (e) {
@@ -68,7 +70,7 @@ describe("Test validateValues function", () => {
         {},
         {
           port: "4000",
-          removeAll: false
+          removeAll: false,
         }
       );
       expect(true).toBe(false);
@@ -83,7 +85,7 @@ describe("Test validateValues function", () => {
     const config = Config();
     validateValues(config, {
       port: "4000",
-      removeAll: false
+      removeAll: false,
     });
   });
 });
@@ -100,7 +102,7 @@ describe("Test execute function", () => {
     await execute(
       {
         port: "4000",
-        removeAll: false
+        removeAll: false,
       },
       exitFn
     );
@@ -112,7 +114,7 @@ describe("Test execute function", () => {
     await execute(
       {
         port: "4000",
-        removeAll: false
+        removeAll: false,
       },
       exitFn
     );
@@ -133,7 +135,7 @@ describe("Validate dashboard container pull", () => {
           "images",
           "-q",
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          config.introspection!.dashboard!.image!
+          config.introspection!.dashboard!.image!,
         ]);
         expect(dockerId).toBeDefined();
         expect(dashboardContainerId).not.toBe("");
@@ -160,7 +162,7 @@ describe("Validate dashboard clean up", () => {
           "images",
           "-q",
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          config.introspection!.dashboard!.image!
+          config.introspection!.dashboard!.image!,
         ]);
 
         expect(dockerId).toBeDefined();
@@ -208,10 +210,10 @@ describe("Fallback to azure devops access token", () => {
 describe("Extract manifest repository information", () => {
   test("Manifest repository information is successfully extracted", () => {
     (Config as jest.Mock).mockReturnValue({
-      "azure_devops": {
-        "manifest_repository":
-          "https://dev.azure.com/bhnook/fabrikam/_git/materialized"
-      }
+      azure_devops: {
+        manifest_repository:
+          "https://dev.azure.com/bhnook/fabrikam/_git/materialized",
+      },
     });
     const config = Config();
     let manifestInfo = extractManifestRepositoryInformation(config);

--- a/src/commands/deployment/dashboard.ts
+++ b/src/commands/deployment/dashboard.ts
@@ -69,7 +69,7 @@ export const cleanDashboardContainers = async (
     "-q",
     "--filter",
     "ancestor=" + config.introspection!.dashboard!.image!,
-    '--format="{{.ID}}"'
+    '--format="{{.ID}}"',
   ]);
   if (dockerOutput.length > 0) {
     dockerOutput = dockerOutput.replace(/\n/g, " ");
@@ -99,11 +99,11 @@ export const extractManifestRepositoryInformation = (
     if (gitComponents.resource === "github.com") {
       return {
         githubUsername: gitComponents.organization,
-        manifestRepoName
+        manifestRepoName,
       };
     } else {
       return {
-        manifestRepoName
+        manifestRepoName,
       };
     }
   }
@@ -218,7 +218,7 @@ export const launchDashboard = async (
       ...(await getEnvVars(config)),
       "-p",
       port + ":5000",
-      dockerRepository
+      dockerRepository,
     ]);
     return containerId;
   } catch (err) {

--- a/src/commands/deployment/get.test.ts
+++ b/src/commands/deployment/get.test.ts
@@ -10,7 +10,7 @@ import { deepClone } from "../../lib/util";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import {
   execute,
@@ -25,7 +25,7 @@ import {
   printDeployments,
   processOutputFormat,
   validateValues,
-  watchGetDeployments
+  watchGetDeployments,
 } from "./get";
 import * as get from "./get";
 
@@ -38,7 +38,7 @@ const MOCKED_INPUT_VALUES: CommandOptions = {
   output: "",
   service: "",
   top: "",
-  watch: false
+  watch: false,
 };
 
 const MOCKED_VALUES: ValidatedOptions = {
@@ -52,7 +52,7 @@ const MOCKED_VALUES: ValidatedOptions = {
   outputFormat: OUTPUT_FORMAT.NORMAL,
   service: "",
   top: "",
-  watch: false
+  watch: false,
 };
 
 const getMockedInputValues = (): CommandOptions => {
@@ -81,7 +81,7 @@ const mockedDeps: IDeployment[] = fakeDeployments.data.map(
       manifestCommitId: dep.manifestCommitId,
       service: dep.service,
       srcToDockerBuild: dep.srcToDockerBuild,
-      timeStamp: dep.timeStamp
+      timeStamp: dep.timeStamp,
     };
   }
 );
@@ -325,10 +325,10 @@ describe("Print deployments", () => {
       "✓",
       6047,
       "✓",
-      "EUROPE"
+      "EUROPE",
     ];
 
-    const matchItems = table!.filter(field => field[2] === deployment[2]);
+    const matchItems = table!.filter((field) => field[2] === deployment[2]);
     expect(matchItems).toHaveLength(1); // one matching row
 
     (matchItems[0] as IDeployment[]).forEach((field, i) => {
@@ -379,7 +379,7 @@ describe("Output formats", () => {
       mockedClusterSyncs
     );
     expect(table).not.toBeUndefined();
-    table!.forEach(field => {
+    table!.forEach((field) => {
       expect(field).toHaveLength(18);
     });
   });

--- a/src/commands/deployment/get.ts
+++ b/src/commands/deployment/get.ts
@@ -6,16 +6,16 @@ import {
   duration,
   getDeploymentsBasedOnFilters,
   IDeployment,
-  status as getDeploymentStatus
+  status as getDeploymentStatus,
 } from "spektate/lib/IDeployment";
 import AzureDevOpsPipeline from "spektate/lib/pipeline/AzureDevOpsPipeline";
 import {
   getManifestSyncState as getAzureManifestSyncState,
-  IAzureDevOpsRepo
+  IAzureDevOpsRepo,
 } from "spektate/lib/repository/IAzureDevOpsRepo";
 import {
   getManifestSyncState as getGithubManifestSyncState,
-  IGitHub
+  IGitHub,
 } from "spektate/lib/repository/IGitHub";
 import { ITag } from "spektate/lib/repository/Tag";
 import { Config } from "../../config";
@@ -31,7 +31,7 @@ import decorator from "./get.decorator.json";
 export enum OUTPUT_FORMAT {
   NORMAL = 0, // normal format
   WIDE = 1, // Wide table format
-  JSON = 2
+  JSON = 2,
 }
 
 /**
@@ -99,7 +99,7 @@ export const validateValues = (opts: CommandOptions): ValidatedOptions => {
     outputFormat: processOutputFormat(opts.output),
     service: opts.service,
     top: opts.top,
-    watch: opts.watch
+    watch: opts.watch,
   };
 };
 
@@ -200,7 +200,7 @@ export const getDeployments = (
           resolve(deployments);
         }
       })
-      .catch(e => {
+      .catch((e) => {
         reject(new Error(e));
       });
   });
@@ -226,7 +226,7 @@ export const getClusterSyncStatuses = (
         const manifestRepo: IAzureDevOpsRepo = {
           org: manifestUrlSplit[3],
           project: manifestUrlSplit[4],
-          repo: manifestUrlSplit[6]
+          repo: manifestUrlSplit[6],
         };
         getAzureManifestSyncState(
           manifestRepo,
@@ -235,7 +235,7 @@ export const getClusterSyncStatuses = (
           .then((syncCommits: ITag[]) => {
             resolve(syncCommits);
           })
-          .catch(e => {
+          .catch((e) => {
             reject(e);
           });
       } else if (
@@ -247,7 +247,7 @@ export const getClusterSyncStatuses = (
         );
         const manifestRepo: IGitHub = {
           reponame: manifestUrlSplit[4],
-          username: manifestUrlSplit[3]
+          username: manifestUrlSplit[3],
         };
 
         getGithubManifestSyncState(
@@ -257,7 +257,7 @@ export const getClusterSyncStatuses = (
           .then((syncCommits: ITag[]) => {
             resolve(syncCommits);
           })
-          .catch(e => {
+          .catch((e) => {
             reject(e);
           });
       } else {
@@ -314,7 +314,7 @@ export const initialize = async (): Promise<InitObject> => {
       config.azure_devops.project,
       false,
       config.azure_devops.access_token
-    )
+    ),
   };
 };
 
@@ -363,14 +363,14 @@ export const printDeployments = (
       "Hld Commit",
       "Result",
       "HLD to Manifest",
-      "Result"
+      "Result",
     ];
     if (outputFormat === OUTPUT_FORMAT.WIDE) {
       header = header.concat([
         "Duration",
         "Status",
         "Manifest Commit",
-        "End Time"
+        "End Time",
       ]);
     }
     if (syncStatuses && syncStatuses.length > 0) {
@@ -394,14 +394,14 @@ export const printDeployments = (
         "mid-mid": "",
         right: "",
         "right-mid": "",
-        middle: " "
+        middle: " ",
       },
-      style: { "padding-left": 0, "padding-right": 0 }
+      style: { "padding-left": 0, "padding-right": 0 },
     });
 
     const toDisplay = limit ? deployments.slice(0, limit) : deployments;
 
-    toDisplay.forEach(deployment => {
+    toDisplay.forEach((deployment) => {
       const row = [];
       row.push(
         deployment.srcToDockerBuild
@@ -496,7 +496,7 @@ export const getClusterSyncStatusForDeployment = (
   deployment: IDeployment,
   syncStatuses: ITag[]
 ): ITag | undefined => {
-  return syncStatuses.find(tag => tag.commit === deployment.manifestCommitId);
+  return syncStatuses.find((tag) => tag.commit === deployment.manifestCommitId);
 };
 
 /**

--- a/src/commands/deployment/index.ts
+++ b/src/commands/deployment/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["create", "dashboard", "get", "onboard", "validate"];
 export const commandDecorator = Command(
   "deployment",
   "Introspect your deployments",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/deployment/onboard.test.ts
+++ b/src/commands/deployment/onboard.test.ts
@@ -12,7 +12,7 @@ import { deepClone } from "../../lib/util";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import { AzureAccessOpts, ConfigYaml } from "../../types";
 import {
@@ -26,7 +26,7 @@ import {
   validateAndCreateStorageAccount,
   validateStorageName,
   validateTableName,
-  validateValues
+  validateValues,
 } from "./onboard";
 import * as onboardImpl from "./onboard";
 
@@ -47,7 +47,7 @@ const MOCKED_VALUES: CommandOptions = {
   storageResourceGroupName: "testResourceGroup",
   storageTableName: "testtable",
   subscriptionId: "subscriptionId",
-  tenantId: "tenantId"
+  tenantId: "tenantId",
 };
 
 const randomTmpDir = createTempDir();
@@ -62,7 +62,7 @@ const getMockedAccessOpts = (values: CommandOptions): AzureAccessOpts => {
     servicePrincipalId: values.servicePrincipalId,
     servicePrincipalPassword: values.servicePrincipalPassword,
     subscriptionId: values.subscriptionId,
-    tenantId: values.tenantId
+    tenantId: values.tenantId,
   };
 };
 
@@ -78,9 +78,9 @@ const testPopulatedVal = (
   const configYaml: ConfigYaml = {
     introspection: {
       azure: {
-        key: "key"
-      }
-    }
+        key: "key",
+      },
+    },
   };
   configFn(configYaml);
   jest.spyOn(config, "Config").mockReturnValueOnce(configYaml);
@@ -116,7 +116,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.storageAccountName = undefined;
       },
-      values => {
+      (values) => {
         expect(values.storageAccountName).toBe("AccountName");
       }
     );
@@ -129,7 +129,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.storageTableName = undefined;
       },
-      values => {
+      (values) => {
         expect(values.storageTableName).toBe("TableName");
       }
     );
@@ -142,7 +142,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.keyVaultName = undefined;
       },
-      values => {
+      (values) => {
         expect(values.keyVaultName).toBe("KeyVaulteName");
       }
     );
@@ -156,7 +156,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.servicePrincipalId = undefined;
       },
-      values => {
+      (values) => {
         expect(values.servicePrincipalId).toBe("ServicePrincipalId");
       }
     );
@@ -170,7 +170,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.servicePrincipalPassword = undefined;
       },
-      values => {
+      (values) => {
         expect(values.servicePrincipalPassword).toBe("ServicePrincipalSecret");
       }
     );
@@ -183,7 +183,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.tenantId = undefined;
       },
-      values => {
+      (values) => {
         expect(values.tenantId).toBe("tenantId");
       }
     );
@@ -196,7 +196,7 @@ describe("test populateValues", () => {
       (values: CommandOptions) => {
         values.subscriptionId = undefined;
       },
-      values => {
+      (values) => {
         expect(values.subscriptionId).toBe("subscriptionId");
       }
     );
@@ -390,9 +390,9 @@ describe("onboard", () => {
       introspection: {
         azure: {
           account_name: "testAccount",
-          table_name: "testTable"
-        }
-      }
+          table_name: "testTable",
+        },
+      },
     };
 
     fs.writeFileSync(testConfigFile, yaml.safeDump(data));
@@ -406,9 +406,9 @@ describe("setConfiguration", () => {
       introspection: {
         azure: {
           account_name: "test-storage",
-          table_name: "test-table"
-        }
-      }
+          table_name: "test-table",
+        },
+      },
     };
 
     // create config file in test location
@@ -429,8 +429,8 @@ describe("setConfiguration", () => {
   test("Should pass updating previous undefined storage account and table names", () => {
     const data = {
       introspection: {
-        azure: {}
-      }
+        azure: {},
+      },
     };
 
     // create config file in test location

--- a/src/commands/deployment/onboard.ts
+++ b/src/commands/deployment/onboard.ts
@@ -10,12 +10,12 @@ import {
   createStorageAccount,
   createTableIfNotExists,
   getStorageAccountKey,
-  isStorageAccountExist
+  isStorageAccountExist,
 } from "../../lib/azure/storage";
 import {
   build as buildCmd,
   exit as exitCmd,
-  validateForRequiredValues
+  validateForRequiredValues,
 } from "../../lib/commandBuilder";
 import { logger } from "../../logger";
 import { AzureAccessOpts, ConfigYaml } from "../../types";
@@ -92,7 +92,7 @@ export const validateValues = (opts: CommandOptions): void => {
     storageResourceGroupName: opts.storageResourceGroupName,
     storageTableName: opts.storageTableName,
     subscriptionId: opts.subscriptionId,
-    tenantId: opts.tenantId
+    tenantId: opts.tenantId,
   });
   if (errors.length > 0) {
     throw new Error("Required values are missing");
@@ -123,7 +123,7 @@ export const setConfiguration = (
     const data = readYaml<ConfigYaml>(defaultConfigFile());
     if (!data.introspection) {
       data.introspection = {
-        azure: {}
+        azure: {},
       };
     } else if (!data.introspection.azure) {
       data.introspection.azure = {};
@@ -257,7 +257,7 @@ export const onboard = async (
     servicePrincipalId: values.servicePrincipalId,
     servicePrincipalPassword: values.servicePrincipalPassword,
     subscriptionId: values.subscriptionId,
-    tenantId: values.tenantId
+    tenantId: values.tenantId,
   };
 
   const storageAccount = await validateAndCreateStorageAccount(

--- a/src/commands/deployment/validate.test.ts
+++ b/src/commands/deployment/validate.test.ts
@@ -6,7 +6,7 @@ import {
   RowACRToHLDPipeline,
   RowHLDToManifestPipeline,
   RowManifest,
-  RowSrcToACRPipeline
+  RowSrcToACRPipeline,
 } from "../../lib/azure/deploymenttable";
 import * as storage from "../../lib/azure/storage";
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
@@ -16,7 +16,7 @@ import {
   execute,
   isValidConfig,
   runSelfTest,
-  writeSelfTestData
+  writeSelfTestData,
 } from "./validate";
 import * as validate from "./validate";
 
@@ -56,8 +56,8 @@ let mockedDB: Array<
 jest.spyOn(deploymenttable, "findMatchingDeployments").mockImplementation(
   (): Promise<RowSrcToACRPipeline[]> => {
     const array: RowSrcToACRPipeline[] = [];
-    return new Promise(resolve => {
-      mockedDB.forEach(row => {
+    return new Promise((resolve) => {
+      mockedDB.forEach((row) => {
         if (row.p1 === "500") {
           array.push(row);
         }
@@ -78,7 +78,7 @@ jest
         | RowHLDToManifestPipeline
     ) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return new Promise<any>(resolve => {
+      return new Promise<any>((resolve) => {
         mockedDB.push(entry);
         resolve(entry);
       });
@@ -87,7 +87,7 @@ jest
 
 jest.spyOn(deploymenttable, "deleteFromTable").mockImplementation(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new Promise<any>(resolve => {
+  return new Promise<any>((resolve) => {
     if (mockedDB.length === 1 && mockedDB[0].p1 === "500") {
       mockedDB = [];
     }
@@ -107,7 +107,7 @@ jest
         | RowManifest
     ) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return new Promise<any>(resolve => {
+      return new Promise<any>((resolve) => {
         mockedDB.forEach((row, index: number) => {
           if (row.RowKey === entry.RowKey) {
             mockedDB[index] = entry;
@@ -136,16 +136,16 @@ describe("Validate deployment configuration", () => {
     const config: ConfigYaml = {
       azure_devops: {
         org: uuid(),
-        project: uuid()
+        project: uuid(),
       },
       introspection: {
         azure: {
           account_name: uuid(),
           key: uuid(),
           partition_key: uuid(),
-          table_name: uuid()
-        }
-      }
+          table_name: uuid(),
+        },
+      },
     };
     await isValidConfig(config);
   });
@@ -159,7 +159,7 @@ describe("test execute function", () => {
     const exitFn = jest.fn();
     await execute(
       {
-        selfTest: false
+        selfTest: false,
       },
       exitFn
     );
@@ -174,7 +174,7 @@ describe("test execute function", () => {
     const exitFn = jest.fn();
     await execute(
       {
-        selfTest: true
+        selfTest: true,
       },
       exitFn
     );
@@ -188,7 +188,7 @@ describe("test execute function", () => {
     const exitFn = jest.fn();
     await execute(
       {
-        selfTest: true
+        selfTest: true,
       },
       exitFn
     );
@@ -210,9 +210,9 @@ describe("test runSelfTest function", () => {
       introspection: {
         azure: {
           key: uuid(),
-          table_name: undefined
-        }
-      }
+          table_name: undefined,
+        },
+      },
     };
 
     await runSelfTest(config);
@@ -229,9 +229,9 @@ describe("test runSelfTest function", () => {
       introspection: {
         azure: {
           key: uuid(),
-          table_name: undefined
-        }
-      }
+          table_name: undefined,
+        },
+      },
     };
     await runSelfTest(config);
   });
@@ -244,9 +244,9 @@ describe("test runSelfTest function", () => {
       introspection: {
         azure: {
           key: uuid(),
-          table_name: undefined
-        }
-      }
+          table_name: undefined,
+        },
+      },
     };
     await expect(runSelfTest(config)).rejects.toThrow();
   });
@@ -255,7 +255,7 @@ describe("test runSelfTest function", () => {
 describe("Validate missing deployment configuration", () => {
   test("no deployment configuration", async () => {
     const config: ConfigYaml = {
-      introspection: undefined
+      introspection: undefined,
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -265,8 +265,8 @@ describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage", async () => {
     const config: ConfigYaml = {
       introspection: {
-        azure: undefined
-      }
+        azure: undefined,
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -278,9 +278,9 @@ describe("Validate missing deployment.storage configuration", () => {
       introspection: {
         azure: {
           account_name: undefined,
-          key: uuid()
-        }
-      }
+          key: uuid(),
+        },
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -292,9 +292,9 @@ describe("Validate missing deployment.storage configuration", () => {
       introspection: {
         azure: {
           key: uuid(),
-          table_name: undefined
-        }
-      }
+          table_name: undefined,
+        },
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -306,9 +306,9 @@ describe("Validate missing deployment.storage configuration", () => {
       introspection: {
         azure: {
           key: uuid(),
-          partition_key: undefined
-        }
-      }
+          partition_key: undefined,
+        },
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -318,8 +318,8 @@ describe("Validate missing deployment.storage configuration", () => {
   test("missing deployment.storage.key configuration", async () => {
     const config: ConfigYaml = {
       introspection: {
-        azure: {}
-      }
+        azure: {},
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -329,8 +329,8 @@ describe("Validate missing deployment.pipeline configuration", () => {
   test("missing deployment.pipeline configuration", async () => {
     const config: ConfigYaml = {
       introspection: {
-        azure: {}
-      }
+        azure: {},
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -340,11 +340,11 @@ describe("Validate missing deployment.pipeline configuration", () => {
   test("missing deployment.pipeline.org configuration", async () => {
     const config: ConfigYaml = {
       azure_devops: {
-        org: undefined
+        org: undefined,
       },
       introspection: {
-        azure: {}
-      }
+        azure: {},
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });
@@ -355,11 +355,11 @@ describe("Validate missing deployment.pipeline configuration", () => {
     const config: ConfigYaml = {
       azure_devops: {
         org: "org",
-        project: undefined
+        project: undefined,
       },
       introspection: {
-        azure: {}
-      }
+        azure: {},
+      },
     };
     await expect(isValidConfig(config)).rejects.toThrow();
   });

--- a/src/commands/deployment/validate.ts
+++ b/src/commands/deployment/validate.ts
@@ -8,7 +8,7 @@ import {
   findMatchingDeployments,
   DeploymentTable,
   EntrySRCToACRPipeline,
-  updateACRToHLDPipeline
+  updateACRToHLDPipeline,
 } from "../../lib/azure/deploymenttable";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { logger } from "../../logger";
@@ -164,7 +164,7 @@ export const writeSelfTestData = async (
     accountKey,
     accountName,
     partitionKey,
-    tableName
+    tableName,
   };
 
   const buildId = Math.floor(Math.random() * 1000).toString();
@@ -210,14 +210,14 @@ export const deleteSelfTestData = async (
     accountKey,
     accountName,
     partitionKey,
-    tableName
+    tableName,
   };
 
   const isDeleted = await findMatchingDeployments(
     tableInfo,
     "service",
     service
-  ).then(async results => {
+  ).then(async (results) => {
     logger.info("Deleting test data...");
     let foundEntry = false;
     const entries = results as EntrySRCToACRPipeline[];

--- a/src/commands/hld/index.ts
+++ b/src/commands/hld/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["init", "pipeline", "reconcile"];
 export const commandDecorator = Command(
   "hld",
   "Commands for initalizing and managing a bedrock HLD repository.",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/hld/init.test.ts
+++ b/src/commands/hld/init.test.ts
@@ -3,14 +3,14 @@ import os from "os";
 import path from "path";
 import {
   HLD_COMPONENT_FILENAME,
-  RENDER_HLD_PIPELINE_FILENAME
+  RENDER_HLD_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import { createTempDir } from "../../lib/ioUtil";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import { execute, initialize } from "./init";
 jest.mock("../../lib/gitutils");
@@ -97,8 +97,8 @@ const testRepoInitialization = async (
 
   // Verify new azure-pipelines created
   [RENDER_HLD_PIPELINE_FILENAME, HLD_COMPONENT_FILENAME]
-    .map(filename => path.join(randomTmpDir, filename))
-    .forEach(filePath => {
+    .map((filename) => path.join(randomTmpDir, filename))
+    .forEach((filePath) => {
       expect(fs.existsSync(filePath)).toBe(true);
     });
 };

--- a/src/commands/hld/init.ts
+++ b/src/commands/hld/init.ts
@@ -4,7 +4,7 @@ import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   generateDefaultHldComponentYaml,
   generateGitIgnoreFile,
-  generateHldAzurePipelinesYaml
+  generateHldAzurePipelinesYaml,
 } from "../../lib/fileutils";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import { hasValue } from "../../lib/validator";

--- a/src/commands/hld/pipeline.test.ts
+++ b/src/commands/hld/pipeline.test.ts
@@ -9,7 +9,7 @@ jest.mock("../../lib/pipelines/pipelines");
 import {
   createPipelineForDefinition,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 import { deepClone } from "../../lib/util";
 import { ConfigYaml } from "../../types";
@@ -20,7 +20,7 @@ import {
   CommandOptions,
   installHldToManifestPipeline,
   populateValues,
-  requiredPipelineVariables
+  requiredPipelineVariables,
 } from "./pipeline";
 import * as pipeline from "./pipeline";
 
@@ -33,7 +33,7 @@ const MOCKED_VALUES: CommandOptions = {
   orgName: "orgName",
   personalAccessToken: "personalAccessToken",
   pipelineName: "pipelineName",
-  yamlFileBranch: "master"
+  yamlFileBranch: "master",
 };
 
 const MOCKED_CONFIG = {
@@ -43,8 +43,8 @@ const MOCKED_CONFIG = {
     manifest_repository:
       "https://dev.azure.com/mocked/fabrikam/_git/materialized",
     org: "mocked_org",
-    project: "mocked_project"
-  }
+    project: "mocked_project",
+  },
 };
 
 const getMockObject = (): CommandOptions => {
@@ -98,7 +98,7 @@ describe("test populateValues function", () => {
       orgName: "",
       personalAccessToken: "",
       pipelineName: "",
-      yamlFileBranch: ""
+      yamlFileBranch: "",
     });
 
     expect(values.buildScriptUrl).toBe(BUILD_SCRIPT_URL);
@@ -132,7 +132,7 @@ describe("test populateValues function", () => {
         orgName: "",
         personalAccessToken: "",
         pipelineName: "",
-        yamlFileBranch: ""
+        yamlFileBranch: "",
       })
     ).toThrow(`GitHub repos are not supported`);
   });
@@ -147,7 +147,7 @@ describe("test populateValues function", () => {
         orgName: "",
         personalAccessToken: "",
         pipelineName: "",
-        yamlFileBranch: ""
+        yamlFileBranch: "",
       })
     ).toThrow(`GitHub repos are not supported`);
   });

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -2,7 +2,7 @@
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   BuildDefinition,
-  BuildDefinitionVariable
+  BuildDefinitionVariable,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import commander from "commander";
 import { Config } from "../../config";
@@ -10,7 +10,7 @@ import { repositoryHasFile } from "../../lib/azdoClient";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   BUILD_SCRIPT_URL,
-  RENDER_HLD_PIPELINE_FILENAME
+  RENDER_HLD_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { AzureDevOpsOpts } from "../../lib/git";
 import { getRepositoryName, isGitHubUrl } from "../../lib/gitutils";
@@ -19,7 +19,7 @@ import {
   definitionForAzureRepoPipeline,
   getBuildApiClient,
   IAzureRepoPipelineConfig,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 import { logger } from "../../logger";
 import decorator from "./pipeline.decorator.json";
@@ -106,18 +106,18 @@ export const requiredPipelineVariables = (
     BUILD_SCRIPT_URL: {
       allowOverride: true,
       isSecret: false,
-      value: buildScriptUrl
+      value: buildScriptUrl,
     },
     MANIFEST_REPO: {
       allowOverride: true,
       isSecret: false,
-      value: manifestRepoUrl
+      value: manifestRepoUrl,
     },
     PAT: {
       allowOverride: true,
       isSecret: true,
-      value: accessToken
-    }
+      value: accessToken,
+    },
   };
 };
 
@@ -150,7 +150,7 @@ export const installHldToManifestPipeline = async (
       values.manifestUrl
     ),
     yamlFileBranch: values.yamlFileBranch,
-    yamlFilePath: RENDER_HLD_PIPELINE_FILENAME
+    yamlFilePath: RENDER_HLD_PIPELINE_FILENAME,
   } as IAzureRepoPipelineConfig);
 
   logger.info(
@@ -196,7 +196,7 @@ export const execute = async (
     const accessOpts: AzureDevOpsOpts = {
       orgName: opts.orgName,
       personalAccessToken: opts.personalAccessToken,
-      project: opts.devopsProject
+      project: opts.devopsProject,
     };
 
     // By default the version descriptor is for the master branch

--- a/src/commands/hld/reconcile.test.ts
+++ b/src/commands/hld/reconcile.test.ts
@@ -18,7 +18,7 @@ import {
   normalizedName,
   reconcileHld,
   testAndGetAbsPath,
-  validateInputs
+  validateInputs,
 } from "./reconcile";
 import * as reconcile from "./reconcile";
 
@@ -254,10 +254,10 @@ describe("addChartToRing", () => {
         chart: {
           branch,
           git,
-          path: chartPath
-        }
+          path: chartPath,
+        },
       },
-      k8sBackendPort: 1337
+      k8sBackendPort: 1337,
     };
 
     const addHelmChartCommand = `fab add chart --source ${git} --path ${chartPath} --branch ${branch} --type helm`;
@@ -282,10 +282,10 @@ describe("addChartToRing", () => {
         chart: {
           git,
           path: chartPath,
-          sha
-        }
+          sha,
+        },
       },
-      k8sBackendPort: 1337
+      k8sBackendPort: 1337,
     };
 
     const addHelmChartCommand = `fab add chart --source ${git} --path ${chartPath} --version ${sha} --type helm`;
@@ -308,10 +308,10 @@ describe("addChartToRing", () => {
       helm: {
         chart: {
           chart,
-          repository
-        }
+          repository,
+        },
       },
-      k8sBackendPort: 1337
+      k8sBackendPort: 1337,
     };
 
     const addHelmChartCommand = `fab add chart --source ${repository} --path ${chart} --type helm`;
@@ -336,10 +336,10 @@ describe("addChartToRing", () => {
       helm: {
         chart: {
           chart,
-          repository
-        }
+          repository,
+        },
       },
-      k8sBackendPort: 1337
+      k8sBackendPort: 1337,
     };
 
     await expect(
@@ -358,11 +358,11 @@ describe("configureChartForRing", () => {
       chart: {
         git: "foo",
         path: "bar",
-        sha: "baz"
-      }
+        sha: "baz",
+      },
     },
     k8sBackend: "k8s-svc",
-    k8sBackendPort: 80
+    k8sBackendPort: 80,
   };
 
   const k8sSvcBackendAndName = [serviceConfig.k8sBackend, ringName].join("-");
@@ -407,15 +407,15 @@ describe("reconcile tests", () => {
       exec: jest.fn().mockReturnValue(Promise.resolve({})),
       generateAccessYaml: jest.fn(),
       getGitOrigin: jest.fn(),
-      writeFile: jest.fn()
+      writeFile: jest.fn(),
     };
 
     bedrockYaml = {
       rings: {
         dev: {
-          isDefault: true
+          isDefault: true,
         },
-        prod: {}
+        prod: {},
       },
       services: {
         "./path/to/a/svc/": {
@@ -425,14 +425,14 @@ describe("reconcile tests", () => {
               accessTokenVariable,
               git,
               path: pathToChart,
-              sha
-            }
+              sha,
+            },
           },
           k8sBackend: "cool-service",
-          k8sBackendPort: 1337
-        }
+          k8sBackendPort: 1337,
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
   });
 
@@ -484,8 +484,8 @@ describe("reconcile tests", () => {
     bedrockYaml = {
       rings: {
         dev: {
-          isDefault: true
-        }
+          isDefault: true,
+        },
       },
       services: {
         "./path/to/svc/": {
@@ -494,13 +494,13 @@ describe("reconcile tests", () => {
             chart: {
               git,
               path: pathToChart,
-              sha
-            }
+              sha,
+            },
           },
-          k8sBackendPort: 1337
-        }
+          k8sBackendPort: 1337,
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
 
     await reconcileHld(
@@ -526,8 +526,8 @@ describe("reconcile tests", () => {
   it("overwrites existing rings", async () => {
     bedrockYaml.rings = {
       dev: {
-        isDefault: true
-      }
+        isDefault: true,
+      },
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -574,11 +574,11 @@ describe("reconcile tests", () => {
           chart: {
             git,
             path: pathToChart,
-            sha
-          }
+            sha,
+          },
         },
-        k8sBackendPort: 80
-      }
+        k8sBackendPort: 80,
+      },
     };
 
     await reconcileHld(
@@ -603,11 +603,11 @@ describe("reconcile tests", () => {
           chart: {
             git,
             path: pathToChart,
-            sha
-          }
+            sha,
+          },
         },
-        k8sBackendPort: 80
-      }
+        k8sBackendPort: 80,
+      },
     };
 
     await reconcileHld(
@@ -636,11 +636,11 @@ describe("reconcile tests", () => {
           chart: {
             git,
             path: pathToChart,
-            sha
-          }
+            sha,
+          },
         },
-        k8sBackendPort: 80
-      }
+        k8sBackendPort: 80,
+      },
     };
 
     await reconcileHld(
@@ -668,10 +668,10 @@ describe("reconcile tests", () => {
           accessTokenVariable: anotherToken,
           git: anotherGit,
           path: "path/to/chart",
-          sha: "12345"
-        }
+          sha: "12345",
+        },
       },
-      k8sBackendPort: 8888
+      k8sBackendPort: 8888,
     };
     const pathToHLD = "./the/path/to/hld";
     const service = "service";

--- a/src/commands/hld/reconcile.ts
+++ b/src/commands/hld/reconcile.ts
@@ -39,11 +39,11 @@ interface ExecResult {
  * @param pipeIO if true, will pipe all stdio the executing parent process
  */
 const exec = async (cmd: string, pipeIO = false): Promise<ExecResult> => {
-  return new Promise<ExecResult>(resolve => {
+  return new Promise<ExecResult>((resolve) => {
     const child = child_process.exec(cmd, (error, stdout, stderr) => {
       return resolve({
         error: error ?? undefined,
-        value: { stdout, stderr }
+        value: { stdout, stderr },
       });
     });
     if (pipeIO) {
@@ -123,7 +123,7 @@ export const execute = async (
       exec: execAndLog,
       generateAccessYaml,
       getGitOrigin: tryGetGitOrigin,
-      writeFile: writeFileSync
+      writeFile: writeFileSync,
     };
 
     await reconcileHld(
@@ -238,21 +238,21 @@ export const reconcileHld = async (
       normalizedSvcName
     );
 
-    const ringsToCreate = Object.keys(managedRings).map(ring => {
+    const ringsToCreate = Object.keys(managedRings).map((ring) => {
       const normalizedRingName = normalizedName(ring);
       return {
         normalizedRingName,
         normalizedRingPathInHld: path.join(
           normalizedSvcPathInHld,
           normalizedRingName
-        )
+        ),
       };
     });
 
     // Will only loop over _existing_ rings in bedrock.yaml - does not cover the deletion case, ie: i remove a ring from bedrock.yaml
     for (const {
       normalizedRingName,
-      normalizedRingPathInHld
+      normalizedRingPathInHld,
     } of ringsToCreate) {
       // Create the ring in the service.
       await dependencies.createRingComponent(
@@ -391,13 +391,13 @@ const createIngressRouteForRing = (
       k8sBackend: serviceConfig.k8sBackend,
       middlewares: [
         middlewares.metadata.name,
-        ...(serviceConfig.middlewares ?? [])
-      ]
+        ...(serviceConfig.middlewares ?? []),
+      ],
     }
   );
 
   const routeYaml = yaml.safeDump(ingressRoute, {
-    lineWidth: Number.MAX_SAFE_INTEGER
+    lineWidth: Number.MAX_SAFE_INTEGER,
   });
 
   logger.info(
@@ -421,10 +421,10 @@ const createMiddlewareForRing = (
   );
 
   const middlewares = TraefikMiddleware(serviceName, ring, [
-    ingressVersionAndPath
+    ingressVersionAndPath,
   ]);
   const middlewareYaml = yaml.safeDump(middlewares, {
-    lineWidth: Number.MAX_SAFE_INTEGER
+    lineWidth: Number.MAX_SAFE_INTEGER,
   });
 
   logger.info(
@@ -445,7 +445,7 @@ export const createRepositoryComponent = async (
 
   return execCmd(
     `cd ${absHldPath} && mkdir -p ${repositoryName} && fab add ${repositoryName} --path ./${repositoryName} --method local`
-  ).catch(err => {
+  ).catch((err) => {
     logger.error(
       `error creating repository component '${repositoryName}' in path '${absHldPath}'`
     );
@@ -465,7 +465,7 @@ export const createServiceComponent = async (
 
   return execCmd(
     `cd ${absRepositoryInHldPath} && mkdir -p ${serviceName} config && fab add ${serviceName} --path ./${serviceName} --method local --type component && touch ./config/common.yaml`
-  ).catch(err => {
+  ).catch((err) => {
     logger.error(
       `error creating service component '${serviceName}' in path '${absRepositoryInHldPath}'`
     );
@@ -482,7 +482,7 @@ export const createRingComponent = async (
   assertIsStringWithContent(normalizedRingName, "ring-name");
   const createRingInSvcCommand = `cd ${svcPathInHld} && mkdir -p ${normalizedRingName} config && fab add ${normalizedRingName} --path ./${normalizedRingName} --method local --type component && touch ./config/common.yaml`;
 
-  return execCmd(createRingInSvcCommand).catch(err => {
+  return execCmd(createRingInSvcCommand).catch((err) => {
     logger.error(
       `error creating ring component '${normalizedRingName}' in path '${svcPathInHld}'`
     );
@@ -515,14 +515,16 @@ export const addChartToRing = async (
     addHelmChartCommand = `fab add chart --source ${chart.repository} --path ${chart.chart} --type helm`;
   }
 
-  return execCmd(`cd ${ringPathInHld} && ${addHelmChartCommand}`).catch(err => {
-    logger.error(
-      `error adding helm chart for service-config ${JSON.stringify(
-        serviceConfig
-      )} to ring path '${ringPathInHld}'`
-    );
-    throw err;
-  });
+  return execCmd(`cd ${ringPathInHld} && ${addHelmChartCommand}`).catch(
+    (err) => {
+      logger.error(
+        `error adding helm chart for service-config ${JSON.stringify(
+          serviceConfig
+        )} to ring path '${ringPathInHld}'`
+      );
+      throw err;
+    }
+  );
 };
 
 export const configureChartForRing = async (
@@ -535,12 +537,12 @@ export const configureChartForRing = async (
   const k8sBackendName = serviceConfig.k8sBackend || "";
   const k8sSvcBackendAndName = [
     normalizedName(k8sBackendName),
-    normalizedRingName
+    normalizedRingName,
   ].join("-");
 
   const fabConfigureCommand = `cd ${normalizedRingPathInHld} && fab set --subcomponent "chart" serviceName="${k8sSvcBackendAndName}"`;
 
-  return execCmd(fabConfigureCommand).catch(err => {
+  return execCmd(fabConfigureCommand).catch((err) => {
     logger.error(`error configuring helm chart for service `);
     throw err;
   });
@@ -553,7 +555,7 @@ export const createStaticComponent = async (
   assertIsStringWithContent(ringPathInHld, "ring-path");
   const createConfigAndStaticComponentCommand = `cd ${ringPathInHld} && mkdir -p config static && fab add static --path ./static --method local --type static && touch ./config/common.yaml`;
 
-  return execCmd(createConfigAndStaticComponentCommand).catch(err => {
+  return execCmd(createConfigAndStaticComponentCommand).catch((err) => {
     logger.error(`error creating static component in path '${ringPathInHld}'`);
     throw err;
   });

--- a/src/commands/infra/generate.test.ts
+++ b/src/commands/infra/generate.test.ts
@@ -22,7 +22,7 @@ import {
   retryRemoteValidate,
   validateDefinition,
   validateRemoteSource,
-  validateTemplateSources
+  validateTemplateSources,
 } from "./generate";
 import * as generate from "./generate";
 import {
@@ -32,7 +32,7 @@ import {
   getSourceFolderNameFromURL,
   SPK_TFVARS,
   spkTemplatesPath,
-  VARIABLES_TF
+  VARIABLES_TF,
 } from "./infra_common";
 import * as infraCommon from "./infra_common";
 
@@ -100,7 +100,7 @@ const getMockedDataForGitTests = async (
   return {
     safeLoggingUrl,
     source,
-    sourcePath
+    sourcePath,
   };
 };
 
@@ -124,7 +124,7 @@ describe("test checkRemoteGitExist function", () => {
   });
   // cannot do negative test because it will take too long
   // and timeout
-  it("negative Test", async done => {
+  it("negative Test", async (done) => {
     await expect(testCheckRemoteGitExist(false)).rejects.toThrow();
     done();
   });
@@ -259,7 +259,7 @@ describe("fetch execute function", () => {
     await execute(
       {
         output: "",
-        project: "test"
+        project: "test",
       },
       exitFn
     );
@@ -284,7 +284,7 @@ describe("fetch execute function", () => {
     await execute(
       {
         output: "",
-        project: "test"
+        project: "test",
       },
       exitFn
     );
@@ -308,7 +308,7 @@ describe("fetch execute function", () => {
     await execute(
       {
         output: "",
-        project: "test"
+        project: "test",
       },
       exitFn
     );
@@ -332,7 +332,7 @@ describe("test validateRemoteSource function", () => {
 
     await validateRemoteSource({
       source: "source",
-      version: "0.1"
+      version: "0.1",
     });
   });
   it("positive test: with Error refusing to merge unrelated histories", async () => {
@@ -353,7 +353,7 @@ describe("test validateRemoteSource function", () => {
 
     await validateRemoteSource({
       source: "source",
-      version: "0.1"
+      version: "0.1",
     });
   });
   it("positive test: with Error Authentication failed", async () => {
@@ -372,7 +372,7 @@ describe("test validateRemoteSource function", () => {
 
     await validateRemoteSource({
       source: "source",
-      version: "0.1"
+      version: "0.1",
     });
   });
   it("negative test: with unknown Error", async () => {
@@ -392,7 +392,7 @@ describe("test validateRemoteSource function", () => {
     try {
       await validateRemoteSource({
         source: "source",
-        version: "0.1"
+        version: "0.1",
       });
       expect(true).toBe(false);
     } catch (err) {
@@ -438,14 +438,14 @@ describe("test generateTfvars function", () => {
   it("one value as data", () => {
     expect(
       generateTfvars({
-        hello: "world"
+        hello: "world",
       })
     ).toEqual(['hello = "world"']);
   });
   it("one key with quote as data", () => {
     expect(
       generateTfvars({
-        'h"ello': "world"
+        'h"ello': "world",
       })
     ).toEqual(['h"ello = "world"']);
   });
@@ -454,7 +454,7 @@ describe("test generateTfvars function", () => {
       generateTfvars({
         key1: "value1",
         key2: "value2",
-        key3: "value3"
+        key3: "value3",
       })
     ).toEqual(['key1 = "value1"', 'key2 = "value2"', 'key3 = "value3"']);
   });
@@ -467,24 +467,24 @@ describe("test dirIteration", () => {
   });
   it("parentObject is undefined", () => {
     const leafObject = {
-      custerName: "cluster1"
+      custerName: "cluster1",
     };
     const result = dirIteration(undefined, leafObject);
     expect(result).toEqual(leafObject);
   });
   it("leafObject is undefined", () => {
     const parentObject = {
-      custerName: "cluster1"
+      custerName: "cluster1",
     };
     const result = dirIteration(parentObject, undefined);
     expect(result).toEqual(parentObject);
   });
   it("one variable test", () => {
     const parentObject = {
-      custerName: "parent"
+      custerName: "parent",
     };
     const leafObject = {
-      custerName: "leaf"
+      custerName: "leaf",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual(leafObject);
@@ -492,14 +492,14 @@ describe("test dirIteration", () => {
   it("one variable test, parentObject without the variable", () => {
     const parentObject = {};
     const leafObject = {
-      custerName: "leaf"
+      custerName: "leaf",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual(leafObject);
   });
   it("one variable test, leafObject without the variable", () => {
     const parentObject = {
-      custerName: "leaf"
+      custerName: "leaf",
     };
     const leafObject = {};
     const result = dirIteration(parentObject, leafObject);
@@ -509,12 +509,12 @@ describe("test dirIteration", () => {
     const parentObject = {
       custerName: "parent",
       variable1: "parent1",
-      variable2: "parent2"
+      variable2: "parent2",
     };
     const leafObject = {
       custerName: "leaf",
       variable1: "leaf1",
-      variable2: "leaf2"
+      variable2: "leaf2",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual(leafObject);
@@ -523,7 +523,7 @@ describe("test dirIteration", () => {
     const parentObject = {
       custerName: "parent",
       variable1: "parent1",
-      variable2: "parent2"
+      variable2: "parent2",
     };
     const leafObject = {};
     const result = dirIteration(parentObject, leafObject);
@@ -534,7 +534,7 @@ describe("test dirIteration", () => {
     const leafObject = {
       custerName: "leaf",
       variable1: "leaf1",
-      variable2: "leaf2"
+      variable2: "leaf2",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual(leafObject);
@@ -544,32 +544,32 @@ describe("test dirIteration", () => {
       custerName: "parent",
       variable1: "parent1",
       variable2: "parent2",
-      xextra: "xextra"
+      xextra: "xextra",
     };
     const leafObject = {
       custerName: "leaf",
       variable1: "leaf1",
-      variable2: "leaf2"
+      variable2: "leaf2",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual({
       custerName: "leaf",
       variable1: "leaf1",
       variable2: "leaf2",
-      xextra: "xextra"
+      xextra: "xextra",
     });
   });
   it("multiple variables test, leafObject has more values", () => {
     const parentObject = {
       custerName: "parent",
       variable1: "parent1",
-      variable2: "parent2"
+      variable2: "parent2",
     };
     const leafObject = {
       custerName: "leaf",
       variable1: "leaf1",
       variable2: "leaf2",
-      xextra: "xextra"
+      xextra: "xextra",
     };
     const result = dirIteration(parentObject, leafObject);
     expect(result).toEqual(leafObject);
@@ -583,7 +583,7 @@ describe("Validate sources in definition.yaml files", () => {
     const expectedSourceWest = {
       source: "https://github.com/yradsmikham/spk-source",
       template: "cluster/environments/azure-single-keyvault",
-      version: "v0.0.2"
+      version: "v0.0.2",
     };
     const outputPath = "";
     const sourceConfiguration = validateDefinition(
@@ -611,7 +611,7 @@ describe("Validate sources in definition.yaml files", () => {
     const expectedSource = {
       source: "https://github.com/yradsmikham/spk-source",
       template: "cluster/environments/azure-single-keyvault",
-      version: "v0.0.1"
+      version: "v0.0.1",
     };
     const outputPath = "";
     const sourceConfiguration = validateDefinition(
@@ -638,8 +638,8 @@ describe("Validate sources in definition.yaml files", () => {
       "main.tf",
       "README.md",
       SPK_TFVARS,
-      VARIABLES_TF
-    ].forEach(f => {
+      VARIABLES_TF,
+    ].forEach((f) => {
       fs.unlinkSync(path.join(mockParentPath, f));
     });
   });
@@ -660,7 +660,7 @@ describe("Validate sources in definition.yaml files", () => {
     const expectedSourceEast = {
       source: "https://github.com/yradsmikham/spk-source",
       template: "cluster/environments/azure-single-keyvault",
-      version: "v0.0.1"
+      version: "v0.0.1",
     };
     const outputPath = "";
     const sourceConfiguration = validateDefinition(
@@ -689,7 +689,7 @@ describe("Validate sources in definition.yaml files", () => {
     const expectedSourceCentral = {
       source: "https://github.com/yradsmikham/spk-source",
       template: "cluster/environments/azure-single-keyvault",
-      version: "v0.0.1"
+      version: "v0.0.1",
     };
     const outputPath = "";
     const sourceConfiguration = validateDefinition(
@@ -754,7 +754,7 @@ describe("Validate replacement of variables between parent and leaf definitions"
       'network_policy = "azure"',
       'oms_agent_enabled = "false"',
       'enable_acr = "false"',
-      `acr_name = "${DEFAULT_VAR_VALUE}"`
+      `acr_name = "${DEFAULT_VAR_VALUE}"`,
     ];
     const parentData = readYaml<InfraConfigYaml>(
       path.join(mockParentPath, DEFINITION_YAML)

--- a/src/commands/infra/generate.ts
+++ b/src/commands/infra/generate.ts
@@ -19,7 +19,7 @@ import {
   DEFINITION_YAML,
   getSourceFolderNameFromURL,
   SPK_TFVARS,
-  spkTemplatesPath
+  spkTemplatesPath,
 } from "./infra_common";
 import { copyTfTemplate } from "./scaffold";
 
@@ -36,7 +36,7 @@ export interface SourceInformation {
 
 export enum DefinitionYAMLExistence {
   BOTH_EXIST,
-  PARENT_ONLY
+  PARENT_ONLY,
 }
 
 export const execute = async (
@@ -154,7 +154,7 @@ export const validateTemplateSources = (
   // setting values into source object for source, template and version
   // taking the values from leaf if it exists, otherwise take it
   // from parent if it exists
-  sourceKeys.forEach(k => {
+  sourceKeys.forEach((k) => {
     if (leafInfraConfig && leafInfraConfig[k]) {
       source[k] = leafInfraConfig[k];
     } else if (parentInfraConfig && parentInfraConfig[k]) {
@@ -485,7 +485,7 @@ export const dirIteration = (
   }
 
   // parent take leaf's value
-  Object.keys(leafObject).forEach(k => {
+  Object.keys(leafObject).forEach((k) => {
     if (leafObject[k]) {
       parentObject[k] = leafObject[k];
     }
@@ -563,7 +563,7 @@ export const generateTfvars = (
   if (!definition) {
     return [];
   }
-  return Object.keys(definition).map(k => `${k} = "${definition[k]}"`);
+  return Object.keys(definition).map((k) => `${k} = "${definition[k]}"`);
 };
 
 /**
@@ -578,7 +578,7 @@ export const writeTfvarsFile = (
   generatedPath: string,
   tfvarsFilename: string
 ): void => {
-  spkTfVars.forEach(tfvar => {
+  spkTfVars.forEach((tfvar) => {
     fs.appendFileSync(path.join(generatedPath, tfvarsFilename), tfvar + "\n");
   });
 };

--- a/src/commands/infra/index.ts
+++ b/src/commands/infra/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["generate", "scaffold"];
 export const commandDecorator = Command(
   "infra",
   "Manage and modify your Bedrock infrastructure.",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/infra/infra_common.ts
+++ b/src/commands/infra/infra_common.ts
@@ -29,8 +29,5 @@ export const getSourceFolderNameFromURL = (source: string): string => {
     // do not have :
     return source.replace(punctuationReg, "_").toLowerCase();
   }
-  return source
-    .substring(idx)
-    .replace(punctuationReg, "_")
-    .toLowerCase();
+  return source.substring(idx).replace(punctuationReg, "_").toLowerCase();
 };

--- a/src/commands/infra/scaffold.test.ts
+++ b/src/commands/infra/scaffold.test.ts
@@ -7,7 +7,7 @@ import uuid from "uuid";
 import {
   createTempDir,
   getMissingFilenames,
-  isDirEmpty
+  isDirEmpty,
 } from "../../lib/ioUtil";
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
 import { validateRemoteSource } from "./generate";
@@ -17,7 +17,7 @@ import {
   DEFAULT_VAR_VALUE,
   DEFINITION_YAML,
   TERRAFORM_TFVARS,
-  VARIABLES_TF
+  VARIABLES_TF,
 } from "./infra_common";
 import * as infraCommon from "./infra_common";
 import {
@@ -30,15 +30,15 @@ import {
   removeTemplateFiles,
   validateBackendTfvars,
   validateValues,
-  validateVariablesTf
+  validateVariablesTf,
 } from "./scaffold";
 import * as scaffold from "./scaffold";
 
 const mockYaml = {
   azure_devops: {
     access_token: "token123",
-    infra_repository: "repoABC"
-  }
+    infra_repository: "repoABC",
+  },
 };
 
 beforeAll(() => {
@@ -130,7 +130,7 @@ describe("test removeTemplateFiles function", () => {
     fs.writeFileSync(path.join(dir, DEFINITION_YAML), "test");
 
     const otherFiles = ["file1.txt", "file2.txt"];
-    otherFiles.forEach(f => {
+    otherFiles.forEach((f) => {
       fs.writeFileSync(path.join(dir, `${f}.txt`), f);
     });
     removeTemplateFiles(dir);
@@ -150,7 +150,7 @@ describe("test validate function", () => {
           name: uuid(),
           source: "http://example@host",
           template: uuid(),
-          version: uuid()
+          version: uuid(),
         }
       );
     } catch (err) {
@@ -166,7 +166,7 @@ describe("test validate function", () => {
           name: uuid(),
           source: "",
           template: uuid(),
-          version: uuid()
+          version: uuid(),
         }
       );
       expect(true).toBe(false);
@@ -175,7 +175,7 @@ describe("test validate function", () => {
     }
   });
   it("name, template, version is missing", () => {
-    ["name", "template", "version"].forEach(key => {
+    ["name", "template", "version"].forEach((key) => {
       try {
         validateValues(
           {},
@@ -183,7 +183,7 @@ describe("test validate function", () => {
             name: key === "name" ? "" : uuid(),
             source: "http://example@host",
             template: key === "template" ? "" : uuid(),
-            version: key === "version" ? "" : uuid()
+            version: key === "version" ? "" : uuid(),
           }
         );
         expect(true).toBe(false);
@@ -208,13 +208,13 @@ describe("test execute function", () => {
     name: "",
     source: "",
     template: "",
-    version: ""
+    version: "",
   };
   const MOCKED_VALS: CommandOptions = {
     name: "name",
     source: "source",
     template: "template",
-    version: "0.1"
+    version: "0.1",
   };
   it("missing config yaml", async () => {
     const exitFn = jest.fn();
@@ -309,7 +309,7 @@ describe("Validate generation of sample scaffold definition", () => {
         name: "test-scaffold",
         source: "https://github.com/microsoft/bedrock",
         template: "cluster/environments/azure-simple",
-        version: "v1.0.0"
+        version: "v1.0.0",
       },
       backendTfVars,
       sampleVarTf

--- a/src/commands/infra/scaffold.ts
+++ b/src/commands/infra/scaffold.ts
@@ -16,7 +16,7 @@ import {
   getSourceFolderNameFromURL,
   spkTemplatesPath,
   TERRAFORM_TFVARS,
-  VARIABLES_TF
+  VARIABLES_TF,
 } from "./infra_common";
 import decorator from "./scaffold.decorator.json";
 
@@ -82,13 +82,13 @@ export const copyTfTemplate = async (
   try {
     if (generation === true) {
       await fsextra.copy(templatePath, envName, {
-        filter: file =>
+        filter: (file) =>
           file.indexOf(TERRAFORM_TFVARS) === -1 &&
-          file.indexOf(BACKEND_TFVARS) === -1
+          file.indexOf(BACKEND_TFVARS) === -1,
       });
     } else {
       await fsextra.copy(templatePath, envName, {
-        filter: file => file.indexOf(TERRAFORM_TFVARS) === -1
+        filter: (file) => file.indexOf(TERRAFORM_TFVARS) === -1,
       });
     }
     logger.info(`Terraform template files copied from ${templatePath}`);
@@ -165,7 +165,7 @@ export const parseVariablesTf = (data: string): { [key: string]: string } => {
   const fields: { [key: string]: string } = {};
   const fieldSplitRegex = /"\s{0,}\{/;
   const defaultRegex = /default\s{0,}=\s{0,}(.*)/;
-  blocks.forEach(b => {
+  blocks.forEach((b) => {
     b = b.trim();
     const elt = b.split(fieldSplitRegex);
     elt[0] = elt[0].trim().replace('"', "");
@@ -198,7 +198,7 @@ export const parseBackendTfvars = (
 ): { [key: string]: string } => {
   const backend: { [key: string]: string | "" } = {};
   const block = backendData.replace(/=/g, ":").split("\n");
-  block.forEach(b => {
+  block.forEach((b) => {
     const elt = b.split(":");
     if (elt[0].length > 0) {
       backend[elt[0]] = elt[1]
@@ -227,7 +227,7 @@ export const generateClusterDefinition = (
     name: values.name,
     source: values.source,
     template: values.template,
-    version: values.version
+    version: values.version,
   };
   if (backendData !== "") {
     const backend = parseBackendTfvars(backendData);
@@ -235,11 +235,11 @@ export const generateClusterDefinition = (
   }
   if (Object.keys(fields).length > 0) {
     const fieldDict: { [key: string]: string } = {};
-    Object.keys(fields).forEach(key => {
+    Object.keys(fields).forEach((key) => {
       fieldDict[key] = fields[key] || DEFAULT_VAR_VALUE;
     });
     // If the value contains a default value, exclude from fieldDict
-    Object.keys(fieldDict).forEach(key => {
+    Object.keys(fieldDict).forEach((key) => {
       if (fieldDict[key] !== DEFAULT_VAR_VALUE) {
         delete fieldDict[key];
       }
@@ -277,7 +277,7 @@ export const scaffold = (values: CommandOptions): void => {
           const confPath: string = path.format({
             base: DEFINITION_YAML,
             dir: values.name,
-            root: "/ignored"
+            root: "/ignored",
           });
           fs.writeFileSync(confPath, definitionYaml, "utf8");
         } else {
@@ -303,8 +303,8 @@ export const removeTemplateFiles = (envPath: string): void => {
   try {
     const files = fs.readdirSync(envPath);
     files
-      .filter(f => f !== DEFINITION_YAML)
-      .forEach(f => {
+      .filter((f) => f !== DEFINITION_YAML)
+      .forEach((f) => {
         fs.unlinkSync(path.join(envPath, f));
       });
   } catch (e) {
@@ -327,7 +327,7 @@ export const execute = async (
     const scaffoldDefinition: SourceInformation = {
       source: opts.source,
       template: opts.template,
-      version: opts.version
+      version: opts.version,
     };
     const sourceFolder = getSourceFolderNameFromURL(opts.source);
     const sourcePath = path.join(spkTemplatesPath, sourceFolder);

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -16,7 +16,7 @@ import {
   handleInteractiveMode,
   handleIntrospectionInteractive,
   prompt,
-  validatePersonalAccessToken
+  validatePersonalAccessToken,
 } from "./init";
 import * as init from "./init";
 
@@ -38,7 +38,7 @@ describe("Test execute function", () => {
     await execute(
       {
         file: undefined,
-        interactive: false
+        interactive: false,
       },
       exitFn
     );
@@ -50,7 +50,7 @@ describe("Test execute function", () => {
     await execute(
       {
         file: uuid(),
-        interactive: false
+        interactive: false,
       },
       exitFn
     );
@@ -63,7 +63,7 @@ describe("Test execute function", () => {
     await execute(
       {
         file: path.join(randomTmpDir, "config.yaml"),
-        interactive: true
+        interactive: true,
       },
       exitFn
     );
@@ -81,7 +81,7 @@ describe("Test execute function", () => {
     await execute(
       {
         file: path.join(randomTmpDir, "config.yaml"),
-        interactive: false
+        interactive: false,
       },
       exitFn
     );
@@ -96,7 +96,7 @@ describe("Test execute function", () => {
     await execute(
       {
         file: "",
-        interactive: true
+        interactive: true,
       },
       exitFn
     );
@@ -111,8 +111,8 @@ describe("test getConfig function", () => {
       azure_devops: {
         access_token: "access_token",
         org: "org",
-        project: "project"
-      }
+        project: "project",
+      },
     };
     jest.spyOn(config, "loadConfiguration").mockReturnValueOnce();
     jest.spyOn(config, "Config").mockReturnValueOnce(mockedValues);
@@ -129,35 +129,35 @@ describe("test getConfig function", () => {
       azure_devops: {
         access_token: "",
         org: "",
-        project: ""
-      }
+        project: "",
+      },
     });
   });
 });
 
 describe("test validatePersonalAccessToken function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest.spyOn(axios, "get").mockReturnValueOnce(
       Promise.resolve({
-        status: 200
+        status: 200,
       })
     );
     const result = await validatePersonalAccessToken({
       access_token: "token",
       org: "org",
-      project: "project"
+      project: "project",
     });
     expect(result).toBe(true);
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     jest
       .spyOn(axios, "get")
       .mockReturnValueOnce(Promise.reject(new Error("fake")));
     const result = await validatePersonalAccessToken({
       access_token: "token",
       org: "org",
-      project: "project"
+      project: "project",
     });
     expect(result).toBe(false);
     done();
@@ -174,17 +174,17 @@ const testHandleInteractiveModeFunc = async (
     azure_devops: {
       access_token: "",
       org: "",
-      project: ""
+      project: "",
     },
     introspection: {
-      azure: {}
-    }
+      azure: {},
+    },
   });
   jest.spyOn(init, "prompt").mockResolvedValueOnce({
     azdo_org_name: "org_name",
     azdo_pat: "pat",
     azdo_project_name: "project",
-    toSetupIntrospectionConfig: true
+    toSetupIntrospectionConfig: true,
   });
   jest
     .spyOn(init, "validatePersonalAccessToken")
@@ -203,23 +203,23 @@ const testHandleInteractiveModeFunc = async (
 };
 
 describe("test handleInteractiveMode function", () => {
-  it("postive test: verified access token", async done => {
+  it("postive test: verified access token", async (done) => {
     await testHandleInteractiveModeFunc(true);
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     await testHandleInteractiveModeFunc(false);
     done();
   });
 });
 
 describe("test prompt function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     const answers = {
       azdo_org_name: "org",
       azdo_pat: "pat",
       azdo_project_name: "project",
-      toSetupIntrospectionConfig: true
+      toSetupIntrospectionConfig: true,
     };
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce(answers);
     const ans = await prompt({});
@@ -235,7 +235,7 @@ const testHandleIntrospectionInteractive = async (
   const config: ConfigYaml = {};
   if (!withIntrospection) {
     config["introspection"] = {
-      azure: {}
+      azure: {},
     };
   }
   jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
@@ -243,7 +243,7 @@ const testHandleIntrospectionInteractive = async (
     azdo_storage_table_name: "storagetabletest",
     azdo_storage_partition_key: "test1234key",
     azdo_storage_access_key: "accessKey",
-    azdo_storage_key_vault_name: withKeyVault ? "keyvault" : ""
+    azdo_storage_key_vault_name: withKeyVault ? "keyvault" : "",
   });
   await handleIntrospectionInteractive(config);
   expect(config.introspection?.azure?.account_name).toBe("storagetest");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,7 +8,7 @@ import {
   Config,
   defaultConfigFile,
   loadConfiguration,
-  saveConfiguration
+  saveConfiguration,
 } from "../config";
 import { build as buildCmd, exit as exitCmd } from "../lib/commandBuilder";
 import * as promptBuilder from "../lib/promptBuilder";
@@ -52,14 +52,14 @@ export const prompt = async (curConfig: ConfigYaml): Promise<Answer> => {
     promptBuilder.azureOrgName(curConfig.azure_devops?.org),
     promptBuilder.azureProjectName(curConfig.azure_devops?.project),
     promptBuilder.azureAccessToken(curConfig.azure_devops?.access_token),
-    promptBuilder.askToSetupIntrospectionConfig(false)
+    promptBuilder.askToSetupIntrospectionConfig(false),
   ];
   const answers = await inquirer.prompt(questions);
   return {
     azdo_org_name: answers.azdo_org_name as string,
     azdo_pat: answers.azdo_pat as string,
     azdo_project_name: answers.azdo_project_name as string,
-    toSetupIntrospectionConfig: answers.toSetupIntrospectionConfig
+    toSetupIntrospectionConfig: answers.toSetupIntrospectionConfig,
   };
 };
 
@@ -77,8 +77,8 @@ export const getConfig = (): ConfigYaml => {
       azure_devops: {
         access_token: "",
         org: "",
-        project: ""
-      }
+        project: "",
+      },
     };
   }
 };
@@ -104,8 +104,8 @@ export const validatePersonalAccessToken = async (
       {
         auth: {
           password: azure.access_token as string,
-          username: ""
-        }
+          username: "",
+        },
       }
     );
     return res.status === 200;
@@ -127,7 +127,7 @@ export const handleIntrospectionInteractive = async (
 ): Promise<void> => {
   if (!isIntrospectionAzureDefined(curConfig)) {
     curConfig.introspection = {
-      azure: {}
+      azure: {},
     };
   }
 
@@ -139,7 +139,7 @@ export const handleIntrospectionInteractive = async (
     promptBuilder.azureStorageTableName(azure.table_name),
     promptBuilder.azureStoragePartitionKey(azure.partition_key),
     promptBuilder.azureStorageAccessKey(azure.key),
-    promptBuilder.azureKeyVaultName(curConfig.key_vault_name)
+    promptBuilder.azureKeyVaultName(curConfig.key_vault_name),
   ]);
   azure["account_name"] = ans.azdo_storage_account_name;
   azure["table_name"] = ans.azdo_storage_table_name;

--- a/src/commands/project/create-variable-group.test.ts
+++ b/src/commands/project/create-variable-group.test.ts
@@ -8,11 +8,11 @@ import { readYaml, write } from "../../config";
 import {
   create as createBedrockYaml,
   isExists as isBedrockFileExists,
-  read as readBedrockFile
+  read as readBedrockFile,
 } from "../../lib/bedrockYaml";
 import {
   PROJECT_PIPELINE_FILENAME,
-  VERSION_MESSAGE
+  VERSION_MESSAGE,
 } from "../../lib/constants";
 import { AzureDevOpsOpts } from "../../lib/git";
 import { createTempDir } from "../../lib/ioUtil";
@@ -20,18 +20,18 @@ import * as pipelineVariableGroup from "../../lib/pipelines/variableGroup";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import {
   createTestBedrockYaml,
-  createTestHldLifecyclePipelineYaml
+  createTestHldLifecyclePipelineYaml,
 } from "../../test/mockFactory";
 import { AzurePipelinesYaml, BedrockFile } from "../../types";
 import {
   create,
   execute,
   setVariableGroupInBedrockFile,
-  updateLifeCyclePipeline
+  updateLifeCyclePipeline,
 } from "./create-variable-group";
 import * as fileutils from "../../lib/fileutils";
 
@@ -74,7 +74,7 @@ describe("test execute function", () => {
         registryName,
         servicePrincipalId,
         servicePrincipalPassword,
-        tenant
+        tenant,
       },
       exitFn
     );
@@ -92,7 +92,7 @@ describe("test execute function", () => {
         registryName: undefined,
         servicePrincipalId,
         servicePrincipalPassword,
-        tenant
+        tenant,
       },
       exitFn
     );
@@ -105,7 +105,7 @@ describe("create", () => {
     const accessOpts: AzureDevOpsOpts = {
       orgName,
       personalAccessToken,
-      project: devopsProject
+      project: devopsProject,
     };
 
     let invalidDataError: Error | undefined;
@@ -134,7 +134,7 @@ describe("create", () => {
     const accessOpts: AzureDevOpsOpts = {
       orgName,
       personalAccessToken,
-      project: devopsProject
+      project: devopsProject,
     };
 
     try {
@@ -225,7 +225,7 @@ describe("setVariableGroupInBedrockFile", () => {
       rings: {}, // rings is optional but necessary to create a bedrock file in config.write method
       services: {}, // service property is not optional so set it to null
       variableGroups: [prevariableGroupName],
-      version: ""
+      version: "",
     };
 
     const randomTmpDir = createBedrockYaml("", bedrockFileData);
@@ -243,7 +243,7 @@ describe("updateLifeCyclePipeline", () => {
   beforeAll(() => {
     mockFs({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      "bedrock.yaml": createTestBedrockYaml() as any
+      "bedrock.yaml": createTestBedrockYaml() as any,
     });
   });
 
@@ -295,7 +295,7 @@ describe("updateLifeCyclePipeline", () => {
     ) as AzurePipelinesYaml;
 
     const asYaml = yaml.safeDump(hldLifeCycleFile, {
-      lineWidth: Number.MAX_SAFE_INTEGER
+      lineWidth: Number.MAX_SAFE_INTEGER,
     });
 
     fs.writeFileSync(hldFilePath, asYaml);
@@ -319,7 +319,7 @@ describe("updateLifeCyclePipeline", () => {
     // add new variabe group
     defaultBedrockFileObject.variableGroups = [
       ...(defaultBedrockFileObject.variableGroups ?? []),
-      variableGroupName
+      variableGroupName,
     ];
 
     write(defaultBedrockFileObject, randomTmpDir);
@@ -331,7 +331,7 @@ describe("updateLifeCyclePipeline", () => {
     ) as AzurePipelinesYaml;
 
     const asYaml = yaml.safeDump(hldLifeCycleFile, {
-      lineWidth: Number.MAX_SAFE_INTEGER
+      lineWidth: Number.MAX_SAFE_INTEGER,
     });
 
     fs.writeFileSync(hldFilePath, asYaml);
@@ -341,7 +341,7 @@ describe("updateLifeCyclePipeline", () => {
     const hldLifeCycleYaml = readYaml<AzurePipelinesYaml>(hldFilePath);
     logger.info(`filejson: ${JSON.stringify(hldLifeCycleYaml)}`);
     expect(hldLifeCycleYaml.variables![0]).toEqual({
-      group: variableGroupName
+      group: variableGroupName,
     });
   });
 });

--- a/src/commands/project/create-variable-group.ts
+++ b/src/commands/project/create-variable-group.ts
@@ -9,11 +9,11 @@ import { fileInfo as bedrockFileInfo } from "../../lib/bedrockYaml";
 import {
   build as buildCmd,
   exit as exitCmd,
-  validateForRequiredValues
+  validateForRequiredValues,
 } from "../../lib/commandBuilder";
 import {
   PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE,
-  PROJECT_PIPELINE_FILENAME
+  PROJECT_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { AzureDevOpsOpts } from "../../lib/git";
 import { addVariableGroup } from "../../lib/pipelines/variableGroup";
@@ -23,7 +23,7 @@ import {
   AzurePipelinesYaml,
   BedrockFileInfo,
   VariableGroupData,
-  VariableGroupDataVariable
+  VariableGroupDataVariable,
 } from "../../types";
 import decorator from "./create-variable-group.decorator.json";
 
@@ -78,13 +78,13 @@ export const execute = async (
       hldRepoUrl = azure_devops?.hld_repository,
       orgName = azure_devops?.org,
       personalAccessToken = azure_devops?.access_token,
-      devopsProject = azure_devops?.project
+      devopsProject = azure_devops?.project,
     } = opts;
 
     const accessOpts: AzureDevOpsOpts = {
       orgName,
       personalAccessToken,
-      project: devopsProject
+      project: devopsProject,
     };
 
     logger.debug(`access options: ${JSON.stringify(accessOpts)}`);
@@ -97,7 +97,7 @@ export const execute = async (
       registryName,
       servicePrincipalId,
       servicePrincipalPassword,
-      tenant
+      tenant,
     });
 
     if (errors.length !== 0) {
@@ -178,33 +178,33 @@ export const create = (
   );
   const vars: VariableGroupDataVariable = {
     ACR_NAME: {
-      value: registryName
+      value: registryName,
     },
     HLD_REPO: {
-      value: hldRepoUrl
+      value: hldRepoUrl,
     },
     PAT: {
       isSecret: true,
-      value: accessOpts.personalAccessToken
+      value: accessOpts.personalAccessToken,
     },
     SP_APP_ID: {
       isSecret: true,
-      value: servicePrincipalId
+      value: servicePrincipalId,
     },
     SP_PASS: {
       isSecret: true,
-      value: servicePrincipalPassword
+      value: servicePrincipalPassword,
     },
     SP_TENANT: {
       isSecret: true,
-      value: tenantId
-    }
+      value: tenantId,
+    },
   };
   const variableGroupData: VariableGroupData = {
     description: "Created from spk CLI",
     name: variableGroupName,
     type: "Vsts",
-    variables: vars
+    variables: vars,
   };
   return addVariableGroup(variableGroupData, accessOpts);
 };
@@ -245,7 +245,7 @@ export const setVariableGroupInBedrockFile = (
   // add new variable group
   bedrockFile.variableGroups = [
     ...(bedrockFile.variableGroups ?? []),
-    variableGroupName
+    variableGroupName,
   ];
 
   // Write out
@@ -284,11 +284,11 @@ export const updateLifeCyclePipeline = (rootProjectPath: string): void => {
   );
 
   pipelineFile.variables = [
-    ...(bedrockFile.variableGroups ?? []).map(groupName => {
+    ...(bedrockFile.variableGroups ?? []).map((groupName) => {
       return {
-        group: groupName
+        group: groupName,
       };
-    })
+    }),
   ];
 
   // Write out

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["create-variable-group", "init", "pipeline"];
 export const commandDecorator = Command(
   "project",
   "Initialize and manage your Bedrock project.",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/project/init.test.ts
+++ b/src/commands/project/init.test.ts
@@ -4,7 +4,7 @@ import uuid from "uuid/v4";
 import { Bedrock, Maintainers, write } from "../../config";
 import {
   PROJECT_PIPELINE_FILENAME,
-  SERVICE_PIPELINE_FILENAME
+  SERVICE_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { createTempDir, getMissingFilenames } from "../../lib/ioUtil";
 import { BedrockFile, MaintainersFile } from "../../types";
@@ -16,7 +16,7 @@ const CREATED_FILES = [
   ".gitignore",
   "bedrock.yaml",
   "maintainers.yaml",
-  PROJECT_PIPELINE_FILENAME
+  PROJECT_PIPELINE_FILENAME,
 ];
 
 describe("Initializing a blank/new bedrock repository", () => {
@@ -39,7 +39,7 @@ describe("Initializing a blank/new bedrock repository", () => {
     // ensure service specific files do not get created
     const unexpected = getMissingFilenames(randomTmpDir, [
       "Dockerfile",
-      SERVICE_PIPELINE_FILENAME
+      SERVICE_PIPELINE_FILENAME,
     ]);
     expect(unexpected.length).toBe(2);
   });
@@ -64,13 +64,13 @@ describe("initializing an existing file does not modify it", () => {
             chart: {
               git: "foo",
               path: "./",
-              sha: "bar"
-            }
+              sha: "bar",
+            },
           },
-          k8sBackendPort: 1337
-        }
+          k8sBackendPort: 1337,
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
     write(bedrockFile, randomDir);
     await initialize(randomDir);
@@ -85,9 +85,9 @@ describe("initializing an existing file does not modify it", () => {
     const maintainersFile: MaintainersFile = {
       services: {
         "some/random/dir": {
-          maintainers: [{ name: "foo bar", email: "foobar@baz.com" }]
-        }
-      }
+          maintainers: [{ name: "foo bar", email: "foobar@baz.com" }],
+        },
+      },
     };
     write(maintainersFile, randomDir);
     await initialize(randomDir);
@@ -105,7 +105,7 @@ describe("Test execute function", () => {
     const randomDir = createTempDir();
     await execute(
       {
-        defaultRing: "master"
+        defaultRing: "master",
       },
       randomDir,
       exitFn
@@ -123,7 +123,7 @@ describe("Test execute function", () => {
     const randomDir = createTempDir();
     await execute(
       {
-        defaultRing: "master"
+        defaultRing: "master",
       },
       randomDir,
       exitFn

--- a/src/commands/project/init.ts
+++ b/src/commands/project/init.ts
@@ -6,7 +6,7 @@ import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   generateGitIgnoreFile,
   generateHldLifecyclePipelineYaml,
-  getVersion
+  getVersion,
 } from "../../lib/fileutils";
 import { exec } from "../../lib/shell";
 import { logger } from "../../logger";
@@ -39,7 +39,7 @@ const generateBedrockFile = (
       {}
     ),
     services: {},
-    version: getVersion()
+    version: getVersion(),
   };
 
   // Check if a bedrock.yaml already exists; skip write if present
@@ -64,12 +64,12 @@ const generateMaintainersFile = async (
   packagePaths: string[]
 ): Promise<void> => {
   const absProjectPath = path.resolve(projectPath);
-  const absPackagePaths = packagePaths.map(p => path.resolve(p));
+  const absPackagePaths = packagePaths.map((p) => path.resolve(p));
   logger.info(`Generating maintainers.yaml file in ${absProjectPath}`);
 
   // Get default name/email from git host
   const [gitName, gitEmail] = await Promise.all(
-    ["name", "email"].map(async field => {
+    ["name", "email"].map(async (field) => {
       try {
         const gitField = await exec("git", ["config", `user.${field}`]);
         return gitField;
@@ -94,7 +94,7 @@ const generateMaintainersFile = async (
       // Root should use the value from reduce init
       if (relPathToPackageFromRoot !== "") {
         file.services["./" + relPathToPackageFromRoot] = {
-          maintainers: [{ email: "", name: "" }]
+          maintainers: [{ email: "", name: "" }],
         };
       }
 
@@ -107,11 +107,11 @@ const generateMaintainersFile = async (
           maintainers: [
             {
               email: gitEmail,
-              name: gitName
-            }
-          ]
-        }
-      }
+              name: gitName,
+            },
+          ],
+        },
+      },
     }
   );
 

--- a/src/commands/project/pipeline.test.ts
+++ b/src/commands/project/pipeline.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../lib/pipelines/pipelines");
 import {
   createPipelineForDefinition,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 
 import {
@@ -16,7 +16,7 @@ import {
   execute,
   fetchValidateValues,
   CommandOptions,
-  installLifecyclePipeline
+  installLifecyclePipeline,
 } from "./pipeline";
 
 beforeAll(() => {
@@ -37,7 +37,7 @@ const mockValues: CommandOptions = {
   pipelineName: "pipelineName",
   repoName: "repoName",
   repoUrl: "repoUrl",
-  yamlFileBranch: "master"
+  yamlFileBranch: "master",
 };
 
 jest.spyOn(azdo, "repositoryHasFile").mockReturnValue(Promise.resolve());
@@ -50,7 +50,7 @@ const mockMissingValues: CommandOptions = {
   pipelineName: "pipelineName",
   repoName: "repoName",
   repoUrl: "",
-  yamlFileBranch: ""
+  yamlFileBranch: "",
 };
 
 const nullValues: CommandOptions = {
@@ -61,7 +61,7 @@ const nullValues: CommandOptions = {
   pipelineName: "pipelineName",
   repoName: "repoName",
   repoUrl: "https://github.com",
-  yamlFileBranch: ""
+  yamlFileBranch: "",
 };
 
 describe("test valid function", () => {
@@ -88,13 +88,13 @@ describe("test fetchValidateValues function", () => {
   it("SPK Config's azure_devops do not have value", () => {
     expect(() => {
       fetchValidateValues(mockMissingValues, gitUrl, {
-        azure_devops: {}
+        azure_devops: {},
       });
     }).toThrow(`Repo url not defined`);
   });
   it("SPK Config's azure_devops do not have value and command line does not have values", () => {
     const values = fetchValidateValues(nullValues, gitUrl, {
-      azure_devops: {}
+      azure_devops: {},
     });
     expect(values).toBeNull();
   });
@@ -116,7 +116,7 @@ describe("installLifecyclePipeline and execute tests", () => {
       rings: {},
       services: {},
       variableGroups: ["test"],
-      version: "1.0"
+      version: "1.0",
     });
     await execute(mockValues, tmpDir, exitFn);
 
@@ -197,7 +197,7 @@ describe("installLifecyclePipeline and execute tests", () => {
   it("should fail if a build definition id doesn't exist", async () => {
     (getBuildApiClient as jest.Mock).mockReturnValue({});
     (createPipelineForDefinition as jest.Mock).mockReturnValue({
-      fakeProperty: "temp"
+      fakeProperty: "temp",
     });
     (queueBuild as jest.Mock).mockReturnValue(Promise.reject());
 

--- a/src/commands/project/pipeline.ts
+++ b/src/commands/project/pipeline.ts
@@ -2,7 +2,7 @@
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   BuildDefinition,
-  BuildDefinitionVariable
+  BuildDefinitionVariable,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import commander from "commander";
 import { Config } from "../../config";
@@ -11,26 +11,26 @@ import { fileInfo as bedrockFileInfo } from "../../lib/bedrockYaml";
 import {
   build as buildCmd,
   exit as exitCmd,
-  validateForRequiredValues
+  validateForRequiredValues,
 } from "../../lib/commandBuilder";
 import {
   BUILD_SCRIPT_URL,
   PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE,
   PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE,
-  PROJECT_PIPELINE_FILENAME
+  PROJECT_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { AzureDevOpsOpts } from "../../lib/git";
 import {
   getOriginUrl,
   getRepositoryName,
   getRepositoryUrl,
-  isGitHubUrl
+  isGitHubUrl,
 } from "../../lib/gitutils";
 import {
   createPipelineForDefinition,
   definitionForAzureRepoPipeline,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 import { logger } from "../../logger";
 import { BedrockFileInfo, ConfigYaml } from "../../types";
@@ -86,11 +86,11 @@ export const fetchValidateValues = (
       opts.pipelineName || getRepositoryName(gitOriginUrl) + "-lifecycle",
     repoName: getRepositoryName(gitOriginUrl),
     repoUrl: opts.repoUrl || getRepositoryUrl(gitOriginUrl),
-    yamlFileBranch: opts.yamlFileBranch
+    yamlFileBranch: opts.yamlFileBranch,
   };
 
   const map: { [key: string]: string | undefined } = {};
-  (Object.keys(values) as Array<keyof CommandOptions>).forEach(key => {
+  (Object.keys(values) as Array<keyof CommandOptions>).forEach((key) => {
     const val = values[key];
     if (key === "personalAccessToken") {
       logger.debug(`${key}: XXXXXXXXXXXXXXXXX`);
@@ -116,8 +116,8 @@ export const requiredPipelineVariables = (
     BUILD_SCRIPT_URL: {
       allowOverride: true,
       isSecret: false,
-      value: buildScriptUrl
-    }
+      value: buildScriptUrl,
+    },
   };
 };
 
@@ -134,7 +134,7 @@ const createPipeline = async (
     repositoryUrl: values.repoUrl!,
     variables: requiredPipelineVariables(values.buildScriptUrl!),
     yamlFileBranch: definitionBranch, // Pipeline is defined in master
-    yamlFilePath: PROJECT_PIPELINE_FILENAME // Pipeline definition lives in root directory.
+    yamlFilePath: PROJECT_PIPELINE_FILENAME, // Pipeline definition lives in root directory.
   });
 
   logger.info(
@@ -231,7 +231,7 @@ export const execute = async (
       const accessOpts: AzureDevOpsOpts = {
         orgName: values.orgName,
         personalAccessToken: values.personalAccessToken,
-        project: values.devopsProject
+        project: values.devopsProject,
       };
       await repositoryHasFile(
         PROJECT_PIPELINE_FILENAME,

--- a/src/commands/ring/create.test.ts
+++ b/src/commands/ring/create.test.ts
@@ -1,6 +1,6 @@
 import {
   create as createBedrockYaml,
-  read as loadBedrockFile
+  read as loadBedrockFile,
 } from "../../lib/bedrockYaml";
 import * as fileUtils from "../../lib/fileutils";
 import { createTempDir } from "../../lib/ioUtil";
@@ -29,12 +29,12 @@ describe("checkDependencies", () => {
     createBedrockYaml(tmpDir, {
       rings: {
         master: {
-          isDefault: true
-        }
+          isDefault: true,
+        },
       },
       services: {},
       variableGroups: ["testvg"],
-      version: "1.0"
+      version: "1.0",
     });
     checkDependencies(tmpDir, "not-master");
     // No errors thrown, this is a pass for the function.
@@ -43,12 +43,12 @@ describe("checkDependencies", () => {
     const tmpDir = createBedrockYaml(undefined, {
       rings: {
         master: {
-          isDefault: true
-        }
+          isDefault: true,
+        },
       },
       services: {},
       variableGroups: ["testvg"],
-      version: "1.0"
+      version: "1.0",
     });
     expect(() => {
       checkDependencies(tmpDir, "master");
@@ -91,8 +91,8 @@ describe("test execute function and logic", () => {
     createBedrockYaml(tmpDir, {
       rings: {
         master: {
-          isDefault: true
-        }
+          isDefault: true,
+        },
       },
       services: {
         "./my-service": {
@@ -100,14 +100,14 @@ describe("test execute function and logic", () => {
             chart: {
               branch: "master",
               git: "https://github.com/catalystcode/spk-demo-repo.git",
-              path: "my-service"
-            }
+              path: "my-service",
+            },
           },
-          k8sBackendPort: 80
-        }
+          k8sBackendPort: 80,
+        },
       },
       variableGroups: ["testvg"],
-      version: "1.0"
+      version: "1.0",
     });
 
     const newRingName = "my-new-ring";

--- a/src/commands/ring/create.ts
+++ b/src/commands/ring/create.ts
@@ -2,12 +2,12 @@ import commander from "commander";
 import {
   addNewRing,
   fileInfo as bedrockFileInfo,
-  read as loadBedrockFile
+  read as loadBedrockFile,
 } from "../../lib/bedrockYaml";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   BEDROCK_FILENAME,
-  PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE
+  PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE,
 } from "../../lib/constants";
 import { updateTriggerBranchesForServiceBuildAndUpdatePipeline } from "../../lib/fileutils";
 import * as dns from "../../lib/net/dns";
@@ -75,7 +75,7 @@ export const execute = async (
       ([serviceRelativeDir]) => serviceRelativeDir
     );
 
-    servicePathDirectories.forEach(s => {
+    servicePathDirectories.forEach((s) => {
       updateTriggerBranchesForServiceBuildAndUpdatePipeline(newRings, s);
     });
 

--- a/src/commands/ring/index.ts
+++ b/src/commands/ring/index.ts
@@ -5,7 +5,7 @@ const subcommands = ["create", "delete", "set-default"];
 export const commandDecorator = Command(
   "ring",
   "Ring management for a bedrock project.",
-  subcommands.map(m => {
+  subcommands.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/ring/set-default.test.ts
+++ b/src/commands/ring/set-default.test.ts
@@ -37,13 +37,13 @@ describe("test execute function and logic", () => {
     createBedrockYaml(tmpDir, {
       rings: {
         master: {
-          isDefault: true
+          isDefault: true,
         },
-        prod: {}
+        prod: {},
       },
       services: {},
       variableGroups: ["testvg"],
-      version: "1.0"
+      version: "1.0",
     });
     await execute("prod", tmpDir, exitFn);
 

--- a/src/commands/ring/set-default.ts
+++ b/src/commands/ring/set-default.ts
@@ -3,7 +3,7 @@ import commander from "commander";
 import {
   fileInfo as bedrockFileInfo,
   read as loadBedrockFile,
-  setDefaultRing
+  setDefaultRing,
 } from "../../lib/bedrockYaml";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { PROJECT_INIT_DEPENDENCY_ERROR_MESSAGE } from "../../lib/constants";

--- a/src/commands/service/create-revision.test.ts
+++ b/src/commands/service/create-revision.test.ts
@@ -10,7 +10,7 @@ import {
   getDefaultRings,
   getRemoteUrl,
   getSourceBranch,
-  makePullRequest
+  makePullRequest,
 } from "./create-revision";
 import * as createRevision from "./create-revision";
 
@@ -22,7 +22,7 @@ jest.spyOn(config, "Config").mockReturnValue({});
 jest.spyOn(config, "Bedrock").mockReturnValue(BedrockMockedContent);
 
 describe("test makePullRequest function", () => {
-  it("sanity test", async done => {
+  it("sanity test", async (done) => {
     const createPullRequestFunc = jest.spyOn(azure, "createPullRequest");
 
     // two times because there are two branches: master and stable
@@ -35,7 +35,7 @@ describe("test makePullRequest function", () => {
       remoteUrl: "testUrl",
       sourceBranch: "testBranch",
       targetBranch: "master",
-      title: undefined
+      title: undefined,
     });
 
     expect(createPullRequestFunc).toBeCalledTimes(2);
@@ -50,23 +50,23 @@ describe("Default rings", () => {
       rings: {
         master: { isDefault: true },
         prod: { isDefault: false },
-        westus: { isDefault: true }
+        westus: { isDefault: true },
       },
       services: {
         "foo/a": {
           helm: {
             chart: {
               chart: "elastic",
-              repository: "some-repo"
-            }
+              repository: "some-repo",
+            },
           },
           k8sBackend: "backendservice",
           k8sBackendPort: 1337,
           pathPrefix: "servicepath",
-          pathPrefixMajorVersion: "v1"
-        }
+          pathPrefixMajorVersion: "v1",
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
 
     write(validBedrockYaml, randomTmpDir);
@@ -82,23 +82,23 @@ describe("Default rings", () => {
       rings: {
         master: { isDefault: false },
         prod: { isDefault: false },
-        westus: { isDefault: false }
+        westus: { isDefault: false },
       },
       services: {
         "foo/a": {
           helm: {
             chart: {
               chart: "elastic",
-              repository: "some-repo"
-            }
+              repository: "some-repo",
+            },
           },
           k8sBackend: "backendservice",
           k8sBackendPort: 1337,
           pathPrefix: "servicepath",
-          pathPrefixMajorVersion: "v1"
-        }
+          pathPrefixMajorVersion: "v1",
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
 
     write(validBedrockYaml, randomTmpDir);
@@ -114,19 +114,19 @@ describe("Default rings", () => {
 });
 
 describe("Source branch", () => {
-  test("Defined source branch", async done => {
+  test("Defined source branch", async (done) => {
     const branch = "master";
     const sourceBranch = await getSourceBranch(branch);
     expect(sourceBranch).toBe("master");
     done();
   });
-  test("Defined source branch", async done => {
+  test("Defined source branch", async (done) => {
     const branch = undefined;
     const sourceBranch = await getSourceBranch(branch);
     expect(sourceBranch).toBe("prod");
     done();
   });
-  test("No source branch", async done => {
+  test("No source branch", async (done) => {
     const branch = undefined;
     let hasError = false;
     try {
@@ -140,7 +140,7 @@ describe("Source branch", () => {
 });
 
 describe("Create pull request", () => {
-  test("invalid parameters", async done => {
+  test("invalid parameters", async (done) => {
     for (const i of Array(4).keys()) {
       const exitFn = jest.fn();
       jest
@@ -154,7 +154,7 @@ describe("Create pull request", () => {
           remoteUrl: i === 2 ? undefined : "url",
           sourceBranch: i === 3 ? undefined : "master",
           targetBranch: undefined,
-          title: "testTitle"
+          title: "testTitle",
         },
         exitFn
       );
@@ -163,7 +163,7 @@ describe("Create pull request", () => {
       done();
     }
   });
-  test("Invalid parameters: target include source git", async done => {
+  test("Invalid parameters: target include source git", async (done) => {
     const exitFn = jest.fn();
     jest
       .spyOn(createRevision, "makePullRequest")
@@ -176,7 +176,7 @@ describe("Create pull request", () => {
         remoteUrl: "testUrl",
         sourceBranch: "master",
         targetBranch: "master",
-        title: "testTitle"
+        title: "testTitle",
       },
       exitFn
     );
@@ -184,7 +184,7 @@ describe("Create pull request", () => {
     expect(exitFn.mock.calls).toEqual([[1]]);
     done();
   });
-  test("Valid parameters", async done => {
+  test("Valid parameters", async (done) => {
     const exitFn = jest.fn();
     jest
       .spyOn(createRevision, "makePullRequest")
@@ -197,7 +197,7 @@ describe("Create pull request", () => {
         remoteUrl: "testUrl",
         sourceBranch: "testBranch",
         targetBranch: "master",
-        title: "testTitle"
+        title: "testTitle",
       },
       exitFn
     );
@@ -205,7 +205,7 @@ describe("Create pull request", () => {
     expect(exitFn.mock.calls).toEqual([[0]]);
     done();
   });
-  test("Default description", async done => {
+  test("Default description", async (done) => {
     const exitFn = jest.fn();
     jest
       .spyOn(createRevision, "makePullRequest")
@@ -218,7 +218,7 @@ describe("Create pull request", () => {
         remoteUrl: "testUrl",
         sourceBranch: "testBranch",
         targetBranch: "master",
-        title: "testTitle"
+        title: "testTitle",
       },
       exitFn
     );
@@ -226,7 +226,7 @@ describe("Create pull request", () => {
     expect(exitFn.mock.calls).toEqual([[0]]);
     done();
   });
-  it("Default title", async done => {
+  it("Default title", async (done) => {
     const exitFn = jest.fn();
     jest
       .spyOn(createRevision, "makePullRequest")
@@ -239,7 +239,7 @@ describe("Create pull request", () => {
         remoteUrl: "testUrl",
         sourceBranch: "testBranch",
         targetBranch: "master",
-        title: undefined
+        title: undefined,
       },
       exitFn
     );
@@ -250,12 +250,12 @@ describe("Create pull request", () => {
 });
 
 describe("test getRemoteUrl function", () => {
-  it("sanity test: get original url", async done => {
+  it("sanity test: get original url", async (done) => {
     const res = await getRemoteUrl(undefined);
     expect(!!res.match(/(.*?)\/spk/i)).toBe(true);
     done();
   });
-  it("sanity test", async done => {
+  it("sanity test", async (done) => {
     const res = await getRemoteUrl("https://github.com/CatalystCode/spk1");
     expect(res).toBe("https://github.com/CatalystCode/spk1");
     done();

--- a/src/commands/service/create-revision.ts
+++ b/src/commands/service/create-revision.ts
@@ -6,13 +6,13 @@ import { Bedrock, Config } from "../../config";
 import {
   build as buildCmd,
   exit as exitCmd,
-  validateForRequiredValues
+  validateForRequiredValues,
 } from "../../lib/commandBuilder";
 import { createPullRequest } from "../../lib/git/azure";
 import {
   getCurrentBranch,
   getOriginUrl,
-  safeGitUrlForLogging
+  safeGitUrlForLogging,
 } from "../../lib/gitutils";
 import { hasValue } from "../../lib/validator";
 import { logger } from "../../logger";
@@ -57,8 +57,8 @@ export const getDefaultRings = (
     ? [targetBranch]
     : Object.entries(bedrockConfig.rings || {})
         .map(([branch, config]) => ({ branch, ...config }))
-        .filter(ring => !!ring.isDefault)
-        .map(ring => ring.branch);
+        .filter((ring) => !!ring.isDefault)
+        .map((ring) => ring.branch);
   if (defaultRings.length === 0) {
     throw Error(
       `Default branches/rings must either be specified in ${join(
@@ -111,7 +111,7 @@ export const makePullRequest = async (
       description: opts.description!,
       orgName: opts.orgName!,
       originPushUrl: opts.remoteUrl!,
-      personalAccessToken: opts.personalAccessToken!
+      personalAccessToken: opts.personalAccessToken!,
     });
   }
 };
@@ -154,7 +154,7 @@ export const execute = async (
       orgName: opts.orgName,
       personalAccessToken: opts.personalAccessToken,
       remoteUrl: opts.remoteUrl,
-      sourceBranch: opts.sourceBranch
+      sourceBranch: opts.sourceBranch,
     });
 
     if (errors.length > 0) {

--- a/src/commands/service/create.test.ts
+++ b/src/commands/service/create.test.ts
@@ -16,11 +16,11 @@ import { deepClone } from "../../lib/util";
 import {
   disableVerboseLogging,
   enableVerboseLogging,
-  logger
+  logger,
 } from "../../logger";
 import {
   createTestBedrockYaml,
-  createTestMaintainersYaml
+  createTestMaintainersYaml,
 } from "../../test/mockFactory";
 import {
   assertValidDnsInputs,
@@ -28,7 +28,7 @@ import {
   execute,
   fetchValues,
   CommandValues,
-  validateGitUrl
+  validateGitUrl,
 } from "./create";
 
 jest.mock("../../lib/gitutils");
@@ -65,7 +65,7 @@ const mockValues: CommandValues = {
   pathPrefix: "",
   pathPrefixMajorVersion: "",
   ringNames: [],
-  variableGroups: []
+  variableGroups: [],
 };
 
 const getMockValues = (): CommandValues => {
@@ -85,7 +85,7 @@ const validateDirNFiles = (
   expect(fs.existsSync(serviceDirPath)).toBe(true);
 
   // Verify new azure-pipelines created
-  const filepaths = [SERVICE_PIPELINE_FILENAME, "Dockerfile"].map(filename =>
+  const filepaths = [SERVICE_PIPELINE_FILENAME, "Dockerfile"].map((filename) =>
     path.join(serviceDirPath, filename)
   );
 
@@ -118,7 +118,7 @@ describe("Test fetchValues function", () => {
     const mockedBedrockFileConfig = { ...BedrockMockedContent };
     mockedBedrockFileConfig.rings = {
       master: {},
-      qa: {}
+      qa: {},
     };
     jest.spyOn(config, "Bedrock").mockReturnValueOnce(mockedBedrockFileConfig);
     const mocked = getMockValues();
@@ -142,7 +142,7 @@ describe("isValidDnsInputs", () => {
         displayName: "bar",
         k8sBackend: "my-service",
         pathPrefix: "service",
-        pathPrefixMajorVersion: "v1"
+        pathPrefixMajorVersion: "v1",
       })
     ).not.toThrow();
   });
@@ -153,7 +153,7 @@ describe("isValidDnsInputs", () => {
         displayName: "-not_dns_compliant",
         k8sBackend: "",
         pathPrefix: "",
-        pathPrefixMajorVersion: ""
+        pathPrefixMajorVersion: "",
       })
     ).toThrow();
 
@@ -162,7 +162,7 @@ describe("isValidDnsInputs", () => {
         displayName: "",
         k8sBackend: "-not_dns_compliant",
         pathPrefix: "",
-        pathPrefixMajorVersion: ""
+        pathPrefixMajorVersion: "",
       })
     ).toThrow();
 
@@ -171,7 +171,7 @@ describe("isValidDnsInputs", () => {
         displayName: "",
         k8sBackend: "",
         pathPrefix: "-not_dns_compliant",
-        pathPrefixMajorVersion: ""
+        pathPrefixMajorVersion: "",
       })
     ).toThrow();
 
@@ -180,7 +180,7 @@ describe("isValidDnsInputs", () => {
         displayName: "",
         k8sBackend: "",
         pathPrefix: "",
-        pathPrefixMajorVersion: "-not_dns_compliant"
+        pathPrefixMajorVersion: "-not_dns_compliant",
       })
     ).toThrow();
   });
@@ -218,7 +218,7 @@ describe("Test execute function", () => {
 
     jest.spyOn(bedrockYaml, "fileInfo").mockImplementation(() => ({
       exist: false,
-      hasVariableGroups: false
+      hasVariableGroups: false,
     }));
 
     try {
@@ -236,7 +236,7 @@ describe("Test execute function", () => {
 
     jest.spyOn(bedrockYaml, "fileInfo").mockImplementation(() => ({
       exist: true,
-      hasVariableGroups: false
+      hasVariableGroups: false,
     }));
 
     try {

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -8,18 +8,18 @@ import { Bedrock } from "../../config";
 import {
   addNewService as addNewServiceToBedrockFile,
   fileInfo as bedrockFileInfo,
-  YAML_NAME as BedrockFileName
+  YAML_NAME as BedrockFileName,
 } from "../../lib/bedrockYaml";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   PROJECT_CVG_DEPENDENCY_ERROR_MESSAGE,
-  PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE
+  PROJECT_INIT_CVG_DEPENDENCY_ERROR_MESSAGE,
 } from "../../lib/constants";
 import {
   addNewServiceToMaintainersFile,
   generateDockerfile,
   generateGitIgnoreFile,
-  generateServiceBuildAndUpdatePipelineYaml
+  generateServiceBuildAndUpdatePipelineYaml,
 } from "../../lib/fileutils";
 import { checkoutCommitPushCreatePRLink } from "../../lib/gitutils";
 import * as dns from "../../lib/net/dns";
@@ -65,7 +65,7 @@ export const fetchValues = (opts: CommandOptions): CommandValues => {
 
   let middlewaresArray: string[] = [];
   if (opts.middlewares && opts.middlewares.trim()) {
-    middlewaresArray = opts.middlewares.split(",").map(str => str.trim());
+    middlewaresArray = opts.middlewares.split(",").map((str) => str.trim());
   }
 
   const values: CommandValues = {
@@ -88,7 +88,7 @@ export const fetchValues = (opts: CommandOptions): CommandValues => {
     pathPrefix: opts.pathPrefix,
     pathPrefixMajorVersion: opts.pathPrefixMajorVersion,
     ringNames: rings,
-    variableGroups
+    variableGroups,
   };
 
   // Values do not need to be validated
@@ -299,7 +299,7 @@ export const createService = async (
   // add maintainers to file in parent repo file
   const newUser = {
     email: values.maintainerEmail,
-    name: values.maintainerName
+    name: values.maintainerName,
   } as User;
 
   const newServiceRelativeDir = path.relative(rootProjectPath, newServiceDir);
@@ -318,16 +318,16 @@ export const createService = async (
       ? {
           chart: {
             chart: values.helmChartChart,
-            repository: values.helmChartRepository
-          }
+            repository: values.helmChartRepository,
+          },
         }
       : {
           chart: {
             accessTokenVariable: values.helmConfigAccessTokenVariable,
             branch: values.helmConfigBranch,
             git: values.helmConfigGit,
-            path: values.helmConfigPath
-          }
+            path: values.helmConfigPath,
+          },
         };
 
   addNewServiceToBedrockFile(

--- a/src/commands/service/index.ts
+++ b/src/commands/service/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["create", "create-revision", "pipeline"];
 export const commandDecorator = Command(
   "service",
   "Create and manage services for a Bedrock project.",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/commands/service/pipeline.test.ts
+++ b/src/commands/service/pipeline.test.ts
@@ -6,7 +6,7 @@ jest.mock("../../lib/pipelines/pipelines");
 import {
   createPipelineForDefinition,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 import { deepClone } from "../../lib/util";
 import {
@@ -14,7 +14,7 @@ import {
   fetchValues,
   CommandOptions,
   installBuildUpdatePipeline,
-  requiredPipelineVariables
+  requiredPipelineVariables,
 } from "./pipeline";
 import * as pipeline from "./pipeline";
 
@@ -27,7 +27,7 @@ const MOCKED_VALUES: CommandOptions = {
   pipelineName: "pipelineName",
   repoName: "repositoryName",
   repoUrl: "https://dev.azure.com/test/fabrikam/_git/app",
-  yamlFileBranch: "master"
+  yamlFileBranch: "master",
 };
 
 beforeAll(() => {

--- a/src/commands/service/pipeline.ts
+++ b/src/commands/service/pipeline.ts
@@ -3,7 +3,7 @@
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   BuildDefinition,
-  BuildDefinitionVariable
+  BuildDefinitionVariable,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import commander from "commander";
 import path from "path";
@@ -12,20 +12,20 @@ import { repositoryHasFile } from "../../lib/azdoClient";
 import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import {
   BUILD_SCRIPT_URL,
-  SERVICE_PIPELINE_FILENAME
+  SERVICE_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { AzureDevOpsOpts } from "../../lib/git";
 import {
   getOriginUrl,
   getRepositoryName,
   getRepositoryUrl,
-  isGitHubUrl
+  isGitHubUrl,
 } from "../../lib/gitutils";
 import {
   createPipelineForDefinition,
   definitionForAzureRepoPipeline,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "../../lib/pipelines/pipelines";
 import { logger } from "../../logger";
 import decorator from "./pipeline.decorator.json";
@@ -79,7 +79,7 @@ export const execute = async (
     const accessOpts: AzureDevOpsOpts = {
       orgName: opts.orgName,
       personalAccessToken: opts.personalAccessToken,
-      project: opts.devopsProject
+      project: opts.devopsProject,
     };
 
     // if a packages dir is supplied, its a mono-repo
@@ -145,7 +145,7 @@ export const installBuildUpdatePipeline = async (
       repositoryUrl: values.repoUrl,
       variables: requiredPipelineVariables(values.buildScriptUrl),
       yamlFileBranch: values.yamlFileBranch,
-      yamlFilePath: pipelinesYamlPath
+      yamlFilePath: pipelinesYamlPath,
     });
 
     logger.debug(
@@ -199,7 +199,7 @@ export const requiredPipelineVariables = (
     BUILD_SCRIPT_URL: {
       allowOverride: true,
       isSecret: false,
-      value: buildScriptUrl
-    }
+      value: buildScriptUrl,
+    },
   };
 };

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -20,7 +20,7 @@ import {
   createAppRepoTasks,
   createSPKConfig,
   execute,
-  getErrorMessage
+  getErrorMessage,
 } from "./setup";
 import * as setup from "./setup";
 
@@ -33,7 +33,7 @@ const mockRequestContext: RequestContext = {
   servicePrincipalTenantId: "72f988bf-86f1-41af-91ab-2d7cd011db47",
   subscriptionId: "72f988bf-86f1-41af-91ab-2d7cd011db48",
   toCreateAppRepo: true,
-  workspace: WORKSPACE
+  workspace: WORKSPACE,
 };
 
 describe("test createSPKConfig function", () => {
@@ -45,7 +45,7 @@ describe("test createSPKConfig function", () => {
     expect(data.azure_devops).toStrictEqual({
       access_token: "pat",
       org: "orgname",
-      project: "project"
+      project: "project",
     });
   });
   it("positive test: with service principal", () => {
@@ -64,15 +64,15 @@ describe("test createSPKConfig function", () => {
     expect(data.azure_devops).toStrictEqual({
       access_token: "pat",
       org: "orgname",
-      project: "project"
+      project: "project",
     });
     expect(data.introspection).toStrictEqual({
       azure: {
         service_principal_id: rc.servicePrincipalId,
         service_principal_secret: rc.servicePrincipalPassword,
         subscription_id: rc.subscriptionId,
-        tenant_id: rc.servicePrincipalTenantId
-      }
+        tenant_id: rc.servicePrincipalTenantId,
+      },
     });
   });
 });
@@ -111,7 +111,7 @@ const testExecuteFunc = async (
     Promise.resolve({
       getCoreApi: async () => {
         return {};
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
   );
@@ -137,14 +137,14 @@ const testExecuteFunc = async (
   if (usePrompt) {
     await execute(
       {
-        file: undefined
+        file: undefined,
       },
       exitFn
     );
   } else {
     await execute(
       {
-        file: "dummy"
+        file: "dummy",
       },
       exitFn
     );
@@ -184,9 +184,9 @@ describe("test execute function", () => {
         getCoreApi: () => {
           throw {
             message: "Authentication failure",
-            statusCode: 401
+            statusCode: 401,
           };
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
     );
@@ -194,7 +194,7 @@ describe("test execute function", () => {
 
     await execute(
       {
-        file: undefined
+        file: undefined,
       },
       exitFn
     );
@@ -213,9 +213,9 @@ describe("test execute function", () => {
       Promise.resolve({
         getCoreApi: () => {
           throw {
-            message: "VS402392: "
+            message: "VS402392: ",
           };
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
     );
@@ -223,7 +223,7 @@ describe("test execute function", () => {
 
     await execute(
       {
-        file: undefined
+        file: undefined,
       },
       exitFn
     );
@@ -242,9 +242,9 @@ describe("test execute function", () => {
       Promise.resolve({
         getCoreApi: () => {
           throw {
-            message: "other error"
+            message: "other error",
           };
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
     );
@@ -252,7 +252,7 @@ describe("test execute function", () => {
 
     await execute(
       {
-        file: undefined
+        file: undefined,
       },
       exitFn
     );
@@ -271,15 +271,15 @@ describe("test execute function", () => {
       Promise.resolve({
         getCoreApi: () => {
           throw {
-            message: "other error"
+            message: "other error",
           };
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
     );
     await execute(
       {
-        file: undefined
+        file: undefined,
       },
       exitFn
     );
@@ -300,11 +300,11 @@ describe("test getErrorMessage function", () => {
         accessToken: "pat",
         orgName: "orgName",
         projectName: "projectName",
-        workspace: WORKSPACE
+        workspace: WORKSPACE,
       },
       {
         message: "VS402392: ",
-        statusCode: 400
+        statusCode: 400,
       }
     );
     expect(res).toBe(
@@ -324,7 +324,7 @@ const testCreateAppRepoTasks = async (prApproved = true): Promise<void> => {
     servicePrincipalTenantId: "tenant",
     subscriptionId: "12344",
     acrName: "acr",
-    workspace: "dummy"
+    workspace: "dummy",
   };
 
   jest.spyOn(resourceService, "create").mockResolvedValueOnce(true);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -13,26 +13,26 @@ import {
   RequestContext,
   RESOURCE_GROUP,
   RESOURCE_GROUP_LOCATION,
-  WORKSPACE
+  WORKSPACE,
 } from "../lib/setup/constants";
 import { createDirectory } from "../lib/setup/fsUtil";
 import { getGitApi } from "../lib/setup/gitService";
 import {
   createBuildPipeline,
   createHLDtoManifestPipeline,
-  createLifecyclePipeline
+  createLifecyclePipeline,
 } from "../lib/setup/pipelineService";
 import { createProjectIfNotExist } from "../lib/setup/projectService";
 import {
   getAnswerFromFile,
   prompt,
-  promptForApprovingHLDPullRequest
+  promptForApprovingHLDPullRequest,
 } from "../lib/setup/prompt";
 import {
   appRepo,
   helmRepo,
   hldRepo,
-  manifestRepo
+  manifestRepo,
 } from "../lib/setup/scaffold";
 import { create as createSetupLog } from "../lib/setup/setupLog";
 import { logger } from "../logger";
@@ -58,23 +58,23 @@ export const createSPKConfig = (rc: RequestContext): void => {
         azure_devops: {
           access_token: rc.accessToken,
           org: rc.orgName,
-          project: rc.projectName
+          project: rc.projectName,
         },
         introspection: {
           azure: {
             service_principal_id: rc.servicePrincipalId,
             service_principal_secret: rc.servicePrincipalPassword,
             subscription_id: rc.subscriptionId,
-            tenant_id: rc.servicePrincipalTenantId
-          }
-        }
+            tenant_id: rc.servicePrincipalTenantId,
+          },
+        },
       }
     : {
         azure_devops: {
           access_token: rc.accessToken,
           org: rc.orgName,
-          project: rc.projectName
-        }
+          project: rc.projectName,
+        },
       };
   fs.writeFileSync(defaultConfigFile(), yaml.safeDump(data));
 };

--- a/src/commands/variable-group/create.ts
+++ b/src/commands/variable-group/create.ts
@@ -7,7 +7,7 @@ import { build as buildCmd, exit as exitCmd } from "../../lib/commandBuilder";
 import { AzureDevOpsOpts } from "../../lib/git";
 import {
   addVariableGroup,
-  addVariableGroupWithKeyVaultMap
+  addVariableGroupWithKeyVaultMap,
 } from "../../lib/pipelines/variableGroup";
 import { logger } from "../../logger";
 import { VariableGroupData } from "../../types";
@@ -19,7 +19,7 @@ import decorator from "./create.decorator.json";
  * @param command Commander command object to decorate
  */
 export const commandDecorator = (command: commander.Command): void => {
-  buildCmd(command, decorator).action(async opts => {
+  buildCmd(command, decorator).action(async (opts) => {
     try {
       if (!opts.file) {
         throw new Error(
@@ -61,7 +61,7 @@ export const commandDecorator = (command: commander.Command): void => {
       const accessOpts: AzureDevOpsOpts = {
         orgName,
         personalAccessToken,
-        project: devopsProject
+        project: devopsProject,
       };
       logger.debug(`access options: ${JSON.stringify(accessOpts)}`);
 

--- a/src/commands/variable-group/index.ts
+++ b/src/commands/variable-group/index.ts
@@ -5,7 +5,7 @@ const subfolders = ["create"];
 export const commandDecorator = Command(
   "variable-group",
   "Creates Variable Group in Azure DevOps project.",
-  subfolders.map(m => {
+  subfolders.map((m) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cmd = require(`./${m}`);
     return cmd.commandDecorator;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,7 @@ import {
   loadConfiguration,
   saveConfiguration,
   updateVariableWithLocalEnv,
-  write
+  write,
 } from "./config";
 import { createTempDir } from "./lib/ioUtil";
 import { disableVerboseLogging, enableVerboseLogging } from "./logger";
@@ -64,29 +64,29 @@ describe("Bedrock", () => {
           helm: {
             chart: {
               chart: "elastic",
-              repository: "some-repo"
-            }
+              repository: "some-repo",
+            },
           },
           k8sBackend: "backendservice",
           k8sBackendPort: 1337,
           pathPrefix: "servicepath",
-          pathPrefixMajorVersion: "v1"
+          pathPrefixMajorVersion: "v1",
         },
         "foo/b": {
           helm: {
             chart: {
               git: "foo",
               path: "some/path",
-              sha: "cef8361c62e7a91887625336eb13a8f90dbcf8df"
-            }
+              sha: "cef8361c62e7a91887625336eb13a8f90dbcf8df",
+            },
           },
           k8sBackend: "backendservice",
           k8sBackendPort: 1337,
           pathPrefix: "servicepath",
-          pathPrefixMajorVersion: "v1"
-        }
+          pathPrefixMajorVersion: "v1",
+        },
       },
-      version: "1.0"
+      version: "1.0",
     };
     write(validBedrockYaml, randomTmpDir);
     const expectedFilePath = path.join(randomTmpDir, "bedrock.yaml");
@@ -110,21 +110,21 @@ describe("Bedrock", () => {
           helm: {
             // Missing 'chart'
             chart: {
-              repository: "some-repo"
-            }
-          }
+              repository: "some-repo",
+            },
+          },
         },
         "foo/b": {
           helm: {
             // missing 'path'
             chart: {
               git: "foo",
-              sha: "cef8361c62e7a91887625336eb13a8f90dbcf8df"
-            }
-          }
-        }
+              sha: "cef8361c62e7a91887625336eb13a8f90dbcf8df",
+            },
+          },
+        },
       },
-      version: "1.0"
+      version: "1.0",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
     write(validBedrockYaml, randomTmpDir);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import {
   AzurePipelinesYaml,
   BedrockFile,
   ConfigYaml,
-  MaintainersFile
+  MaintainersFile,
 } from "./types";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -182,7 +182,7 @@ export const Bedrock = (fileDirectory = process.cwd()): BedrockFile => {
         );
       }
     })
-    .filter(e => !!e) as Error[];
+    .filter((e) => !!e) as Error[];
   // log all the errors and throw an exception if their are any
   if (helmErrors.length > 0) {
     for (const error of helmErrors) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const commandModules = [
   "project",
   // "ring", // Uncomment when ready to add rings
   "service",
-  "variable-group"
+  "variable-group",
 ];
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ const commandModules = [
 ////////////////////////////////////////////////////////////////////////////////
 (async (): Promise<void> => {
   const cmds = await Promise.all(
-    commandModules.map(async m => {
+    commandModules.map(async (m) => {
       const cmd = await import(`./commands/${m}`);
       return cmd.commandDecorator;
     })
@@ -48,7 +48,7 @@ const commandModules = [
         c.version(require("../package.json").version);
       },
       initCommandDecorator,
-      setupCommandDecorator
+      setupCommandDecorator,
     ],
     cmds
   );

--- a/src/lib/azdoClient.test.ts
+++ b/src/lib/azdoClient.test.ts
@@ -11,7 +11,7 @@ import {
   getTaskAgentApi,
   getWebApi,
   invalidateWebApi,
-  repositoryHasFile
+  repositoryHasFile,
 } from "./azdoClient";
 import * as azdoClient from "./azdoClient";
 import { AzureDevOpsOpts } from "./git";
@@ -35,8 +35,8 @@ const mockConfig = (token?: string, org?: string): void => {
   (Config as jest.Mock).mockReturnValueOnce({
     azure_devops: {
       access_token: token,
-      org
-    }
+      org,
+    },
   });
 };
 
@@ -74,7 +74,7 @@ describe("test getTaskAgentApi function", () => {
     const mockFn = jest.spyOn(azdoClient, "getWebApi").mockReturnValueOnce({
       getTaskAgentApi: () => {
         return {};
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
@@ -101,7 +101,7 @@ describe("test getRestClient function", () => {
     mockConfig(TOKEN, ORG);
     const mockFn = jest.spyOn(azdoClient, "getWebApi").mockReturnValueOnce(
       Promise.resolve({
-        rest: {}
+        rest: {},
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
     );
@@ -130,7 +130,7 @@ describe("test getBuildApi function", () => {
     const mockFn = jest.spyOn(azdoClient, "getWebApi").mockReturnValueOnce({
       getBuildApi: () => {
         return {};
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
@@ -154,7 +154,7 @@ describe("repositoryHasFile", () => {
     const accessOpts: AzureDevOpsOpts = {
       orgName: "testOrg",
       personalAccessToken: "mytoken",
-      project: "testProject"
+      project: "testProject",
     };
     let hasError = false;
 
@@ -179,7 +179,7 @@ describe("repositoryHasFile", () => {
     const accessOpts: AzureDevOpsOpts = {
       orgName: "testOrg",
       personalAccessToken: "mytoken",
-      project: "testProject"
+      project: "testProject",
     };
     let hasError = false;
 

--- a/src/lib/azdoClient.ts
+++ b/src/lib/azdoClient.ts
@@ -38,7 +38,7 @@ export const getWebApi = async (
   const config = Config();
   const {
     personalAccessToken = config.azure_devops?.access_token,
-    orgName = config.azure_devops?.org
+    orgName = config.azure_devops?.org,
   } = opts;
 
   // PAT and devops URL are required

--- a/src/lib/azure/azurecredentials.test.ts
+++ b/src/lib/azure/azurecredentials.test.ts
@@ -5,36 +5,36 @@ import { ConfigYaml } from "../../types";
 import { getCredentials, getManagementCredentials } from "./azurecredentials";
 
 describe("test getCredentials function", () => {
-  it("missing values", async done => {
+  it("missing values", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
-      introspection: {}
+      introspection: {},
     });
     const cred = await getCredentials({});
     expect(cred).toBe(undefined);
     done();
   });
-  it("positive tests: taking values from config", async done => {
+  it("positive tests: taking values from config", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
       introspection: {
         azure: {
           service_principal_id: "servicePrincipalId",
           service_principal_secret: "servicePrincipalPassword",
-          tenant_id: "tenantId"
-        }
-      }
+          tenant_id: "tenantId",
+        },
+      },
     } as ConfigYaml);
     const cred = await getCredentials({});
     expect(cred).toBeDefined();
     done();
   });
-  it("positive tests", async done => {
+  it("positive tests", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
-      introspection: {}
+      introspection: {},
     });
     const cred = await getCredentials({
       servicePrincipalId: "servicePrincipalId",
       servicePrincipalPassword: "servicePrincipalPassword",
-      tenantId: "tenantId"
+      tenantId: "tenantId",
     });
     expect(cred).toBeDefined();
     done();
@@ -42,23 +42,23 @@ describe("test getCredentials function", () => {
 });
 
 describe("test getManagementCredentials function", () => {
-  it("missing values", async done => {
+  it("missing values", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
-      introspection: {}
+      introspection: {},
     });
     const cred = await getManagementCredentials({});
     expect(cred).toBe(undefined);
     done();
   });
-  it("positive tests: taking values from config", async done => {
+  it("positive tests: taking values from config", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
       introspection: {
         azure: {
           service_principal_id: "servicePrincipalId",
           service_principal_secret: "servicePrincipalPassword",
-          tenant_id: "tenantId"
-        }
-      }
+          tenant_id: "tenantId",
+        },
+      },
     } as ConfigYaml);
     jest
       .spyOn(msRestNodeAuth, "loginWithServicePrincipalSecret")
@@ -67,9 +67,9 @@ describe("test getManagementCredentials function", () => {
     expect(cred).toBeUndefined(); // not defined because loginWithServicePrincipalSecret mock is returing undefined
     done();
   });
-  it("positive tests", async done => {
+  it("positive tests", async (done) => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
-      introspection: {}
+      introspection: {},
     });
     jest
       .spyOn(msRestNodeAuth, "loginWithServicePrincipalSecret")
@@ -77,7 +77,7 @@ describe("test getManagementCredentials function", () => {
     const cred = await getManagementCredentials({
       servicePrincipalId: "servicePrincipalId",
       servicePrincipalPassword: "servicePrincipalPassword",
-      tenantId: "tenantId"
+      tenantId: "tenantId",
     });
     expect(cred).toBeUndefined(); // not defined because loginWithServicePrincipalSecret mock is returing undefined
     done();

--- a/src/lib/azure/containerRegistryService.test.ts
+++ b/src/lib/azure/containerRegistryService.test.ts
@@ -1,6 +1,6 @@
 import {
   RegistriesCreateResponse,
-  RegistriesListResponse
+  RegistriesListResponse,
 } from "@azure/arm-containerregistry/src/models";
 
 import * as restAuth from "@azure/ms-rest-nodeauth";
@@ -8,7 +8,7 @@ import {
   create,
   getContainerRegistries,
   getContainerRegistry,
-  isExist
+  isExist,
 } from "./containerRegistryService";
 import * as containerRegistryService from "./containerRegistryService";
 
@@ -26,17 +26,17 @@ jest.mock("@azure/arm-containerregistry", () => {
               {
                 id:
                   "/subscriptions/dd831253-787f-4dc8-8eb0-ac9d052177d9/resourceGroups/bedrockSPK/providers/Microsoft.ContainerRegistry/registries/acrWest",
-                name: "acrWest"
-              }
+                name: "acrWest",
+              },
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ] as any;
-          }
-        }
+          },
+        },
       };
     }
   }
   return {
-    ContainerRegistryManagementClient: MockClient
+    ContainerRegistryManagementClient: MockClient,
   };
 });
 
@@ -80,8 +80,8 @@ describe("test container registries function", () => {
         id:
           "/subscriptions/dd831253-787f-4dc8-8eb0-ac9d052177d9/resourceGroups/bedrockSPK/providers/Microsoft.ContainerRegistry/registries/acrWest",
         name: "acrWest",
-        resourceGroup: "bedrockSPK"
-      }
+        resourceGroup: "bedrockSPK",
+      },
     ]);
   });
   it("cache test", async () => {
@@ -102,8 +102,8 @@ describe("test container registries function", () => {
         {
           id: "fakeId",
           name: "test",
-          resourceGroup: RESOURCE_GROUP
-        }
+          resourceGroup: RESOURCE_GROUP,
+        },
       ]);
     const res = await isExist(
       servicePrincipalId,
@@ -134,8 +134,8 @@ describe("test container registries function", () => {
         {
           id: "fakeId",
           name: "test1",
-          resourceGroup: RESOURCE_GROUP
-        }
+          resourceGroup: RESOURCE_GROUP,
+        },
       ]);
     const res = await isExist(
       servicePrincipalId,
@@ -182,7 +182,7 @@ describe("test getContainerRegistry function", () => {
       id:
         "/subscriptions/dd831253-787f-4dc8-8eb0-ac9d052177d9/resourceGroups/quick-start-rg/providers/Microsoft.ContainerRegistry/registries/quickStartACR",
       name: "quickStartACR",
-      resourceGroup: "quick-start-rg"
+      resourceGroup: "quick-start-rg",
     };
     jest
       .spyOn(containerRegistryService, "getContainerRegistries")

--- a/src/lib/azure/containerRegistryService.ts
+++ b/src/lib/azure/containerRegistryService.ts
@@ -63,13 +63,13 @@ export const getContainerRegistries = async (
   );
   const registries = await client.registries.list();
   logger.info("Successfully acquired Azure container registries");
-  return registries.map(r => {
+  return registries.map((r) => {
     const id = r.id! as string;
     const match = id.match(/\/resourceGroups\/(.+?)\//);
     return {
       id,
       name: r.name!,
-      resourceGroup: match ? match[1] : ""
+      resourceGroup: match ? match[1] : "",
     };
   });
 };
@@ -97,7 +97,7 @@ export const getContainerRegistry = async (
     subscriptionId
   );
   return registries.find(
-    r => r.resourceGroup === resourceGroup && r.name === name
+    (r) => r.resourceGroup === resourceGroup && r.name === name
   );
 };
 
@@ -126,7 +126,7 @@ export const isExist = async (
   );
 
   return (registries || []).some(
-    r => r.name === name // ACR name will be unique across Azure so only check the name.
+    (r) => r.name === name // ACR name will be unique across Azure so only check the name.
   );
 };
 
@@ -174,7 +174,7 @@ export const create = async (
   );
   await client.registries.create(resourceGroup, name, {
     location,
-    sku: { name: "Standard", tier: "Standard" }
+    sku: { name: "Standard", tier: "Standard" },
   });
   logger.info(
     `Successfully create Azure container registry, ${name} in ${resourceGroup}.`

--- a/src/lib/azure/deploymenttable.test.ts
+++ b/src/lib/azure/deploymenttable.test.ts
@@ -21,14 +21,14 @@ import {
   updateLastHLDtoManifestEntry,
   updateLastRowOfArcToHLDPipelines,
   updateManifestCommitId,
-  updateMatchingArcToHLDPipelineEntry
+  updateMatchingArcToHLDPipelineEntry,
 } from "./deploymenttable";
 
 const mockedTableInfo: DeploymentTable = {
   accountKey: Buffer.from(uuid()).toString("base64"),
   accountName: uuid(),
   partitionKey: uuid(),
-  tableName: uuid()
+  tableName: uuid(),
 };
 const mockedPipelineId = uuid();
 const mockedPipelineId2 = uuid();
@@ -46,13 +46,13 @@ const mockedEntryACRPipeline: deploymenttable.EntrySRCToACRPipeline = {
   RowKey: uuid(),
   commitId: mockedCommitId,
   env: {
-    _: mockedEnv
+    _: mockedEnv,
   },
   imageTag: mockedImageTag,
   p1: {
-    _: mockedPipelineId
+    _: mockedPipelineId,
   },
-  service: mockedServiceName
+  service: mockedServiceName,
 };
 
 const mockedEntryACRToHLDPipeline = {
@@ -60,17 +60,17 @@ const mockedEntryACRToHLDPipeline = {
   RowKey: uuid(),
   commitId: mockedCommitId,
   env: {
-    _: mockedEnv
+    _: mockedEnv,
   },
   hldCommitId: {
-    _: mockedHldCommitId
+    _: mockedHldCommitId,
   },
   imageTag: mockedImageTag,
   p1: mockedPipelineId,
   p2: {
-    _: mockedPipelineId
+    _: mockedPipelineId,
   },
-  service: mockedServiceName
+  service: mockedServiceName,
 };
 
 const mockedNonMatchEntryACRToHLDPipeline = {
@@ -78,17 +78,17 @@ const mockedNonMatchEntryACRToHLDPipeline = {
   RowKey: uuid(),
   commitId: mockedCommitId,
   env: {
-    _: mockedEnv
+    _: mockedEnv,
   },
   hldCommitId: {
-    _: mockedHldCommitId
+    _: mockedHldCommitId,
   },
   imageTag: mockedImageTag,
   p1: mockedPipelineId,
   p2: {
-    _: uuid()
+    _: uuid(),
   },
-  service: mockedServiceName
+  service: mockedServiceName,
 };
 
 const mockedRowACRToHLDPipeline = {
@@ -101,13 +101,13 @@ const mockedRowACRToHLDPipeline = {
   p1: mockedPipelineId,
   p2: mockedPipelineId2,
   pr: mockedPr,
-  service: mockedServiceName
+  service: mockedServiceName,
 };
 
 const mockedRowHLDToManifestPipeline = Object.assign(
   {
     manifestCommitId: mockedManifestCommitId,
-    p3: mockedPipelineId3
+    p3: mockedPipelineId3,
   },
   mockedRowACRToHLDPipeline
 ) as RowHLDToManifestPipeline;
@@ -120,19 +120,19 @@ const mockedEntryHLDToManifestPipeline = {
   hldCommitId: mockedHldCommitId,
   imageTag: mockedImageTag,
   manifestCommitId: {
-    _: mockedManifestCommitId
+    _: mockedManifestCommitId,
   },
   p1: mockedPipelineId,
   p2: mockedPipelineId2,
   p3: {
-    _: mockedPipelineId3
+    _: mockedPipelineId3,
   },
-  service: mockedServiceName
+  service: mockedServiceName,
 };
 
 const mockedManifestRow: RowManifest = Object.assign(
   {
-    manifestCommitId: uuid()
+    manifestCommitId: uuid(),
   },
   mockedRowHLDToManifestPipeline
 );
@@ -146,7 +146,7 @@ afterAll(() => {
 });
 
 describe("test findMatchingDeployments function", () => {
-  it("catching exception", async done => {
+  it("catching exception", async (done) => {
     await expect(
       findMatchingDeployments(mockedTableInfo, "", "")
     ).rejects.toThrow();
@@ -155,7 +155,7 @@ describe("test findMatchingDeployments function", () => {
 });
 
 describe("test table operation functions", () => {
-  it("catching exception", async done => {
+  it("catching exception", async (done) => {
     await expect(
       insertToTable(mockedTableInfo, mockedEntryACRToHLDPipeline)
     ).rejects.toThrow();
@@ -177,7 +177,7 @@ describe("test getTableService function", () => {
 });
 
 describe("test addSrcToACRPipeline function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -194,7 +194,7 @@ describe("test addSrcToACRPipeline function", () => {
     expect(entry.imageTag).toBe(mockedImageTag);
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.reject(new Error("Error")));
@@ -212,7 +212,7 @@ describe("test addSrcToACRPipeline function", () => {
 });
 
 describe("test updateMatchingArcToHLDPipelineEntry function", () => {
-  it("positive test: matching entry", async done => {
+  it("positive test: matching entry", async (done) => {
     jest
       .spyOn(deploymenttable, "updateEntryInTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -229,7 +229,7 @@ describe("test updateMatchingArcToHLDPipelineEntry function", () => {
     expect(result).toBeDefined();
     done();
   });
-  it("positive test: no matching entries", async done => {
+  it("positive test: no matching entries", async (done) => {
     const result = await updateMatchingArcToHLDPipelineEntry(
       [],
       mockedTableInfo,
@@ -273,12 +273,12 @@ const testUpdateLastRowOfArcToHLDPipelines = async (
 };
 
 describe("test updateLastRowOfArcToHLDPipelines function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     const result = await testUpdateLastRowOfArcToHLDPipelines();
     expect(result).toBeDefined();
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     await expect(testUpdateLastRowOfArcToHLDPipelines(false)).rejects.toThrow();
     done();
   });
@@ -300,12 +300,12 @@ const testAddNewRowToArcToHLDPipelines = async (
 };
 
 describe("test addNewRowToArcToHLDPipelines function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     const result = await testAddNewRowToArcToHLDPipelines();
     expect(result).toBeDefined();
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     await expect(testAddNewRowToArcToHLDPipelines(false)).rejects.toThrow();
     done();
   });
@@ -381,15 +381,15 @@ const testUpdateACRToHLDPipeline = async (
 };
 
 describe("test updateACRToHLDPipeline function", () => {
-  it("positive test: matching entry", async done => {
+  it("positive test: matching entry", async (done) => {
     await testUpdateACRToHLDPipeline(false, true);
     done();
   });
-  it("positive test: no matching entries", async done => {
+  it("positive test: no matching entries", async (done) => {
     await testUpdateACRToHLDPipeline(false, false);
     done();
   });
-  it("positive test: no entries returned", async done => {
+  it("positive test: no entries returned", async (done) => {
     await testUpdateACRToHLDPipeline(true, false);
     done();
   });
@@ -430,18 +430,18 @@ const testUpdateHLDToManifestPipeline = async (
 };
 
 describe("test updateHLDToManifestPipeline function", () => {
-  it("positive test: matching hldCommitId entry", async done => {
+  it("positive test: matching hldCommitId entry", async (done) => {
     await testUpdateHLDToManifestPipeline();
     done();
   });
-  it("positive test: matching pr entry", async done => {
+  it("positive test: matching pr entry", async (done) => {
     await testUpdateHLDToManifestPipeline(false);
     done();
   });
 });
 
 describe("test updateHLDtoManifestEntry function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest
       .spyOn(deploymenttable, "updateEntryInTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -457,7 +457,7 @@ describe("test updateHLDtoManifestEntry function", () => {
     expect(res).toBeDefined();
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     const res = await updateHLDtoManifestEntry(
       [mockedEntryHLDToManifestPipeline],
       mockedTableInfo,
@@ -469,7 +469,7 @@ describe("test updateHLDtoManifestEntry function", () => {
     expect(res).toBeNull();
     done();
   });
-  it("negative test: exception thrown", async done => {
+  it("negative test: exception thrown", async (done) => {
     const fn = jest.spyOn(deploymenttable, "updateEntryInTable");
     fn.mockReturnValueOnce(Promise.reject(new Error("Fake")));
 
@@ -488,7 +488,7 @@ describe("test updateHLDtoManifestEntry function", () => {
 });
 
 describe("test updateLastHLDtoManifestEntry function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -504,7 +504,7 @@ describe("test updateLastHLDtoManifestEntry function", () => {
     expect(res).toBeDefined();
     done();
   });
-  it("negative test: exeption thrown", async done => {
+  it("negative test: exeption thrown", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.reject(new Error("Fake")));
@@ -524,7 +524,7 @@ describe("test updateLastHLDtoManifestEntry function", () => {
 });
 
 describe("test addNewRowToHLDtoManifestPipeline function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -538,7 +538,7 @@ describe("test addNewRowToHLDtoManifestPipeline function", () => {
     expect(res).toBeDefined();
     done();
   });
-  it("nagative test", async done => {
+  it("nagative test", async (done) => {
     jest
       .spyOn(deploymenttable, "insertToTable")
       .mockReturnValueOnce(Promise.reject(new Error("Fake")));
@@ -612,22 +612,22 @@ const testUpdateHLDtoManifestHelper = async (
 };
 
 describe("test updateHLDtoManifestHelper function", () => {
-  it("positive test: matching entry", async done => {
+  it("positive test: matching entry", async (done) => {
     await testUpdateHLDtoManifestHelper(false, true);
     done();
   });
-  it("positive test: no matching entries", async done => {
+  it("positive test: no matching entries", async (done) => {
     await testUpdateHLDtoManifestHelper(false, false);
     done();
   });
-  it("positive test: empty entries", async done => {
+  it("positive test: empty entries", async (done) => {
     await testUpdateHLDtoManifestHelper(true, false);
     done();
   });
 });
 
 describe("test updateManifestCommitId function", () => {
-  it("positive test", async done => {
+  it("positive test", async (done) => {
     jest
       .spyOn(deploymenttable, "updateEntryInTable")
       .mockReturnValueOnce(Promise.resolve());
@@ -642,7 +642,7 @@ describe("test updateManifestCommitId function", () => {
     expect(res).toBeDefined();
     done();
   });
-  it("negative test", async done => {
+  it("negative test", async (done) => {
     jest
       .spyOn(deploymenttable, "findMatchingDeployments")
       .mockReturnValueOnce(Promise.resolve([]));

--- a/src/lib/azure/deploymenttable.ts
+++ b/src/lib/azure/deploymenttable.ts
@@ -151,7 +151,7 @@ export const addSrcToACRPipeline = async (
     commitId,
     imageTag,
     p1: pipelineId,
-    service: serviceName
+    service: serviceName,
   };
   if (repository) {
     entry.sourceRepo = repository.toLowerCase();
@@ -200,7 +200,7 @@ export const updateMatchingArcToHLDPipelineEntry = async (
       p1: found.p1,
       p2: pipelineId.toLowerCase(),
       service: found.service,
-      sourceRepo: found.sourceRepo
+      sourceRepo: found.sourceRepo,
     };
     if (pr) {
       updateEntry.pr = pr.toLowerCase();
@@ -250,7 +250,7 @@ export const updateLastRowOfArcToHLDPipelines = async (
     p1: lastEntry.p1,
     p2: pipelineId.toLowerCase(),
     service: lastEntry.service,
-    sourceRepo: lastEntry.sourceRepo
+    sourceRepo: lastEntry.sourceRepo,
   };
   if (pr) {
     last.pr = pr.toLowerCase();
@@ -295,7 +295,7 @@ export const addNewRowToArcToHLDPipelines = async (
     imageTag: imageTag.toLowerCase(),
     p1: "",
     p2: pipelineId.toLowerCase(),
-    service: ""
+    service: "",
   };
   if (pr) {
     newEntry.pr = pr.toLowerCase();
@@ -467,7 +467,7 @@ export const updateHLDtoManifestEntry = async (
       p2: found.p2,
       p3: pipelineId.toLowerCase(),
       service: found.service,
-      sourceRepo: found.sourceRepo
+      sourceRepo: found.sourceRepo,
     };
     if (manifestCommitId) {
       entry.manifestCommitId = manifestCommitId.toLowerCase();
@@ -523,7 +523,7 @@ export const updateLastHLDtoManifestEntry = async (
     p2: lastEntry.p2,
     p3: pipelineId.toLowerCase(),
     service: lastEntry.service,
-    sourceRepo: lastEntry.sourceRepo
+    sourceRepo: lastEntry.sourceRepo,
   };
   if (manifestCommitId) {
     newEntry.manifestCommitId = manifestCommitId.toLowerCase();
@@ -571,7 +571,7 @@ export const addNewRowToHLDtoManifestPipeline = async (
     p1: "",
     p2: "",
     p3: pipelineId.toLowerCase(),
-    service: ""
+    service: "",
   };
   if (manifestCommitId) {
     newEntry.manifestCommitId = manifestCommitId.toLowerCase();
@@ -739,7 +739,7 @@ export const insertToTable = (
   const tableService = getTableService(tableInfo);
 
   return new Promise((resolve, reject) => {
-    tableService.insertEntity(tableInfo.tableName, entry, err => {
+    tableService.insertEntity(tableInfo.tableName, entry, (err) => {
       if (!err) {
         resolve();
       } else {
@@ -761,7 +761,7 @@ export const deleteFromTable = (
   const tableService = getTableService(tableInfo);
 
   return new Promise((resolve, reject) => {
-    tableService.deleteEntity(tableInfo.tableName, entry, {}, err => {
+    tableService.deleteEntity(tableInfo.tableName, entry, {}, (err) => {
       if (!err) {
         resolve();
       } else {
@@ -788,7 +788,7 @@ export const updateEntryInTable = (
   const tableService = getTableService(tableInfo);
 
   return new Promise((resolve, reject) => {
-    tableService.replaceEntity(tableInfo.tableName, entry, err => {
+    tableService.replaceEntity(tableInfo.tableName, entry, (err) => {
       if (!err) {
         resolve();
       } else {
@@ -802,7 +802,5 @@ export const updateEntryInTable = (
  * Generates a RowKey GUID 12 characters long
  */
 export const getRowKey = (): string => {
-  return uuid()
-    .replace("-", "")
-    .substring(0, 12);
+  return uuid().replace("-", "").substring(0, 12);
 };

--- a/src/lib/azure/keyvault.test.ts
+++ b/src/lib/azure/keyvault.test.ts
@@ -3,7 +3,7 @@ import {
   GetSecretOptions,
   KeyVaultSecret,
   SecretClient,
-  SetSecretOptions
+  SetSecretOptions,
 } from "@azure/keyvault-secrets";
 import uuid from "uuid/v4";
 import { disableVerboseLogging, enableVerboseLogging } from "../../logger";
@@ -24,9 +24,9 @@ jest.spyOn(keyvault, "getClient").mockReturnValue(
         name: "test",
         properties: {
           name: "test",
-          vaultUrl: "http://test.com"
+          vaultUrl: "http://test.com",
         },
-        value: "secretValue"
+        value: "secretValue",
       };
     },
     setSecret: async (
@@ -38,10 +38,10 @@ jest.spyOn(keyvault, "getClient").mockReturnValue(
         name: "test",
         properties: {
           name: "test",
-          vaultUrl: "http://test.com"
-        }
+          vaultUrl: "http://test.com",
+        },
       };
-    }
+    },
   } as SecretClient)
 );
 
@@ -73,7 +73,7 @@ describe("set secret", () => {
           options?: SetSecretOptions
         ): Promise<KeyVaultSecret> => {
           throw new Error("fake error");
-        }
+        },
       } as SecretClient)
     );
     try {
@@ -106,9 +106,9 @@ describe("get secret", () => {
         ): Promise<KeyVaultSecret> => {
           throw {
             code: "SecretNotFound",
-            statusCode: 404
+            statusCode: 404,
           };
-        }
+        },
       } as SecretClient)
     );
     try {
@@ -127,9 +127,9 @@ describe("get secret", () => {
         ): Promise<KeyVaultSecret> => {
           throw {
             code: "something else",
-            statusCode: 400
+            statusCode: 400,
           };
-        }
+        },
       } as SecretClient)
     );
     try {

--- a/src/lib/azure/resourceService.test.ts
+++ b/src/lib/azure/resourceService.test.ts
@@ -1,6 +1,6 @@
 import {
   ResourceGroupsCreateOrUpdateResponse,
-  ResourceGroupsListResponse
+  ResourceGroupsListResponse,
 } from "@azure/arm-resources/src/models";
 import * as restAuth from "@azure/ms-rest-nodeauth";
 import { create, getResourceGroups, isExist } from "./resourceService";
@@ -24,17 +24,17 @@ jest.mock("@azure/arm-resources", () => {
               {
                 id: "1234567890-abcdef",
                 location: RESOURCE_GROUP_LOCATION,
-                name: "test"
-              }
+                name: "test",
+              },
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ] as any;
-          }
-        }
+          },
+        },
       };
     }
   }
   return {
-    ResourceManagementClient: MockClient
+    ResourceManagementClient: MockClient,
   };
 });
 
@@ -76,8 +76,8 @@ describe("Resource Group tests", () => {
       {
         id: "1234567890-abcdef",
         location: RESOURCE_GROUP_LOCATION,
-        name: "test"
-      }
+        name: "test",
+      },
     ]);
   });
   it("getResourceGroups: cache test", async () => {
@@ -96,8 +96,8 @@ describe("Resource Group tests", () => {
       {
         id: "fakeId",
         location: RESOURCE_GROUP_LOCATION,
-        name: "test"
-      }
+        name: "test",
+      },
     ]);
     const res = await isExist(
       servicePrincipalId,
@@ -124,8 +124,8 @@ describe("Resource Group tests", () => {
       {
         id: "fakeId",
         location: RESOURCE_GROUP_LOCATION,
-        name: "test1"
-      }
+        name: "test1",
+      },
     ]);
     const res = await isExist(
       servicePrincipalId,

--- a/src/lib/azure/resourceService.ts
+++ b/src/lib/azure/resourceService.ts
@@ -59,11 +59,11 @@ export const getResourceGroups = async (
   );
   const groups = await client.resourceGroups.list();
   logger.info("Successfully acquired resource groups");
-  return groups.map(g => {
+  return groups.map((g) => {
     return {
       id: g.id as string,
       location: g.location as string,
-      name: g.name as string
+      name: g.name as string,
     };
   });
 };
@@ -90,7 +90,7 @@ export const isExist = async (
     servicePrincipalTenantId,
     subscriptionId
   );
-  return (groups || []).some(g => g.name === name);
+  return (groups || []).some((g) => g.name === name);
 };
 
 /**
@@ -131,7 +131,7 @@ export const create = async (
     subscriptionId
   );
   await client.resourceGroups.createOrUpdate(name, {
-    location
+    location,
   });
   logger.info(`Successfully create resource group ${name}.`);
   return true;

--- a/src/lib/azure/servicePrincipalService.test.ts
+++ b/src/lib/azure/servicePrincipalService.test.ts
@@ -7,8 +7,8 @@ describe("test azCLILogin function", () => {
       JSON.stringify([
         {
           id: "subid",
-          name: "subname"
-        }
+          name: "subname",
+        },
       ])
     );
     await azCLILogin();
@@ -24,7 +24,7 @@ describe("test createWithAzCLI function", () => {
     const result = {
       appId: "b510c1ff-358c-4ed4-96c8-eb23f42bb65b",
       password: "a510c1ff-358c-4ed4-96c8-eb23f42bbc5b",
-      tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47"
+      tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47",
     };
     jest.spyOn(shell, "exec").mockResolvedValueOnce(JSON.stringify(result));
     const sub = await createWithAzCLI("subscriptionId");

--- a/src/lib/azure/servicePrincipalService.ts
+++ b/src/lib/azure/servicePrincipalService.ts
@@ -25,7 +25,7 @@ export const azCLILogin = async (): Promise<SubscriptionData[]> => {
     return JSON.parse(result).map((item: SubscriptionData) => {
       return {
         id: item.id,
-        name: item.name
+        name: item.name,
       };
     });
   } catch (err) {
@@ -51,14 +51,14 @@ export const createWithAzCLI = async (
       "sp",
       "create-for-rbac",
       "--scope",
-      `/subscriptions/${subscriptionId}`
+      `/subscriptions/${subscriptionId}`,
     ]);
     const oResult = JSON.parse(result);
     logger.info("Successfully created service principal with az command line");
     return {
       id: oResult.appId,
       password: oResult.password,
-      tenantId: oResult.tenant
+      tenantId: oResult.tenant,
     };
   } catch (err) {
     logger.error("Unable to create service principal with az command line");

--- a/src/lib/azure/storage.test.ts
+++ b/src/lib/azure/storage.test.ts
@@ -21,9 +21,9 @@ const location = uuid();
       service_principal_id: uuid(),
       service_principal_secret: uuid(),
       subscription_id: uuid,
-      tenant_id: uuid
-    }
-  }
+      tenant_id: uuid,
+    },
+  },
 });
 
 const mockGetStorageManagementClient = (
@@ -42,7 +42,7 @@ const mockGetStorageManagementClient = (
             if (hasResourceGroups) {
               return [
                 { name: "testAccountName" },
-                { name: "otherTestAccountName" }
+                { name: "otherTestAccountName" },
               ];
             }
             return undefined;
@@ -51,13 +51,13 @@ const mockGetStorageManagementClient = (
             return {};
           },
           create(): Promise<unknown> {
-            return new Promise(resolve => {
+            return new Promise((resolve) => {
               resolve({
-                status: "created"
+                status: "created",
               });
             });
-          }
-        }
+          },
+        },
       };
     }
   );
@@ -108,8 +108,8 @@ describe("get storage account key", () => {
           storageAccounts: {
             listKeys: (): never => {
               throw Error("fake");
-            }
-          }
+            },
+          },
         };
       }
     );
@@ -125,8 +125,8 @@ describe("get storage account key", () => {
           storageAccounts: {
             listKeys: (): unknown => {
               return {};
-            }
-          }
+            },
+          },
         };
       }
     );
@@ -144,8 +144,8 @@ describe("get storage account key", () => {
           storageAccounts: {
             listKeys: (): unknown => {
               return { keys: [{ value: "testkey" }] };
-            }
-          }
+            },
+          },
         };
       }
     );
@@ -200,8 +200,8 @@ describe("get storage account keys", () => {
           storageAccounts: {
             listKeys: (): unknown => {
               return { keys: [{ value: "testkey" }] };
-            }
-          }
+            },
+          },
         };
       }
     );
@@ -241,7 +241,7 @@ describe("storage account exists", () => {
       async (): Promise<StorageAccount | undefined> => {
         return {
           enableHttpsTrafficOnly: true,
-          location: "uswest"
+          location: "uswest",
         };
       }
     );

--- a/src/lib/azure/storage.ts
+++ b/src/lib/azure/storage.ts
@@ -4,7 +4,7 @@ import {
   SkuName,
   StorageAccount,
   StorageAccountsCreateResponse,
-  StorageAccountsListKeysResponse
+  StorageAccountsListKeysResponse,
 } from "@azure/arm-storage/esm/models";
 import * as storage from "azure-storage";
 import { exec } from "child_process";
@@ -141,7 +141,7 @@ export const validateStorageAccount = async (
       resourceGroup
     );
 
-    const found = (storageAccountKeys || []).find(k => k === key);
+    const found = (storageAccountKeys || []).find((k) => k === key);
     if (found) {
       logger.info(`Storage account validation for ${accountName} succeeded.`);
       return true;
@@ -203,7 +203,7 @@ export const getStorageAccount = async (
       `${accounts.length} storage accounts found in ${resourceGroup}`
     );
 
-    const found = accounts.find(acc => acc.name === accountName);
+    const found = accounts.find((acc) => acc.name === accountName);
     if (found) {
       logger.debug(`Found ${message}`);
     }
@@ -324,8 +324,8 @@ export const createStorageAccount = async (
       kind: "Storage" as Kind,
       location,
       sku: {
-        name: "Standard_LRS" as SkuName
-      }
+        name: "Standard_LRS" as SkuName,
+      },
     };
 
     logger.info(`Creating ${message}`);

--- a/src/lib/azure/subscriptionService.test.ts
+++ b/src/lib/azure/subscriptionService.test.ts
@@ -16,17 +16,17 @@ jest.mock("@azure/arm-subscriptions", () => {
             return [
               {
                 displayName: "test",
-                subscriptionId: "1234567890-abcdef"
-              }
+                subscriptionId: "1234567890-abcdef",
+              },
             ];
-          }
-        }
+          },
+        },
       };
     }
   }
 
   return {
-    SubscriptionClient: MockClient
+    SubscriptionClient: MockClient,
   };
 });
 
@@ -47,8 +47,8 @@ describe("test getSubscriptions function", () => {
     expect(result).toStrictEqual([
       {
         id: "1234567890-abcdef",
-        name: "test"
-      }
+        name: "test",
+      },
     ]);
   });
   it("negative test: missing values", async () => {

--- a/src/lib/azure/subscriptionService.ts
+++ b/src/lib/azure/subscriptionService.ts
@@ -36,11 +36,11 @@ export const getSubscriptions = async (
   const subsciptions = await client.subscriptions.list();
   const result: SubscriptionItem[] = [];
 
-  (subsciptions || []).forEach(s => {
+  (subsciptions || []).forEach((s) => {
     if (s.subscriptionId && s.displayName) {
       result.push({
         id: s.subscriptionId,
-        name: s.displayName
+        name: s.displayName,
       });
     }
   });

--- a/src/lib/bedrockYaml.test.ts
+++ b/src/lib/bedrockYaml.test.ts
@@ -11,7 +11,7 @@ import {
   isExists,
   read,
   removeRing,
-  setDefaultRing
+  setDefaultRing,
 } from "./bedrockYaml";
 
 describe("Creation and Existence test on bedrock.yaml", () => {
@@ -31,7 +31,7 @@ describe("Creation and Existence test on bedrock.yaml", () => {
     const data = {
       rings: {},
       services: {},
-      version: "1.0"
+      version: "1.0",
     };
     create(dir, data);
     expect(isExists(dir)).toBe(true);
@@ -49,8 +49,8 @@ describe("Adding a new service to a Bedrock file", () => {
     const helmConfig: HelmConfig = {
       chart: {
         chart: "somehelmchart",
-        repository: "somehelmrepository"
-      }
+        repository: "somehelmrepository",
+      },
     };
     const traefikMiddlewares = ["foo", "bar"];
     const k8sBackendPort = 8080;
@@ -88,11 +88,11 @@ describe("Adding a new service to a Bedrock file", () => {
           k8sBackendPort,
           middlewares: traefikMiddlewares,
           pathPrefix,
-          pathPrefixMajorVersion
-        }
+          pathPrefixMajorVersion,
+        },
       },
       variableGroups: [],
-      version: defaultBedrockFileObject.version
+      version: defaultBedrockFileObject.version,
     };
 
     expect(read(dir)).toEqual(expected);
@@ -115,13 +115,13 @@ describe("Adding a new ring to an existing bedrock.yaml", () => {
     const expected: BedrockFile = {
       rings: {
         ...(defaultBedrockFileObject as BedrockFile).rings,
-        [ringName]: {}
+        [ringName]: {},
       },
       services: {
-        ...(defaultBedrockFileObject as BedrockFile).services
+        ...(defaultBedrockFileObject as BedrockFile).services,
       },
       variableGroups: [],
-      version: defaultBedrockFileObject.version
+      version: defaultBedrockFileObject.version,
     };
 
     expect(read(dir)).toEqual(expected);
@@ -150,7 +150,7 @@ describe("Bedrock file info", () => {
       rings: {},
       services: {},
       variableGroups: [uuid()],
-      version: "1.0"
+      version: "1.0",
     };
     create(dir, data);
     const file = fileInfo(dir);
@@ -165,11 +165,11 @@ describe("Set default ring", () => {
     const data = {
       rings: {
         master: { isDefault: false },
-        prod: {}
+        prod: {},
       },
       services: {},
       variableGroups: [uuid()],
-      version: "1.0"
+      version: "1.0",
     };
     create(dir, data);
     setDefaultRing(data, "master", dir);
@@ -182,11 +182,11 @@ describe("Set default ring", () => {
     const data = {
       rings: {
         master: { isDefault: false },
-        prod: { isDefault: true }
+        prod: { isDefault: true },
       },
       services: {},
       variableGroups: [uuid()],
-      version: "1.0"
+      version: "1.0",
     };
     create(dir, data);
     setDefaultRing(data, "master", dir);

--- a/src/lib/bedrockYaml.ts
+++ b/src/lib/bedrockYaml.ts
@@ -12,7 +12,7 @@ export const DEFAULT_CONTENT: BedrockFile = {
   rings: {},
   services: {},
   variableGroups: [],
-  version: getVersion()
+  version: getVersion(),
 };
 
 /**
@@ -30,7 +30,7 @@ export const create = (dir?: string, data?: BedrockFile): string => {
   const absPath = path.resolve(dir);
   data = data || DEFAULT_CONTENT;
   const asYaml = yaml.safeDump(data, {
-    lineWidth: Number.MAX_SAFE_INTEGER
+    lineWidth: Number.MAX_SAFE_INTEGER,
   });
   writeVersion(path.join(absPath, YAML_NAME));
   fs.appendFileSync(path.join(absPath, YAML_NAME), asYaml);
@@ -99,11 +99,11 @@ export const addNewService = (
     k8sBackendPort,
     middlewares,
     pathPrefix,
-    pathPrefixMajorVersion
+    pathPrefixMajorVersion,
   };
 
   const asYaml = yaml.safeDump(data, {
-    lineWidth: Number.MAX_SAFE_INTEGER
+    lineWidth: Number.MAX_SAFE_INTEGER,
   });
   fs.writeFileSync(path.join(absPath, YAML_NAME), asYaml);
 };
@@ -153,7 +153,7 @@ export const addNewRing = (dir: string, ringName: string): void => {
   data.rings[ringName] = {}; // Alternatively, we can set isDefault = false or some passable value.
 
   const asYaml = yaml.safeDump(data, {
-    lineWidth: Number.MAX_SAFE_INTEGER
+    lineWidth: Number.MAX_SAFE_INTEGER,
   });
   fs.writeFileSync(path.join(absPath, YAML_NAME), asYaml);
 };
@@ -176,13 +176,13 @@ export const fileInfo = (rootProjectPath?: string): BedrockFileInfo => {
     logger.verbose(`bedrockFile: \n ${JSON.stringify(bedrockFile)}`);
     return {
       exist: true,
-      hasVariableGroups: (bedrockFile?.variableGroups ?? []).length > 0
+      hasVariableGroups: (bedrockFile?.variableGroups ?? []).length > 0,
     };
   } catch (error) {
     logger.error(error);
     return {
       exist: false,
-      hasVariableGroups: false
+      hasVariableGroups: false,
     };
   }
 };
@@ -204,7 +204,7 @@ export const removeRing = (
   // Check if ring exists, if not, warn and exit
   const rings = Object.entries(bedrock.rings).map(([name, config]) => ({
     config,
-    name
+    name,
   }));
   const matchingRing = rings.find(({ name }) => name === ringToDelete);
   if (matchingRing === undefined) {
@@ -228,7 +228,7 @@ export const removeRing = (
   }, {});
   const bedrockWithoutRing: BedrockFile = {
     ...bedrock,
-    rings: updatedRings
+    rings: updatedRings,
   };
 
   return bedrockWithoutRing;

--- a/src/lib/commandBuilder.test.ts
+++ b/src/lib/commandBuilder.test.ts
@@ -7,7 +7,7 @@ import {
   build,
   exit as exitCmd,
   CommandBuildElements,
-  validateForRequiredValues
+  validateForRequiredValues,
 } from "./commandBuilder";
 
 interface CommandOption {
@@ -21,7 +21,7 @@ describe("Tests Command Builder's build function", () => {
     const descriptor: CommandBuildElements = {
       alias: "cbt",
       command: "command-build-test",
-      description: "description of command"
+      description: "description of command",
     };
 
     const cmd = build(new commander.Command(), descriptor);
@@ -39,31 +39,31 @@ describe("Tests Command Builder's build function", () => {
         {
           arg: "-a, --option-a <optionA>",
           description: "description for optionA",
-          required: false
+          required: false,
         },
         {
           arg: "-b, --option-b <optionB>",
           description: "description for optionB",
-          required: false
+          required: false,
         },
         {
           arg: "-c, --option-c <optionC>",
           description: "description for optionC",
-          required: false
+          required: false,
         },
         {
           arg: "-d, --option-d <optionD>",
           defaultValue: false,
           description: "description for optionD",
-          required: false
+          required: false,
         },
         {
           arg: "-e, --option-d <optionE>",
           defaultValue: "test",
           description: "description for optionE",
-          required: false
-        }
-      ]
+          required: false,
+        },
+      ],
     };
 
     const cmd = build(new commander.Command(), descriptor);
@@ -88,7 +88,7 @@ describe("Tests Command Builder's validation function", () => {
     const descriptor: CommandBuildElements = {
       alias: "cbt",
       command: "command-build-test",
-      description: "description of command"
+      description: "description of command",
     };
 
     const errors = validateForRequiredValues(descriptor, {});
@@ -104,27 +104,27 @@ describe("Tests Command Builder's validation function", () => {
         {
           arg: "-a, --option-a <optionA>",
           description: "description for optionA",
-          required: true
+          required: true,
         },
         {
           arg: "-b, --option-b <optionB>",
           description: "description for optionB",
-          required: false
+          required: false,
         },
         {
           arg: "-c --option-c <optionC>",
           description: "description for optionC",
-          required: true
+          required: true,
         },
         {
           arg: "-d --option-d <optionD>",
-          description: "description for optionD" // required is not defined, treated as false
-        }
-      ]
+          description: "description for optionD", // required is not defined, treated as false
+        },
+      ],
     };
 
     const errors = validateForRequiredValues(descriptor, {
-      optionA: "has value"
+      optionA: "has value",
     });
 
     // Option-A is ok because we have value for optionA
@@ -136,7 +136,7 @@ describe("Tests Command Builder's validation function", () => {
 });
 
 describe("Tests Command Builder's exit function", () => {
-  it("calling exit function", async done => {
+  it("calling exit function", async (done) => {
     (watchFile as jest.Mock).mockImplementationOnce((f, cb) => {
       cb({ size: 100 });
     });
@@ -147,13 +147,13 @@ describe("Tests Command Builder's exit function", () => {
       done();
     });
   });
-  it("calling exit function without file transport", async done => {
+  it("calling exit function without file transport", async (done) => {
     const exitFn = jest.fn();
     await exitCmd(
       createLogger({
         defaultMeta: { service: "spk" },
         level: "info",
-        transports: []
+        transports: [],
       }),
       exitFn,
       1,

--- a/src/lib/commandBuilder.ts
+++ b/src/lib/commandBuilder.ts
@@ -46,7 +46,7 @@ export const build = (
     .alias(decorator.alias)
     .description(decorator.description);
 
-  (decorator.options || []).forEach(opt => {
+  (decorator.options || []).forEach((opt) => {
     if (opt.defaultValue !== undefined) {
       cmd.option(opt.arg, opt.description, opt.defaultValue);
     } else {
@@ -70,7 +70,7 @@ export const validateForRequiredValues = (
   values: { [key: string]: string | undefined }
 ): string[] => {
   // gather the required options
-  const required = (decorator.options || []).filter(opt => opt.required);
+  const required = (decorator.options || []).filter((opt) => opt.required);
 
   // no required variables hence return empty error array
   if (required.length === 0) {
@@ -80,7 +80,7 @@ export const validateForRequiredValues = (
   // opt name to variable name mapping
   // example --org-name is orgName
   const mapVariableName2Opt: CommandVariableName2Opt[] = [];
-  required.forEach(opt => {
+  required.forEach((opt) => {
     const match = opt.arg.match(/\s?--([-\w]+)\s?/);
 
     if (match) {
@@ -91,18 +91,18 @@ export const validateForRequiredValues = (
         .replace(/-/g, "");
       mapVariableName2Opt.push({
         opt,
-        variableName
+        variableName,
       });
     }
   });
 
   // figure out which variables have missing values
   const missingItems = mapVariableName2Opt.filter(
-    item => !hasValue(values[item.variableName])
+    (item) => !hasValue(values[item.variableName])
   );
 
   // gather the option flags (args) for the missing one
-  const errors = missingItems.map(item => item.opt.arg);
+  const errors = missingItems.map((item) => item.opt.arg);
 
   if (errors.length !== 0) {
     logger.error(`the following arguments are required: ${errors.join("\n ")}`);
@@ -124,14 +124,14 @@ export const exit = (
   statusCode: number,
   timeout = 10000
 ): Promise<void> => {
-  return new Promise(resolve => {
-    const hasFileLogger = log.transports.some(t => {
+  return new Promise((resolve) => {
+    const hasFileLogger = log.transports.some((t) => {
       if (t instanceof transports.File) {
         // callback will be called once if spk.log
         // already exist.
         // it will be called twice if spk.log
         // do not exist. the one call has size === 0
-        fs.watchFile(t.filename, curr => {
+        fs.watchFile(t.filename, (curr) => {
           if (curr.size > 0) {
             exitFn(statusCode);
             resolve();

--- a/src/lib/fileutils.test.ts
+++ b/src/lib/fileutils.test.ts
@@ -22,7 +22,7 @@ import {
   PROJECT_PIPELINE_FILENAME,
   RENDER_HLD_PIPELINE_FILENAME,
   SERVICE_PIPELINE_FILENAME,
-  VM_IMAGE
+  VM_IMAGE,
 } from "../lib/constants";
 import { disableVerboseLogging, enableVerboseLogging } from "../logger";
 import {
@@ -30,7 +30,7 @@ import {
   createTestHldAzurePipelinesYaml,
   createTestHldLifecyclePipelineYaml,
   createTestMaintainersYaml,
-  createTestServiceBuildAndUpdatePipelineYaml
+  createTestServiceBuildAndUpdatePipelineYaml,
 } from "../test/mockFactory";
 import { AccessYaml, AzurePipelinesYaml, MaintainersFile } from "../types";
 import {
@@ -46,7 +46,7 @@ import {
   getVersionMessage,
   sanitizeTriggerPath,
   serviceBuildAndUpdatePipeline,
-  updateTriggerBranchesForServiceBuildAndUpdatePipeline
+  updateTriggerBranchesForServiceBuildAndUpdatePipeline,
 } from "./fileutils";
 
 beforeAll(() => {
@@ -73,8 +73,8 @@ describe("generateAccessYaml", () => {
   beforeEach(() => {
     mockFs({
       "hld-repository": {
-        "my-service": {}
-      }
+        "my-service": {},
+      },
     });
   });
 
@@ -105,7 +105,7 @@ describe("generateAccessYaml", () => {
 
   it("if an access.yaml already exists, it should update access.yaml in the filepath", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${serviceDirectory}/${ACCESS_FILENAME}`]: "'https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019': ACCESS_TOKEN_SECRET"
+      [`${targetDirectory}/${serviceDirectory}/${ACCESS_FILENAME}`]: "'https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019': ACCESS_TOKEN_SECRET",
     };
     mockFs(mockFsOptions);
 
@@ -134,7 +134,7 @@ describe("generateAccessYaml", () => {
 
   it("if an access.yaml already exists, it should update access.yaml in the filepath, but not overwrite anything that exists.", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${serviceDirectory}/${ACCESS_FILENAME}`]: "'https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019': MY_CUSTOM_SECRET"
+      [`${targetDirectory}/${serviceDirectory}/${ACCESS_FILENAME}`]: "'https://fabrikam@dev.azure.com/someorg/someproject/_git/fabrikam2019': MY_CUSTOM_SECRET",
     };
     mockFs(mockFsOptions);
 
@@ -168,8 +168,8 @@ describe("generateServiceBuildAndUpdatePipelineYaml", () => {
   beforeEach(() => {
     mockFs({
       "app-repository": {
-        "my-service": {}
-      }
+        "my-service": {},
+      },
     });
   });
 
@@ -179,7 +179,7 @@ describe("generateServiceBuildAndUpdatePipelineYaml", () => {
 
   it("should not do anything if build-update-hld.yaml exists", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${serviceDirectory}/${SERVICE_PIPELINE_FILENAME}`]: "existing pipeline"
+      [`${targetDirectory}/${serviceDirectory}/${SERVICE_PIPELINE_FILENAME}`]: "existing pipeline",
     };
     mockFs(mockFsOptions);
 
@@ -226,21 +226,21 @@ describe("generateServiceBuildAndUpdatePipelineYaml", () => {
 
   test("no path trigger injected when the path is the project root (is: ./)", () => {
     const serviceYaml = serviceBuildAndUpdatePipeline("my-service", "./", [
-      "master"
+      "master",
     ]);
     expect(serviceYaml?.trigger?.paths).toBeUndefined();
     expect(serviceYaml.trigger).toStrictEqual({
-      branches: { include: ["master"] }
+      branches: { include: ["master"] },
     });
   });
 
   test("path trigger is injected when the path is not the root of the project (not: ./)", () => {
     for (const p of ["my-service", "foo/bar/baz"]) {
       const serviceYaml = serviceBuildAndUpdatePipeline("my-service", p, [
-        "master"
+        "master",
       ]);
       expect(serviceYaml?.trigger?.paths).toStrictEqual({
-        include: [p]
+        include: [p],
       });
     }
     const yamlWithNoDot = serviceBuildAndUpdatePipeline(
@@ -249,7 +249,7 @@ describe("generateServiceBuildAndUpdatePipelineYaml", () => {
       ["master"]
     );
     expect(yamlWithNoDot?.trigger?.paths).toStrictEqual({
-      include: ["another-service"]
+      include: ["another-service"],
     });
   });
 });
@@ -263,8 +263,8 @@ describe("updateTriggerBranchesForServiceBuildAndUpdatePipeline", () => {
   beforeEach(() => {
     mockFs({
       "app-repository": {
-        "my-service": {}
-      }
+        "my-service": {},
+      },
     });
   });
 
@@ -295,7 +295,7 @@ describe("updateTriggerBranchesForServiceBuildAndUpdatePipeline", () => {
     const mockFsOptions = {
       [`${targetDirectory}/${serviceDirectory}/${SERVICE_PIPELINE_FILENAME}`]: Buffer.from(
         existingPipelineAsString
-      )
+      ),
     };
     mockFs(mockFsOptions);
 
@@ -344,7 +344,7 @@ describe("generateHldLifecyclePipelineYaml", () => {
 
   beforeEach(() => {
     mockFs({
-      "app-repository": {}
+      "app-repository": {},
     });
   });
 
@@ -354,7 +354,7 @@ describe("generateHldLifecyclePipelineYaml", () => {
 
   it("should not do anything if hld-lifecycle.yaml exists", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${PROJECT_PIPELINE_FILENAME}`]: "existing pipeline"
+      [`${targetDirectory}/${PROJECT_PIPELINE_FILENAME}`]: "existing pipeline",
     };
     mockFs(mockFsOptions);
 
@@ -387,7 +387,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   beforeEach(() => {
     mockFs({
-      "hld-repository": {}
+      "hld-repository": {},
     });
   });
   afterEach(() => {
@@ -396,7 +396,7 @@ describe("generateHldAzurePipelinesYaml", () => {
 
   it("should not do anything if file exist", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/${RENDER_HLD_PIPELINE_FILENAME}`]: "existing pipeline"
+      [`${targetDirectory}/${RENDER_HLD_PIPELINE_FILENAME}`]: "existing pipeline",
     };
     mockFs(mockFsOptions);
 
@@ -433,7 +433,7 @@ describe("generateDefaultHldComponentYaml", () => {
   const componentPath = "definitions/traefik2";
   beforeEach(() => {
     mockFs({
-      "hld-repository": {}
+      "hld-repository": {},
     });
   });
   afterEach(() => {
@@ -442,7 +442,7 @@ describe("generateDefaultHldComponentYaml", () => {
 
   it("should not do anything if file exist", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/component.yaml`]: "existing component"
+      [`${targetDirectory}/component.yaml`]: "existing component",
     };
     mockFs(mockFsOptions);
 
@@ -477,7 +477,7 @@ describe("Adding a new service to a Maintainer file", () => {
   beforeAll(() => {
     mockFs({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      "maintainers.yaml": createTestMaintainersYaml() as any
+      "maintainers.yaml": createTestMaintainersYaml() as any,
     });
   });
 
@@ -495,7 +495,7 @@ describe("Adding a new service to a Maintainer file", () => {
     const servicePath = "packages/my-new-service";
     const newUser = {
       email: "hello@example.com",
-      name: "testUser"
+      name: "testUser",
     };
 
     const writeSpy = jest.spyOn(fs, "writeFileSync");
@@ -508,9 +508,9 @@ describe("Adding a new service to a Maintainer file", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...((defaultMaintainersFileObject as any) as MaintainersFile).services,
         ["./" + servicePath]: {
-          maintainers: [newUser]
-        }
-      }
+          maintainers: [newUser],
+        },
+      },
     };
 
     expect(writeSpy).toBeCalledWith(
@@ -526,7 +526,7 @@ describe("generating service gitignore file", () => {
 
   beforeEach(() => {
     mockFs({
-      "my-new-service": {}
+      "my-new-service": {},
     });
   });
   afterEach(() => {
@@ -537,7 +537,7 @@ describe("generating service gitignore file", () => {
 
   it("should not do anything if file exist", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/.gitignore`]: "foobar"
+      [`${targetDirectory}/.gitignore`]: "foobar",
     };
     mockFs(mockFsOptions);
 
@@ -562,7 +562,7 @@ describe("generating service Dockerfile", () => {
 
   beforeEach(() => {
     mockFs({
-      "my-new-service": {}
+      "my-new-service": {},
     });
   });
   afterEach(() => {
@@ -571,7 +571,7 @@ describe("generating service Dockerfile", () => {
 
   it("should not do anything if file exist", () => {
     const mockFsOptions = {
-      [`${targetDirectory}/Dockerfile`]: "hello!!!!"
+      [`${targetDirectory}/Dockerfile`]: "hello!!!!",
     };
     mockFs(mockFsOptions);
 
@@ -615,7 +615,7 @@ describe("serviceBuildUpdatePipeline", () => {
       variableGroups
     );
     const serializedYaml = yaml.safeDump(buildPipelineYaml, {
-      lineWidth: Number.MAX_SAFE_INTEGER
+      lineWidth: Number.MAX_SAFE_INTEGER,
     });
     const pipelinesPath = path.join(randomDirPath, SERVICE_PIPELINE_FILENAME);
     fs.writeFileSync(pipelinesPath, serializedYaml);
@@ -654,7 +654,7 @@ describe("serviceBuildUpdatePipeline", () => {
   test("that all services receive an build-update-hld-pipeline.yaml with the correct paths and variable groups have been inserted", async () => {
     // Create service directories
     const serviceReferences = ["serviceA", "serviceB", "serviceC"].map(
-      serviceName => {
+      (serviceName) => {
         const servicePath = path.join(randomDirPath, "packages", serviceName);
         shelljs.mkdir("-p", servicePath);
         return { serviceName, servicePath };
@@ -725,23 +725,23 @@ describe("sanitizeTriggerPath", () => {
     {
       name: "removes ./ when present",
       expected: "foo/bar",
-      actual: sanitizeTriggerPath("./foo/bar")
+      actual: sanitizeTriggerPath("./foo/bar"),
     },
     {
       name: "should only remove one slash",
       expected: "/foo/bar",
-      actual: sanitizeTriggerPath(".//foo/bar")
+      actual: sanitizeTriggerPath(".//foo/bar"),
     },
     {
       name: "does nothing if not starting with ./",
       expected: "foo/bar",
-      actual: sanitizeTriggerPath("foo/bar")
+      actual: sanitizeTriggerPath("foo/bar"),
     },
     {
       name: "dot is escaped",
       expected: "a/foo/bar",
-      actual: sanitizeTriggerPath("a/foo/bar")
-    }
+      actual: sanitizeTriggerPath("a/foo/bar"),
+    },
   ];
 
   for (const { name, expected, actual } of tests) {

--- a/src/lib/git/azure.test.ts
+++ b/src/lib/git/azure.test.ts
@@ -9,7 +9,7 @@ import {
   createPullRequest,
   generatePRUrl,
   getGitOrigin,
-  GitAPI
+  GitAPI,
 } from "./azure";
 
 jest.mock("azure-devops-node-api");
@@ -46,7 +46,7 @@ describe("test getGitOrigin function", () => {
 describe("GitAPI", () => {
   test("should fail when PAT not set", async () => {
     (Config as jest.Mock).mockReturnValueOnce({
-      azure_devops: {}
+      azure_devops: {},
     });
     await expect(GitAPI()).rejects.toThrow();
   });
@@ -54,8 +54,8 @@ describe("GitAPI", () => {
   test("should fail when DevOps org is invalid", async () => {
     (Config as jest.Mock).mockReturnValueOnce({
       azure_devops: {
-        access_token: uuid()
-      }
+        access_token: uuid(),
+      },
     });
     await expect(GitAPI()).rejects.toThrow();
   });
@@ -64,8 +64,8 @@ describe("GitAPI", () => {
     (Config as jest.Mock).mockReturnValueOnce({
       azure_devops: {
         access_token: uuid(),
-        org: uuid()
-      }
+        org: uuid(),
+      },
     });
 
     await GitAPI();
@@ -84,25 +84,25 @@ describe("createPullRequest", () => {
   (Config as jest.Mock).mockImplementation(() => ({
     azure_devops: {
       access_token: uuid(),
-      org: uuid()
-    }
+      org: uuid(),
+    },
   }));
   // Mutable copy of the gitApi
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const gitApi: { [name: string]: (...args: any) => Promise<any> } = {
     createPullRequest: async () => ({
       pullRequestId: 123,
-      repository: { id: 456 }
+      repository: { id: 456 },
     }),
     getBranches: async () => [{ name: "sourceRef" }, { name: "targetRef" }],
     getPullRequests: async () => [],
     getRepositories: async () => [{ url: "my-git-url" }],
-    getRepository: async () => ({ webUrl: "http://foobar.com" })
+    getRepository: async () => ({ webUrl: "http://foobar.com" }),
   };
   // Keep a reference to the original gitApi functions so they be reused to reset the mocks
   const originalGitApi = { ...gitApi };
   ((WebApi as unknown) as jest.Mock).mockImplementation(() => ({
-    getGitApi: async (): Promise<unknown> => gitApi
+    getGitApi: async (): Promise<unknown> => gitApi,
   }));
 
   beforeEach(() => {
@@ -120,7 +120,7 @@ describe("createPullRequest", () => {
     try {
       await createPullRequest(uuid(), uuid(), uuid(), {
         description: uuid(),
-        originPushUrl: uuid()
+        originPushUrl: uuid(),
       });
     } catch (e) {
       err = e;
@@ -140,7 +140,7 @@ describe("createPullRequest", () => {
     try {
       await createPullRequest("random title", "sourceRef", "targetRef", {
         description: uuid(),
-        originPushUrl: "my-git-url"
+        originPushUrl: "my-git-url",
       });
       expect(true).toBe(false);
     } catch (err) {
@@ -155,7 +155,7 @@ describe("createPullRequest", () => {
     try {
       await createPullRequest("random title", "sourceRef", "targetRef", {
         description: uuid(),
-        originPushUrl: "my-git-url"
+        originPushUrl: "my-git-url",
       });
     } catch (e) {
       expect(true).toBe(false);
@@ -169,7 +169,7 @@ describe("createPullRequest", () => {
     await expect(
       createPullRequest("random title", "sourceRef", "targetRef", {
         description: uuid(),
-        originPushUrl: "my-git-url"
+        originPushUrl: "my-git-url",
       })
     ).rejects.toThrow();
   });
@@ -181,7 +181,7 @@ describe("createPullRequest", () => {
     await expect(
       createPullRequest("random title", "sourceRef", "targetRef", {
         description: uuid(),
-        originPushUrl: "my-git-url"
+        originPushUrl: "my-git-url",
       })
     ).rejects.toThrow();
   });
@@ -192,15 +192,15 @@ describe("test generatePRUrl function", async () => {
     const res = await generatePRUrl({
       pullRequestId: 1,
       repository: {
-        id: "test"
-      }
+        id: "test",
+      },
     });
     expect(res).toBe("http://foobar.com/pullrequest/1");
   });
   test("negative test", async () => {
     await expect(
       generatePRUrl({
-        repository: {}
+        repository: {},
       })
     ).rejects.toThrow();
   });

--- a/src/lib/git/azure.ts
+++ b/src/lib/git/azure.ts
@@ -3,7 +3,7 @@ import * as azdo from "azure-devops-node-api";
 import { IGitApi } from "azure-devops-node-api/GitApi";
 import AZGitInterfaces, {
   GitPullRequestSearchCriteria,
-  GitRepository
+  GitRepository,
 } from "azure-devops-node-api/interfaces/GitInterfaces";
 import { AzureDevOpsOpts } from ".";
 import { Config } from "../../config";
@@ -33,7 +33,7 @@ export const GitAPI = async (opts: AzureDevOpsOpts = {}): Promise<IGitApi> => {
     const azureDevops = config["azure_devops"];
     const {
       personalAccessToken = azureDevops && azureDevops.access_token,
-      orgName = azureDevops && azureDevops.org
+      orgName = azureDevops && azureDevops.org,
     } = opts;
 
     // PAT and devops URL are required
@@ -156,7 +156,7 @@ export const getMatchingBranch = async (
   allRepos: GitRepository[],
   gitOriginUrlForLogging: string
 ): Promise<GitRepository> => {
-  const reposWithMatchingOrigin = allRepos.filter(repo =>
+  const reposWithMatchingOrigin = allRepos.filter((repo) =>
     [repo.url, repo.sshUrl, repo.webUrl, repo.remoteUrl].includes(gitOrigin)
   );
   logger.info(
@@ -168,23 +168,23 @@ export const getMatchingBranch = async (
   // Search for repos with branches matching those to make the PR against
   const reposWithMatchingBranches = (
     await Promise.all(
-      reposWithMatchingOrigin.map(async repo => {
+      reposWithMatchingOrigin.map(async (repo) => {
         logger.info(`Retrieving branches for repository '${repo.name}'`);
         const branches = await gitAPI.getBranches(repo.id!);
         return {
-          branches: branches.filter(branch => {
+          branches: branches.filter((branch) => {
             return [sourceRef, targetRef].includes(branch.name!);
           }),
-          repo
+          repo,
         };
       })
     )
   )
-    .filter(repo => {
+    .filter((repo) => {
       // Valid repos must contain both the source and target repo
       return repo.branches.length >= 2;
     })
-    .map(repo => repo.repo);
+    .map((repo) => repo.repo);
 
   // Only allow one matching repo to be found
   if (reposWithMatchingBranches.length === 0) {
@@ -216,7 +216,7 @@ const handleErrorForCreatePullRequest = async (
     );
     const searchCriteria: GitPullRequestSearchCriteria = {
       sourceRefName: `refs/heads/${sourceRef}`,
-      targetRefName: `refs/heads/${targetRef}`
+      targetRefName: `refs/heads/${targetRef}`,
     };
     const existingPRs = await gitAPI.getPullRequests(
       repoToPRAgainst.id!,
@@ -257,7 +257,7 @@ export const createPullRequest = async (
     description,
     sourceRefName: `refs/heads/${sourceRef}`,
     targetRefName: `refs/heads/${targetRef}`,
-    title
+    title,
   };
 
   // Get the git origin from args or fallback to parsing from git client

--- a/src/lib/gitutils.test.ts
+++ b/src/lib/gitutils.test.ts
@@ -12,7 +12,7 @@ import {
   isGitHubUrl,
   pushBranch,
   safeGitUrlForLogging,
-  tryGetGitOrigin
+  tryGetGitOrigin,
 } from "../lib/gitutils";
 import { disableVerboseLogging, enableVerboseLogging } from "../logger";
 import { exec } from "./shell";
@@ -57,7 +57,7 @@ describe("getCurrentBranch", () => {
     expect(currentBranch).toEqual("currentBranch");
     expect(exec).toHaveBeenCalledTimes(1);
     expect(exec).toHaveBeenCalledWith("git", ["branch", "--show-current"], {
-      cwd: process.cwd()
+      cwd: process.cwd(),
     });
   });
 
@@ -97,7 +97,7 @@ describe("checkoutBranch", () => {
     expect(exec).toHaveBeenCalledWith("git", [
       "checkout",
       "-b",
-      `${branchName}`
+      `${branchName}`,
     ]);
   });
 
@@ -157,12 +157,12 @@ describe("commitDir", () => {
       "add",
       directory,
       bedrockFile,
-      maintainersFile
+      maintainersFile,
     ]);
     expect(exec).toHaveBeenCalledWith("git", [
       "commit",
       "-m",
-      `Adding new service: ${branchName}`
+      `Adding new service: ${branchName}`,
     ]);
   });
 
@@ -193,7 +193,7 @@ describe("pushBranch", () => {
       "push",
       "-u",
       "origin",
-      `${branchName}`
+      `${branchName}`,
     ]);
   });
 
@@ -266,7 +266,7 @@ describe("getOriginUrl", () => {
 
     when(exec as jest.Mock)
       .calledWith("git", ["config", "--get", "remote.origin.url"], {
-        cwd: repoPath
+        cwd: repoPath,
       })
       .mockReturnValue(originUrl);
 

--- a/src/lib/gitutils.ts
+++ b/src/lib/gitutils.ts
@@ -32,7 +32,7 @@ export const getCurrentBranch = async (
 ): Promise<string> => {
   try {
     const branch = await exec("git", ["branch", "--show-current"], {
-      cwd: path.resolve(repoDir)
+      cwd: path.resolve(repoDir),
     });
     return branch;
   } catch (err) {
@@ -282,24 +282,24 @@ export const checkoutCommitPushCreatePRLink = async (
   ...pathspecs: string[]
 ): Promise<void> => {
   try {
-    const currentBranch = await getCurrentBranch().catch(e => {
+    const currentBranch = await getCurrentBranch().catch((e) => {
       throw Error(
         `Cannot fetch current branch. Changes will have to be manually committed. ${e}`
       );
     });
-    await checkoutBranch(newBranchName, true).catch(e => {
+    await checkoutBranch(newBranchName, true).catch((e) => {
       throw Error(
         `Cannot create and checkout new branch ${newBranchName}. Changes will have to be manually committed. ${e}`
       );
     });
-    await commitPath(newBranchName, ...pathspecs).catch(e => {
+    await commitPath(newBranchName, ...pathspecs).catch((e) => {
       throw Error(
         `Cannot commit changes in ${pathspecs.join(
           ", "
         )} to branch ${newBranchName}. Changes will have to be manually committed. ${e}`
       );
     });
-    await pushBranch(newBranchName).catch(e => {
+    await pushBranch(newBranchName).catch((e) => {
       throw Error(
         `Cannot push branch ${newBranchName}. Changes will have to be manually committed. ${e}`
       );
@@ -310,7 +310,7 @@ export const checkoutCommitPushCreatePRLink = async (
       currentBranch,
       newBranchName,
       originUrl
-    ).catch(e => {
+    ).catch((e) => {
       throw Error(
         `Could not create link for Pull Request. It will need to be done manually. ${e}`
       );
@@ -318,12 +318,12 @@ export const checkoutCommitPushCreatePRLink = async (
     logger.info(`Link to create PR: ${pullRequestLink}`);
 
     // cleanup
-    await checkoutBranch(currentBranch, false).catch(e => {
+    await checkoutBranch(currentBranch, false).catch((e) => {
       throw Error(
         `Cannot checkout original branch ${currentBranch}. Clean up will need to be done manually. ${e}`
       );
     });
-    await deleteBranch(newBranchName).catch(e => {
+    await deleteBranch(newBranchName).catch((e) => {
       throw Error(
         `Cannot delete new branch ${newBranchName}. Cleanup will need to be done manually. ${e}`
       );

--- a/src/lib/ioUtil.test.ts
+++ b/src/lib/ioUtil.test.ts
@@ -5,7 +5,7 @@ import {
   createTempDir,
   getMissingFilenames,
   isDirEmpty,
-  removeDir
+  removeDir,
 } from "./ioUtil";
 
 describe("test createTempDir function", () => {
@@ -73,13 +73,13 @@ describe("test doFilesExist function", () => {
     const dir = createTempDir();
     const files = ["hello", "world"];
 
-    files.forEach(f => {
+    files.forEach((f) => {
       fs.writeFileSync(path.join(dir, `${f}.txt`), f);
     });
 
     const missing = getMissingFilenames(
       dir,
-      files.map(f => `${f}.txt`)
+      files.map((f) => `${f}.txt`)
     );
     expect(missing.length).toBe(0);
   });
@@ -89,7 +89,7 @@ describe("test doFilesExist function", () => {
 
     const missing = getMissingFilenames(
       dir,
-      files.map(f => `${f}.txt`)
+      files.map((f) => `${f}.txt`)
     );
     expect(missing.length).toBe(2);
   });
@@ -98,14 +98,14 @@ describe("test doFilesExist function", () => {
     const files = ["hello", "world", "again"];
 
     files
-      .filter(f => f !== "again")
-      .forEach(f => {
+      .filter((f) => f !== "again")
+      .forEach((f) => {
         fs.writeFileSync(path.join(dir, `${f}.txt`), f);
       });
 
     const missing = getMissingFilenames(
       dir,
-      files.map(f => `${f}.txt`)
+      files.map((f) => `${f}.txt`)
     );
     expect(missing.length).toBe(1);
   });

--- a/src/lib/ioUtil.ts
+++ b/src/lib/ioUtil.ts
@@ -25,7 +25,7 @@ export const createTempDir = (parent?: string): string => {
 export const removeDir = (dir: string): void => {
   const folder = path.resolve(dir);
   if (fs.existsSync(folder)) {
-    fs.readdirSync(folder).forEach(item => {
+    fs.readdirSync(folder).forEach((item) => {
       const curPath = path.join(folder, item);
       if (fs.statSync(curPath).isDirectory()) {
         removeDir(curPath);
@@ -61,10 +61,10 @@ export const getMissingFilenames = (
 ): string[] => {
   return fileNames
     .map(
-      f => path.join(dir, f) // form full path
+      (f) => path.join(dir, f) // form full path
     )
     .filter(
-      f => !fs.existsSync(f) // keep those files that do not exist
+      (f) => !fs.existsSync(f) // keep those files that do not exist
     )
-    .map(f => path.basename(f));
+    .map((f) => path.basename(f));
 };

--- a/src/lib/pipelines/pipelines.test.ts
+++ b/src/lib/pipelines/pipelines.test.ts
@@ -8,12 +8,12 @@ import {
   GithubRepoPipelineConfig,
   IAzureRepoPipelineConfig,
   queueBuild,
-  RepositoryTypes
+  RepositoryTypes,
 } from "./pipelines";
 import {
   BuildDefinition,
   BuildRepository,
-  YamlProcess
+  YamlProcess,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import * as azdoClient from "../azdoClient";
 
@@ -45,11 +45,11 @@ describe("It builds an azure repo pipeline definition", () => {
         foo: {
           allowOverride: false,
           isSecret: true,
-          value: "bar"
-        }
+          value: "bar",
+        },
       },
       yamlFileBranch: "master",
-      yamlFilePath: "path/to/azure-pipelines.yml"
+      yamlFilePath: "path/to/azure-pipelines.yml",
     } as IAzureRepoPipelineConfig;
 
     const definition: BuildDefinition = definitionForAzureRepoPipeline(
@@ -91,11 +91,11 @@ describe("It builds a github repo pipeline definition", () => {
         foo: {
           allowOverride: false,
           isSecret: true,
-          value: "bar"
-        }
+          value: "bar",
+        },
       },
       yamlFileBranch: "master",
-      yamlFilePath: "path/to/azure-pipelines.yml"
+      yamlFilePath: "path/to/azure-pipelines.yml",
     } as GithubRepoPipelineConfig;
 
     const definition: BuildDefinition = definitionForGithubRepoPipeline(
@@ -136,7 +136,7 @@ describe("test createPipelineForDefinition function", () => {
       {
         createDefinition: () => {
           return {};
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
       "project",
@@ -151,7 +151,7 @@ describe("test createPipelineForDefinition function", () => {
         {
           createDefinition: () => {
             throw Error("fake");
-          }
+          },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
         "project",
@@ -168,7 +168,7 @@ describe("test queueBuild function", () => {
       {
         queueBuild: () => {
           return {};
-        }
+        },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
       "project",
@@ -183,7 +183,7 @@ describe("test queueBuild function", () => {
         {
           queueBuild: () => {
             throw Error("fake");
-          }
+          },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
         "project",

--- a/src/lib/pipelines/pipelines.ts
+++ b/src/lib/pipelines/pipelines.ts
@@ -10,7 +10,7 @@ import {
   DefinitionQueueStatus,
   DefinitionTriggerType,
   DefinitionType,
-  YamlProcess
+  YamlProcess,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import { logger } from "../../logger";
 import { getBuildApi } from "../azdoClient";
@@ -23,7 +23,7 @@ const hostedUbuntuPoolId = 224;
  */
 export enum RepositoryTypes {
   Github = "github",
-  Azure = "tfsgit"
+  Azure = "tfsgit",
 }
 
 /**
@@ -38,7 +38,7 @@ export const getBuildApiClient = async (
 ): Promise<IBuildApi> => {
   return await getBuildApi({
     orgName,
-    personalAccessToken
+    personalAccessToken,
   });
 };
 
@@ -86,16 +86,16 @@ export const definitionForAzureRepoPipeline = (
       branchFilters: pipelineConfig.branchFilters,
       maxConcurrentBuildsPerBranch: pipelineConfig.maximumConcurrentBuilds,
       settingsSourceType: 2,
-      triggerType: DefinitionTriggerType.ContinuousIntegration
-    } as ContinuousIntegrationTrigger
+      triggerType: DefinitionTriggerType.ContinuousIntegration,
+    } as ContinuousIntegrationTrigger,
   ];
 
   pipelineDefinition.queue = {
     name: hostedUbuntuPool,
     pool: {
       id: hostedUbuntuPoolId,
-      name: hostedUbuntuPool
-    }
+      name: hostedUbuntuPool,
+    },
   } as AgentPoolQueue;
 
   pipelineDefinition.queueStatus = DefinitionQueueStatus.Enabled;
@@ -109,11 +109,11 @@ export const definitionForAzureRepoPipeline = (
     id: pipelineConfig.repositoryName,
     name: pipelineConfig.repositoryName,
     type: RepositoryTypes.Azure,
-    url: pipelineConfig.repositoryUrl
+    url: pipelineConfig.repositoryUrl,
   } as BuildRepository;
 
   pipelineDefinition.process = {
-    yamlFilename: pipelineConfig.yamlFilePath
+    yamlFilename: pipelineConfig.yamlFilePath,
   } as YamlProcess;
 
   if (pipelineConfig.variables) {
@@ -140,16 +140,16 @@ export const definitionForGithubRepoPipeline = (
       branchFilters: pipelineConfig.branchFilters,
       maxConcurrentBuildsPerBranch: pipelineConfig.maximumConcurrentBuilds,
       settingsSourceType: 2,
-      triggerType: DefinitionTriggerType.ContinuousIntegration
-    } as ContinuousIntegrationTrigger
+      triggerType: DefinitionTriggerType.ContinuousIntegration,
+    } as ContinuousIntegrationTrigger,
   ];
 
   pipelineDefinition.queue = {
     name: hostedUbuntuPool,
     pool: {
       id: hostedUbuntuPoolId,
-      name: hostedUbuntuPool
-    }
+      name: hostedUbuntuPool,
+    },
   } as AgentPoolQueue;
 
   pipelineDefinition.queueStatus = DefinitionQueueStatus.Enabled;
@@ -163,14 +163,14 @@ export const definitionForGithubRepoPipeline = (
     id: pipelineConfig.repositoryName,
     name: pipelineConfig.repositoryName,
     properties: {
-      connectedServiceId: pipelineConfig.serviceConnectionId
+      connectedServiceId: pipelineConfig.serviceConnectionId,
     },
     type: RepositoryTypes.Github,
-    url: pipelineConfig.repositoryUrl
+    url: pipelineConfig.repositoryUrl,
   } as BuildRepository;
 
   pipelineDefinition.process = {
-    yamlFilename: pipelineConfig.yamlFilePath
+    yamlFilename: pipelineConfig.yamlFilePath,
   } as YamlProcess;
 
   if (pipelineConfig.variables) {
@@ -219,8 +219,8 @@ export const queueBuild = async (
 ): Promise<Build> => {
   const buildReference: Build = {
     definition: {
-      id: definitionId
-    }
+      id: definitionId,
+    },
   };
 
   try {

--- a/src/lib/pipelines/serviceEndpoint.test.ts
+++ b/src/lib/pipelines/serviceEndpoint.test.ts
@@ -10,7 +10,7 @@ import {
   addServiceEndpoint,
   createServiceEndpointIfNotExists,
   createServiceEndPointParams,
-  getServiceEndpointByName
+  getServiceEndpointByName,
 } from "./serviceEndpoint";
 import * as serviceEndpoint from "./serviceEndpoint";
 
@@ -28,8 +28,8 @@ const tenantId: string = uuid();
 
 const mockedConfig = {
   azure_devops: {
-    orrg: uuid()
-  }
+    orrg: uuid(),
+  },
 };
 
 const mockedYaml = {
@@ -42,10 +42,10 @@ const mockedYaml = {
       service_principal_secret: servicePrincipalSecret,
       subscription_id: subscriptionId,
       subscription_name: subscriptionName,
-      tenant_id: tenantId
-    }
+      tenant_id: tenantId,
+    },
   },
-  name: "myvg"
+  name: "myvg",
 };
 
 const mockedMatchServiceEndpointResponse = {
@@ -58,29 +58,29 @@ const mockedMatchServiceEndpointResponse = {
             authenticationType: "authenticationType",
             serviceprincipalid: "serviceprincipalid",
             serviceprincipalkey: "serviceprincipalkey",
-            tenantid: "tenantid"
+            tenantid: "tenantid",
           },
-          scheme: "ssh"
+          scheme: "ssh",
         },
         createdBy: {
           _links: {
             avatar: {
-              href: "https://person.com"
-            }
+              href: "https://person.com",
+            },
           },
           descriptor: "test",
           displayName: "tester",
           id: "test",
           imageUrl: "https://www.test.com",
           uniqueName: "test",
-          url: "https://www.tester.com"
+          url: "https://www.tester.com",
         },
         data: {
           creationMode: "creationMode",
           environment: "environment",
           scopeLevel: "scopeLevel",
           subscriptionId: "subscriptionId",
-          subscriptionName: "subscriptionName"
+          subscriptionName: "subscriptionName",
         },
         id: "test",
         isReady: true,
@@ -88,27 +88,27 @@ const mockedMatchServiceEndpointResponse = {
         name: "test",
         owner: "tester",
         type: "test",
-        url: "https://www.test.com"
-      }
-    ]
+        url: "https://www.test.com",
+      },
+    ],
   },
-  statusCode: 200
+  statusCode: 200,
 };
 
 const mockedNonMatchServiceEndpointResponse = {
   result: {
     count: 0,
-    value: []
+    value: [],
   },
-  statusCode: 200
+  statusCode: 200,
 };
 
 const mockedInvalidServiceEndpointResponse = {
   result: {
     count: 2,
-    value: []
+    value: [],
   },
-  statusCode: 200
+  statusCode: 200,
 };
 
 const createServiceEndpointInput: ServiceEndpointData = {
@@ -117,7 +117,7 @@ const createServiceEndpointInput: ServiceEndpointData = {
   service_principal_secret: servicePrincipalSecret,
   subscription_id: subscriptionId,
   subscription_name: subscriptionName,
-  tenant_id: tenantId
+  tenant_id: tenantId,
 };
 
 beforeAll(() => {
@@ -139,9 +139,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_secret: servicePrincipalSecret,
           subscription_id: subscriptionId,
           subscription_name: subscriptionName,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -174,9 +174,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_secret: servicePrincipalSecret,
           subscription_id: subscriptionId,
           subscription_name: subscriptionName,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -199,9 +199,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_secret: servicePrincipalSecret,
           subscription_id: subscriptionId,
           subscription_name: subscriptionName,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -224,9 +224,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_id: servicePrincipalId,
           subscription_id: subscriptionId,
           subscription_name: subscriptionName,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -249,9 +249,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_id: servicePrincipalId,
           service_principal_secret: servicePrincipalSecret,
           subscription_name: subscriptionName,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -274,9 +274,9 @@ describe("Validate service endpoint parameters creation", () => {
           service_principal_id: servicePrincipalId,
           service_principal_secret: servicePrincipalSecret,
           subscription_id: subscriptionId,
-          tenant_id: tenantId
-        }
-      }
+          tenant_id: tenantId,
+        },
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -294,8 +294,8 @@ describe("Validate service endpoint parameters creation", () => {
     (readYaml as jest.Mock).mockReturnValue({
       description: "mydesc",
       key_vault_provider: {
-        service_endpoint: {}
-      }
+        service_endpoint: {},
+      },
     });
     const input = readYaml<VariableGroupData>("");
 
@@ -325,15 +325,15 @@ const testAddServiceEndpoint = async (
             reject(new Error("fake"));
           });
         }
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           resolve({
             result: {
-              status: "OK"
+              status: "OK",
             },
-            statusCode: positive ? 200 : 400
+            statusCode: positive ? 200 : 400,
           });
         });
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
   );
@@ -347,7 +347,7 @@ describe("test addServiceEndpoint function", () => {
   it("+ve: should pass when service endpoint config is set", async () => {
     const result = await testAddServiceEndpoint();
     expect(result).toStrictEqual({
-      status: "OK"
+      status: "OK",
     });
   });
   it("-ve: create API returns non 200 status code", async () => {
@@ -373,7 +373,7 @@ const testGetServiceEndpointByName = async (
           value: ServiceEndpoint[];
         }>
       > => {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           if (more) {
             resolve(mockedInvalidServiceEndpointResponse);
           } else if (positive) {
@@ -382,7 +382,7 @@ const testGetServiceEndpointByName = async (
             resolve(mockedNonMatchServiceEndpointResponse);
           }
         });
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
   );

--- a/src/lib/pipelines/serviceEndpoint.ts
+++ b/src/lib/pipelines/serviceEndpoint.ts
@@ -67,18 +67,18 @@ export const createServiceEndPointParams = (
         authenticationType: "spnKey",
         serviceprincipalid: serviceEndpointData.service_principal_id,
         serviceprincipalkey: serviceEndpointData.service_principal_secret,
-        tenantid: serviceEndpointData.tenant_id
+        tenantid: serviceEndpointData.tenant_id,
       },
-      scheme: "ServicePrincipal"
+      scheme: "ServicePrincipal",
     },
     data: {
       subscriptionId: serviceEndpointData.subscription_id,
-      subscriptionName: serviceEndpointData.subscription_name
+      subscriptionName: serviceEndpointData.subscription_name,
     },
     id: generateUuid(),
     isReady: false,
     name: serviceEndpointData.name,
-    type: "azurerm"
+    type: "azurerm",
   };
 
   return endPointParams;
@@ -103,7 +103,7 @@ export const addServiceEndpoint = async (
   const config = Config();
   const {
     project = config.azure_devops && config.azure_devops.project,
-    orgName = config.azure_devops && config.azure_devops.org
+    orgName = config.azure_devops && config.azure_devops.org,
   } = opts;
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -162,7 +162,7 @@ export const getServiceEndpointByName = async (
   const config = Config();
   const {
     project = config.azure_devops && config.azure_devops.project,
-    orgName = config.azure_devops && config.azure_devops.org
+    orgName = config.azure_devops && config.azure_devops.org,
   } = opts;
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/lib/pipelines/try_pipeline.ts
+++ b/src/lib/pipelines/try_pipeline.ts
@@ -10,7 +10,7 @@ import {
   createPipelineForDefinition,
   definitionForAzureRepoPipeline,
   getBuildApiClient,
-  queueBuild
+  queueBuild,
 } from "./pipelines";
 
 const token = process.env.PERSONAL_ACCESS_TOKEN || "some-super-secret-token";
@@ -46,7 +46,7 @@ const start = async (): Promise<void> => {
     repositoryName: azdoRepoName,
     repositoryUrl: azdoRepoUrl,
     yamlFileBranch: "master",
-    yamlFilePath: pipelineYamlPath
+    yamlFilePath: pipelineYamlPath,
   });
 
   try {

--- a/src/lib/pipelines/variableGroup.test.ts
+++ b/src/lib/pipelines/variableGroup.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import {
   VariableGroup,
-  VariableGroupParameters
+  VariableGroupParameters,
 } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 import uuid from "uuid/v4";
 import * as azdoClient from "../azdoClient";
@@ -15,7 +15,7 @@ import {
   authorizeAccessToAllPipelines,
   buildVariablesMap,
   deleteVariableGroup,
-  doAddVariableGroup
+  doAddVariableGroup,
 } from "./variableGroup";
 import * as variableGroup from "./variableGroup";
 import * as serviceEndpoint from "./serviceEndpoint";
@@ -43,7 +43,7 @@ describe("addVariableGroup", () => {
   });
   test("should fail when variable group config variables are not set", async () => {
     (readYaml as jest.Mock).mockReturnValueOnce({
-      variables: undefined
+      variables: undefined,
     });
 
     const data = readYaml<VariableGroupData>("");
@@ -58,10 +58,10 @@ describe("addVariableGroup", () => {
         {
           var1: {
             isSecret: true,
-            value: "val1"
-          }
-        }
-      ]
+            value: "val1",
+          },
+        },
+      ],
     });
     const data = readYaml<VariableGroupData>("");
     jest.spyOn(variableGroup, "doAddVariableGroup").mockResolvedValueOnce({});
@@ -84,10 +84,10 @@ describe("addVariableGroupWithKeyVaultMap", () => {
       variables: [
         {
           secret1: {
-            enabled: true
-          }
-        }
-      ]
+            enabled: true,
+          },
+        },
+      ],
     });
     const data = readYaml<VariableGroupData>("");
     await expect(addVariableGroupWithKeyVaultMap(data)).rejects.toThrow();
@@ -102,18 +102,18 @@ describe("addVariableGroupWithKeyVaultMap", () => {
           service_principal_secret: "secret",
           subscription_id: "id",
           subscription_name: "subname",
-          tenant_id: "tid"
-        }
+          tenant_id: "tid",
+        },
       },
       name: "myvg",
       type: "AzureKeyVault",
       variables: [
         {
           secret1: {
-            enabled: true
-          }
-        }
-      ]
+            enabled: true,
+          },
+        },
+      ],
     });
 
     const data = readYaml<VariableGroupData>("");
@@ -124,16 +124,16 @@ describe("addVariableGroupWithKeyVaultMap", () => {
       description: "myvg desc",
       key_vault_provider: {
         name: "mykv",
-        service_endpoint: {}
+        service_endpoint: {},
       },
       name: "myvg",
       variables: [
         {
           secret1: {
-            enabled: true
-          }
-        }
-      ]
+            enabled: true,
+          },
+        },
+      ],
     });
     const data = readYaml<VariableGroupData>("");
     await expect(addVariableGroupWithKeyVaultMap(data)).rejects.toThrow();
@@ -149,24 +149,24 @@ describe("addVariableGroupWithKeyVaultMap", () => {
           service_principal_secret: "princsecret",
           subscription_id: "subid",
           subscription_name: "subname",
-          tenant_id: "tenid"
-        }
+          tenant_id: "tenid",
+        },
       },
       name: "myvg",
       variables: [
         {
           secret1: {
-            enabled: true
-          }
-        }
-      ]
+            enabled: true,
+          },
+        },
+      ],
     });
 
     const data = readYaml<VariableGroupData>("");
     jest
       .spyOn(serviceEndpoint, "createServiceEndpointIfNotExists")
       .mockResolvedValueOnce({
-        id: "test"
+        id: "test",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
     jest.spyOn(variableGroup, "doAddVariableGroup").mockResolvedValueOnce({});
@@ -178,16 +178,16 @@ describe("addVariableGroupWithKeyVaultMap", () => {
 const mockForDoAddVariableGroupTest = (): void => {
   jest.spyOn(config, "Config").mockReturnValueOnce({
     azure_devops: {
-      project: "project"
-    }
+      project: "project",
+    },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);
   jest.spyOn(azdoClient, "getTaskAgentApi").mockResolvedValueOnce({
     addVariableGroup: () => {
       return {
-        id: "test"
+        id: "test",
       };
-    }
+    },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);
   jest
@@ -212,13 +212,13 @@ describe("doAddVariableGroup", () => {
       variables: {
         var1: {
           isSecret: false,
-          value: "val1"
+          value: "val1",
         },
         var2: {
           isSecret: true,
-          value: "val2"
-        }
-      }
+          value: "val2",
+        },
+      },
     });
 
     const data = readYaml<VariableGroupData>("");
@@ -229,7 +229,7 @@ describe("doAddVariableGroup", () => {
       description: data.description,
       name: data.name,
       type: data.type,
-      variables: variablesMap
+      variables: variablesMap,
     };
 
     const group = await doAddVariableGroup(params, true);
@@ -247,21 +247,21 @@ describe("doAddVariableGroup", () => {
           service_principal_secret: "princsecret",
           subscription_id: "subid",
           subscription_name: "subname",
-          tenant_id: "tenid"
-        }
+          tenant_id: "tenid",
+        },
       },
       name: uuid(),
       type: "AzureKeyVault",
       variables: {
         var1: {
           isSecret: false,
-          value: "val1"
+          value: "val1",
         },
         var2: {
           isSecret: true,
-          value: "val2"
-        }
-      }
+          value: "val2",
+        },
+      },
     });
 
     const data = readYaml<VariableGroupData>("");
@@ -271,7 +271,7 @@ describe("doAddVariableGroup", () => {
       description: data.description,
       name: data.name,
       type: data.type,
-      variables: buildVariablesMap(data.variables)
+      variables: buildVariablesMap(data.variables),
     };
 
     const group = await doAddVariableGroup(params, true);
@@ -283,29 +283,29 @@ describe("authorizeAccessToAllPipelines", () => {
   test("negative test", async () => {
     await expect(
       authorizeAccessToAllPipelines({
-        id: undefined
+        id: undefined,
       })
     ).rejects.toThrow();
   });
   test("should pass when valid variable group is passed", async () => {
     jest.spyOn(config, "Config").mockReturnValueOnce({
       azure_devops: {
-        project: "test"
-      }
+        project: "test",
+      },
     });
     jest.spyOn(azdoClient, "getBuildApi").mockResolvedValueOnce({
       authorizeProjectResources: () => {
         return [
           {
-            authorized: true
-          }
+            authorized: true,
+          },
         ];
-      }
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     const authorized = await authorizeAccessToAllPipelines({
       id: 1,
-      name: "group"
+      name: "group",
     });
     expect(authorized).toBeTruthy();
   });
@@ -316,7 +316,7 @@ describe("authorizeAccessToAllPipelines", () => {
     await expect(
       authorizeAccessToAllPipelines({
         id: 1,
-        name: "group"
+        name: "group",
       })
     ).rejects.toThrow();
   });
@@ -327,12 +327,12 @@ describe("buildVariablesMap", () => {
     const variables: VariableGroupDataVariable = {
       var1: {
         isSecret: false,
-        value: "val1"
+        value: "val1",
       },
       var2: {
         isSecret: true,
-        value: "val2"
-      }
+        value: "val2",
+      },
     };
 
     const map = buildVariablesMap(variables);
@@ -343,8 +343,8 @@ describe("buildVariablesMap", () => {
     const variables: VariableGroupDataVariable = {
       var1: {
         isSecret: false,
-        value: "val1"
-      }
+        value: "val1",
+      },
     };
 
     const map = buildVariablesMap(variables);
@@ -360,11 +360,11 @@ describe("buildVariablesMap", () => {
   test("should create variable map with two secrets", async () => {
     const variables: VariableGroupDataVariable = {
       secret1: {
-        enabled: false
+        enabled: false,
       },
       secret2: {
-        enabled: true
-      }
+        enabled: true,
+      },
     };
 
     const secretsMap = buildVariablesMap(variables);
@@ -374,8 +374,8 @@ describe("buildVariablesMap", () => {
   test("should create variable map with one secret", async () => {
     const variables: VariableGroupDataVariable = {
       secret1: {
-        enabled: true
-      }
+        enabled: true,
+      },
     };
 
     const secretsMap = buildVariablesMap(variables);
@@ -395,9 +395,9 @@ describe("test deleteVariableGroup function", () => {
       deleteVariableGroup: delFn,
       getVariableGroups: () => [
         {
-          id: "test"
-        }
-      ]
+          id: "test",
+        },
+      ],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     const deleted = await deleteVariableGroup({}, "test");
@@ -408,7 +408,7 @@ describe("test deleteVariableGroup function", () => {
     const delFn = jest.fn();
     jest.spyOn(azdoClient, "getTaskAgentApi").mockResolvedValueOnce({
       deleteVariableGroup: delFn,
-      getVariableGroups: () => []
+      getVariableGroups: () => [],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     const deleted = await deleteVariableGroup({}, "test");

--- a/src/lib/pipelines/variableGroup.ts
+++ b/src/lib/pipelines/variableGroup.ts
@@ -2,7 +2,7 @@ import { DefinitionResourceReference } from "azure-devops-node-api/interfaces/Bu
 import {
   AzureKeyVaultVariableGroupProviderData,
   VariableGroup,
-  VariableGroupParameters
+  VariableGroupParameters,
 } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 import { Config } from "../../config";
 import { logger } from "../../logger";
@@ -55,14 +55,14 @@ export const authorizeAccessToAllPipelines = async (
     logger.info(`Creating ${message}`);
     const config = Config();
     const {
-      project = config.azure_devops && config.azure_devops.project
+      project = config.azure_devops && config.azure_devops.project,
     } = opts;
 
     const resourceDefinition: DefinitionResourceReference = {
       authorized: true,
       id: variableGroup.id.toString(),
       name: variableGroup.name,
-      type: "variablegroup"
+      type: "variablegroup",
     };
 
     logger.debug(
@@ -166,7 +166,7 @@ export const addVariableGroup = async (
       description: variableGroupData.description,
       name: variableGroupData.name,
       type: "Vsts",
-      variables: variablesMap
+      variables: variablesMap,
     };
 
     return doAddVariableGroup(params, true, opts);
@@ -217,7 +217,7 @@ export const addVariableGroupWithKeyVaultMap = async (
     // create AzureKeyVaultVariableValue object
     const kvProvideData: AzureKeyVaultVariableGroupProviderData = {
       serviceEndpointId: serviceEndpoint.id,
-      vault: variableGroupData.key_vault_provider.name
+      vault: variableGroupData.key_vault_provider.name,
     };
 
     // map variables as secrets from input
@@ -229,7 +229,7 @@ export const addVariableGroupWithKeyVaultMap = async (
       name: variableGroupData.name,
       providerData: kvProvideData,
       type: "AzureKeyVault",
-      variables: secretsMap
+      variables: secretsMap,
     };
 
     return doAddVariableGroup(params, true, opts);

--- a/src/lib/promptBuilder.ts
+++ b/src/lib/promptBuilder.ts
@@ -10,7 +10,7 @@ export const azureOrgName = (
     message: `${i18n.prompt.orgName}\n`,
     name: "azdo_org_name",
     type: "input",
-    validate: validator.validateOrgName
+    validate: validator.validateOrgName,
   };
 };
 
@@ -22,7 +22,7 @@ export const azureProjectName = (
     message: `${i18n.prompt.projectName}\n`,
     name: "azdo_project_name",
     type: "input",
-    validate: validator.validateProjectName
+    validate: validator.validateProjectName,
   };
 };
 
@@ -35,7 +35,7 @@ export const azureAccessToken = (
     message: `${i18n.prompt.personalAccessToken}\n`,
     name: "azdo_pat",
     type: "password",
-    validate: validator.validateAccessToken
+    validate: validator.validateAccessToken,
   };
 };
 
@@ -46,7 +46,7 @@ export const askToSetupIntrospectionConfig = (
     default: defaultValue,
     message: i18n.prompt.setupIntrospectionConfig,
     name: "toSetupIntrospectionConfig",
-    type: "confirm"
+    type: "confirm",
   };
 };
 
@@ -57,7 +57,7 @@ export const askToCreateServicePrincipal = (
     default: defaultValue,
     message: i18n.prompt.createServicePrincipal,
     name: "create_service_principal",
-    type: "confirm"
+    type: "confirm",
   };
 };
 
@@ -69,7 +69,7 @@ export const servicePrincipalId = (
     message: `${i18n.prompt.servicePrincipalId}\n`,
     name: "az_sp_id",
     type: "input",
-    validate: validator.validateServicePrincipalId
+    validate: validator.validateServicePrincipalId,
   };
 };
 
@@ -82,7 +82,7 @@ export const servicePrincipalPassword = (
     message: `${i18n.prompt.servicePrincipalPassword}\n`,
     name: "az_sp_password",
     type: "password",
-    validate: validator.validateServicePrincipalPassword
+    validate: validator.validateServicePrincipalPassword,
   };
 };
 
@@ -94,7 +94,7 @@ export const servicePrincipalTenantId = (
     message: `${i18n.prompt.servicePrincipalTenantId}\n`,
     name: "az_sp_tenant",
     type: "input",
-    validate: validator.validateServicePrincipalTenantId
+    validate: validator.validateServicePrincipalTenantId,
   };
 };
 
@@ -106,7 +106,7 @@ export const servicePrincipal = (
   return [
     servicePrincipalId(id),
     servicePrincipalPassword(pwd),
-    servicePrincipalTenantId(tenantId)
+    servicePrincipalTenantId(tenantId),
   ];
 };
 
@@ -115,7 +115,7 @@ export const chooseSubscriptionId = (names: string[]): QuestionCollection => {
     choices: names,
     message: `${i18n.prompt.selectSubscriptionId}\n`,
     name: "az_subscription",
-    type: "list"
+    type: "list",
   };
 };
 
@@ -127,7 +127,7 @@ export const azureStorageAccountName = (
     message: `${i18n.prompt.storageAccountName}\n`,
     name: "azdo_storage_account_name",
     type: "input",
-    validate: validator.validateStorageAccountName
+    validate: validator.validateStorageAccountName,
   };
 };
 
@@ -139,7 +139,7 @@ export const azureStorageTableName = (
     message: `${i18n.prompt.storageTableName}\n`,
     name: "azdo_storage_table_name",
     type: "input",
-    validate: validator.validateStorageTableName
+    validate: validator.validateStorageTableName,
   };
 };
 
@@ -151,7 +151,7 @@ export const azureStoragePartitionKey = (
     message: `${i18n.prompt.storagePartitionKey}\n`,
     name: "azdo_storage_partition_key",
     type: "input",
-    validate: validator.validateStoragePartitionKey
+    validate: validator.validateStoragePartitionKey,
   };
 };
 
@@ -163,7 +163,7 @@ export const azureKeyVaultName = (
     message: `${i18n.prompt.storageKeVaultName}\n`,
     name: "azdo_storage_key_vault_name",
     type: "input",
-    validate: validator.validateStorageKeyVaultName
+    validate: validator.validateStorageKeyVaultName,
   };
 };
 
@@ -176,6 +176,6 @@ export const azureStorageAccessKey = (
     message: `${i18n.prompt.storageAccessKey}\n`,
     name: "azdo_storage_access_key",
     type: "password",
-    validate: validator.validateStorageAccessKey
+    validate: validator.validateStorageAccessKey,
   };
 };

--- a/src/lib/setup/gitService.test.ts
+++ b/src/lib/setup/gitService.test.ts
@@ -9,14 +9,14 @@ import {
   getAzureRepoUrl,
   getGitApi,
   getRepoInAzureOrg,
-  getRepoURL
+  getRepoURL,
 } from "./gitService";
 
 const mockRequestContext = {
   accessToken: "pat",
   orgName: "orgname",
   projectName: "project",
-  workspace: WORKSPACE
+  workspace: WORKSPACE,
 };
 
 describe("test getAzureRepoUrl function", () => {
@@ -30,14 +30,14 @@ describe("test getAzureRepoUrl function", () => {
 describe("test getGitApi function", () => {
   it("mocked webAPI", async () => {
     await getGitApi({
-      getGitApi: jest.fn()
+      getGitApi: jest.fn(),
     } as any);
   });
   it("mocked webAPI: cached", async () => {
     await getGitApi({
       getGitApi: () => {
         return {};
-      }
+      },
     } as any);
     await getGitApi({
       // without getGitApi function works because the client is cached in the first call
@@ -49,7 +49,7 @@ describe("test getRepoURL function", () => {
   it("positive test", () => {
     const res = getRepoURL(
       {
-        remoteUrl: "https://orgName@github.com/test"
+        remoteUrl: "https://orgName@github.com/test",
       } as any,
       "orgName"
     );
@@ -60,13 +60,13 @@ describe("test getRepoURL function", () => {
 describe("test createRepo function", () => {
   it("positive test", async () => {
     const mockResult = {
-      id: "testRepo"
+      id: "testRepo",
     };
     const res = await createRepo(
       {
         createRepository: async () => {
           return mockResult;
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
@@ -80,9 +80,9 @@ describe("test createRepo function", () => {
           createRepository: () => {
             throw {
               message: "Authentication failure",
-              statusCode: 401
+              statusCode: 401,
             };
-          }
+          },
         } as any,
         "testRepo",
         "testProject"
@@ -95,7 +95,7 @@ describe("test createRepo function", () => {
         {
           createRepository: () => {
             throw new Error("fake");
-          }
+          },
         } as any,
         "testRepo",
         "testProject"
@@ -110,11 +110,11 @@ describe("test deleteRepo function", () => {
       {
         deleteRepository: () => {
           return;
-        }
+        },
       } as any,
       {
         id: "test",
-        name: "test"
+        name: "test",
       },
       "project"
     );
@@ -125,11 +125,11 @@ describe("test deleteRepo function", () => {
         {
           deleteRepository: () => {
             throw new Error("Fake");
-          }
+          },
         } as any,
         {
           id: "test",
-          name: "test"
+          name: "test",
         },
         "project"
       )
@@ -141,10 +141,10 @@ describe("test deleteRepo function", () => {
         {
           deleteRepository: () => {
             throw new Error("Fake");
-          }
+          },
         } as any,
         {
-          name: "test"
+          name: "test",
         },
         "project"
       )
@@ -157,14 +157,14 @@ describe("test getRepoInAzureOrg function", () => {
     const mockRepo = {
       name: "testRepo",
       project: {
-        name: "testProject"
-      }
+        name: "testProject",
+      },
     };
     const res = await getRepoInAzureOrg(
       {
         getRepositories: () => {
           return [mockRepo];
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
@@ -176,7 +176,7 @@ describe("test getRepoInAzureOrg function", () => {
       {
         getRepositories: () => {
           return [];
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
@@ -191,11 +191,11 @@ describe("test getRepoInAzureOrg function", () => {
             {
               name: "otherRepo",
               project: {
-                name: "testProject"
-              }
-            }
+                name: "testProject",
+              },
+            },
           ];
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
@@ -209,9 +209,9 @@ describe("test getRepoInAzureOrg function", () => {
           getRepositories: () => {
             throw {
               message: "Authentication failure",
-              statusCode: 401
+              statusCode: 401,
             };
-          }
+          },
         } as any,
         "testRepo",
         "testProject"
@@ -224,7 +224,7 @@ describe("test getRepoInAzureOrg function", () => {
         {
           getRepositories: () => {
             throw new Error("fake");
-          }
+          },
         } as any,
         "testRepo",
         "testProject"
@@ -240,14 +240,14 @@ describe("test createRepoInAzureOrg function", () => {
     const mockRepo = {
       name: "testRepo",
       project: {
-        name: "testProject"
-      }
+        name: "testProject",
+      },
     };
     const res = await createRepoInAzureOrg(
       {
         getRepositories: () => {
           return [mockRepo];
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
@@ -260,7 +260,7 @@ describe("test createRepoInAzureOrg function", () => {
     const fnCreateRepo = jest.spyOn(gitService, "createRepo");
     fnCreateRepo.mockReturnValueOnce(
       Promise.resolve({
-        id: "testRepo"
+        id: "testRepo",
       })
     );
 
@@ -268,13 +268,13 @@ describe("test createRepoInAzureOrg function", () => {
       {
         getRepositories: () => {
           return [];
-        }
+        },
       } as any,
       "testRepo",
       "testProject"
     );
     expect(res).toStrictEqual({
-      id: "testRepo"
+      id: "testRepo",
     });
     expect(fnCreateRepo).toBeCalledTimes(1);
     fnCreateRepo.mockReset();
@@ -284,8 +284,8 @@ describe("test createRepoInAzureOrg function", () => {
       id: "testRepo",
       name: "testRepo",
       project: {
-        name: "testProject"
-      }
+        name: "testProject",
+      },
     };
     const fnCreateRepo = jest.spyOn(gitService, "createRepo");
     fnCreateRepo.mockReturnValueOnce(Promise.resolve(mockRepo));
@@ -296,7 +296,7 @@ describe("test createRepoInAzureOrg function", () => {
       {
         getRepositories: () => {
           return [mockRepo];
-        }
+        },
       } as any,
       "testRepo",
       "testProject",
@@ -325,12 +325,12 @@ describe("test commitAndPushToRemote function", () => {
             all: [
               {
                 date: "2020-03-01 07:50:48 -0800",
-                message: "Initial commit for some repo"
-              }
-            ]
+                message: "Initial commit for some repo",
+              },
+            ],
           };
         },
-        push: jest.fn
+        push: jest.fn,
       } as any,
       mockRequestContext,
       "repoName"
@@ -342,7 +342,7 @@ describe("test commitAndPushToRemote function", () => {
         {
           commit: () => {
             throw new Error("fake");
-          }
+          },
         } as any,
         mockRequestContext,
         "repoName"

--- a/src/lib/setup/gitService.ts
+++ b/src/lib/setup/gitService.ts
@@ -46,7 +46,7 @@ export const createRepo = async (
   projectName: string
 ): Promise<GitRepository> => {
   const createOptions = {
-    name: repoName
+    name: repoName,
   };
   try {
     return await gitApi.createRepository(createOptions, projectName);
@@ -95,7 +95,7 @@ export const getRepoInAzureOrg = async (
 ): Promise<GitRepository | undefined> => {
   try {
     const respositories = await gitApi.getRepositories();
-    return (respositories || []).find(repo => {
+    return (respositories || []).find((repo) => {
       return repo.project?.name === projectName && repo.name === repoName;
     });
   } catch (err) {
@@ -165,7 +165,9 @@ export const commitAndPushToRemote = async (
 
   const resultLog = await git.log();
   logger.info("Log Messages from Git:");
-  resultLog.all.forEach(f => logger.info("\t" + f.date + " --> " + f.message));
+  resultLog.all.forEach((f) =>
+    logger.info("\t" + f.date + " --> " + f.message)
+  );
 
   // TOFIX: We know AzDO url style so hack it for now instead of discovering via API
   const remoteURL = `dev.azure.com/${rc.orgName}/${rc.projectName}/_git/${repoName}`;

--- a/src/lib/setup/pipelineService.test.ts
+++ b/src/lib/setup/pipelineService.test.ts
@@ -13,7 +13,7 @@ import {
   getBuildStatusString,
   getPipelineBuild,
   getPipelineByName,
-  pollForPipelineStatus
+  pollForPipelineStatus,
 } from "./pipelineService";
 import * as pipelineService from "./pipelineService";
 
@@ -21,7 +21,7 @@ const mockRequestContext: RequestContext = {
   accessToken: "pat",
   orgName: "orgname",
   projectName: "project",
-  workspace: WORKSPACE
+  workspace: WORKSPACE,
 };
 
 const getMockRequestContext = (): RequestContext => {
@@ -36,7 +36,7 @@ describe("test getBuildStatusString function", () => {
       "Completed",
       "Cancelling",
       "Postponed",
-      "Not Started"
+      "Not Started",
     ];
 
     [
@@ -45,7 +45,7 @@ describe("test getBuildStatusString function", () => {
       BuildStatus.Completed,
       BuildStatus.Cancelling,
       BuildStatus.Postponed,
-      BuildStatus.NotStarted
+      BuildStatus.NotStarted,
     ].forEach((s, i) => {
       expect(getBuildStatusString(s)).toBe(results[i]);
     });
@@ -62,7 +62,7 @@ describe("test getPipelineByName function", () => {
       {
         getDefinitions: () => {
           return [];
-        }
+        },
       } as any,
       "project",
       "pipeline"
@@ -75,10 +75,10 @@ describe("test getPipelineByName function", () => {
         getDefinitions: () => {
           return [
             {
-              name: "pipeline"
-            }
+              name: "pipeline",
+            },
           ];
-        }
+        },
       } as any,
       "project",
       "pipeline"
@@ -91,16 +91,16 @@ describe("test getPipelineByName function", () => {
         getDefinitions: () => {
           return [
             {
-              name: "pipeline1"
+              name: "pipeline1",
             },
             {
-              name: "pipeline2"
+              name: "pipeline2",
             },
             {
-              name: "pipeline3"
-            }
+              name: "pipeline3",
+            },
           ];
-        }
+        },
       } as any,
       "project",
       "pipeline"
@@ -113,16 +113,16 @@ describe("test getPipelineByName function", () => {
         getDefinitions: () => {
           return [
             {
-              name: "pipeline"
+              name: "pipeline",
             },
             {
-              name: "pipeline2"
+              name: "pipeline2",
             },
             {
-              name: "pipeline3"
-            }
+              name: "pipeline3",
+            },
           ];
-        }
+        },
       } as any,
       "project",
       "pipeline"
@@ -135,7 +135,7 @@ describe("test getPipelineByName function", () => {
         {
           getDefinitions: () => {
             throw Error("fake");
-          }
+          },
         } as any,
         "project",
         "pipeline"
@@ -148,7 +148,7 @@ describe("test deletePipeline function", () => {
   it("sanity test", async () => {
     await deletePipeline(
       {
-        deleteDefinition: jest.fn
+        deleteDefinition: jest.fn,
       } as any,
       "project",
       "pipeline",
@@ -161,7 +161,7 @@ describe("test deletePipeline function", () => {
         {
           deleteDefinition: () => {
             throw Error("Fake");
-          }
+          },
         } as any,
         "project",
         "pipeline",
@@ -177,7 +177,7 @@ describe("test getPipelineBuild function", () => {
       {
         getLatestBuild: () => {
           return {};
-        }
+        },
       } as any,
       "project",
       "pipeline"
@@ -190,7 +190,7 @@ describe("test getPipelineBuild function", () => {
         {
           getLatestBuild: () => {
             throw Error("Fake");
-          }
+          },
         } as any,
         "project",
         "pipeline"
@@ -206,7 +206,7 @@ describe("test pollForPipelineStatus function", () => {
       .mockReturnValueOnce(Promise.resolve({}));
     jest.spyOn(pipelineService, "getPipelineBuild").mockReturnValueOnce(
       Promise.resolve({
-        status: 1
+        status: 1,
       })
     );
 
@@ -248,7 +248,7 @@ describe("test createHLDtoManifestPipeline function", () => {
   });
   it("positive test: pipeline already exists previously", async () => {
     jest.spyOn(pipelineService, "getPipelineByName").mockResolvedValueOnce({
-      id: 1
+      id: 1,
     });
     const fnDeletePipeline = jest
       .spyOn(pipelineService, "deletePipeline")
@@ -294,7 +294,7 @@ describe("test createLifecyclePipeline function", () => {
   it("positive test: pipeline already exists", async () => {
     jest.spyOn(pipelineService, "getPipelineByName").mockReturnValueOnce(
       Promise.resolve({
-        id: 1
+        id: 1,
       })
     );
     const fnDeletePipeline = jest
@@ -341,7 +341,7 @@ describe("test createBuildPipeline function", () => {
   it("positive test: pipeline already exists", async () => {
     jest.spyOn(pipelineService, "getPipelineByName").mockReturnValueOnce(
       Promise.resolve({
-        id: 1
+        id: 1,
       })
     );
     const fnDeletePipeline = jest

--- a/src/lib/setup/pipelineService.ts
+++ b/src/lib/setup/pipelineService.ts
@@ -2,7 +2,7 @@ import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   Build,
   BuildDefinitionReference,
-  BuildStatus
+  BuildStatus,
 } from "azure-devops-node-api/interfaces/BuildInterfaces";
 import path from "path";
 import { installHldToManifestPipeline } from "../../commands/hld/pipeline";
@@ -10,7 +10,7 @@ import { installLifecyclePipeline } from "../../commands/project/pipeline";
 import { installBuildUpdatePipeline } from "../../commands/service/pipeline";
 import {
   BUILD_SCRIPT_URL,
-  SERVICE_PIPELINE_FILENAME
+  SERVICE_PIPELINE_FILENAME,
 } from "../../lib/constants";
 import { sleep } from "../../lib/util";
 import { logger } from "../../logger";
@@ -20,7 +20,7 @@ import {
   APP_REPO_LIFECYCLE,
   HLD_REPO,
   RequestContext,
-  MANIFEST_REPO
+  MANIFEST_REPO,
 } from "./constants";
 import { getAzureRepoUrl } from "./gitService";
 
@@ -78,7 +78,7 @@ export const getPipelineByName = async (
   try {
     logger.info(`Finding pipeline ${pipelineName}`);
     const defs = await buildApi.getDefinitions(projectName);
-    return defs.find(d => d.name === pipelineName);
+    return defs.find((d) => d.name === pipelineName);
   } catch (e) {
     logger.error(`Error in getting pipelines.`);
     throw e;
@@ -207,7 +207,7 @@ export const createHLDtoManifestPipeline = async (
       orgName: rc.orgName,
       personalAccessToken: rc.accessToken,
       pipelineName,
-      yamlFileBranch: "master"
+      yamlFileBranch: "master",
     });
     await pollForPipelineStatus(buildApi, rc.projectName, pipelineName);
     rc.createdHLDtoManifestPipeline = true;
@@ -240,7 +240,7 @@ export const createLifecyclePipeline = async (
       pipelineName,
       repoName: APP_REPO,
       repoUrl: getAzureRepoUrl(rc.orgName, rc.projectName, APP_REPO),
-      yamlFileBranch: "master"
+      yamlFileBranch: "master",
     });
     await pollForPipelineStatus(buildApi, rc.projectName, pipelineName);
     rc.createdLifecyclePipeline = true;
@@ -276,7 +276,7 @@ export const createBuildPipeline = async (
         pipelineName,
         repoName: APP_REPO,
         repoUrl: getAzureRepoUrl(rc.orgName, rc.projectName, APP_REPO),
-        yamlFileBranch: "master"
+        yamlFileBranch: "master",
       }
     );
     await pollForPipelineStatus(buildApi, rc.projectName, pipelineName);

--- a/src/lib/setup/projectService.test.ts
+++ b/src/lib/setup/projectService.test.ts
@@ -7,9 +7,9 @@ describe("test getProject function", () => {
       {
         getProject: async () => {
           return {
-            valid: true
+            valid: true,
           };
-        }
+        },
       } as any,
       "test"
     );
@@ -20,7 +20,7 @@ describe("test getProject function", () => {
       {
         getProject: async () => {
           return null;
-        }
+        },
       } as any,
       "test"
     );
@@ -33,9 +33,9 @@ describe("test getProject function", () => {
           getProject: () => {
             throw {
               message: "Authentication Failed",
-              statusCode: 401
+              statusCode: 401,
             };
-          }
+          },
         } as any,
         "test"
       )
@@ -47,7 +47,7 @@ describe("test getProject function", () => {
         {
           getProject: () => {
             throw new Error("fake");
-          }
+          },
         } as any,
         "test"
       )
@@ -61,12 +61,12 @@ describe("test createProject function", () => {
       {
         getProject: () => {
           return {
-            state: "wellFormed"
+            state: "wellFormed",
           };
         },
         queueCreateProject: async () => {
           return;
-        }
+        },
       } as any,
       "test"
     );
@@ -80,7 +80,7 @@ describe("test createProject function", () => {
           },
           queueCreateProject: async () => {
             return;
-          }
+          },
         } as any,
         "test",
         1,
@@ -95,9 +95,9 @@ describe("test createProject function", () => {
           queueCreateProject: () => {
             throw {
               message: "Authentication Failed",
-              statusCode: 401
+              statusCode: 401,
             };
-          }
+          },
         } as any,
         "test"
       )
@@ -109,7 +109,7 @@ describe("test createProject function", () => {
         {
           queueCreateProject: () => {
             throw new Error("fake");
-          }
+          },
         } as any,
         "test"
       )

--- a/src/lib/setup/projectService.ts
+++ b/src/lib/setup/projectService.ts
@@ -1,7 +1,7 @@
 import { ICoreApi } from "azure-devops-node-api/CoreApi";
 import {
   ProjectVisibility,
-  TeamProject
+  TeamProject,
 } from "azure-devops-node-api/interfaces/CoreInterfaces";
 import { sleep } from "../../lib/util";
 import { logger } from "../../logger";
@@ -48,15 +48,15 @@ export const createProject = async (
     await coreAPI.queueCreateProject({
       capabilities: {
         processTemplate: {
-          templateTypeId: "6b724908-ef14-45cf-84f8-768b5384da45" // TOFIX: do not know what this GUID is about (https://docs.microsoft.com/en-us/rest/api/azure/devops/processes/processes/list?view=azure-devops-rest-5.1)
+          templateTypeId: "6b724908-ef14-45cf-84f8-768b5384da45", // TOFIX: do not know what this GUID is about (https://docs.microsoft.com/en-us/rest/api/azure/devops/processes/processes/list?view=azure-devops-rest-5.1)
         },
         versioncontrol: {
-          sourceControlType: "Git"
-        }
+          sourceControlType: "Git",
+        },
       },
       description: "Created by automated tool",
       name,
-      visibility: ProjectVisibility.Organization
+      visibility: ProjectVisibility.Organization,
     });
     // poll to check if project is checked.
     let created = false;

--- a/src/lib/setup/prompt.test.ts
+++ b/src/lib/setup/prompt.test.ts
@@ -12,7 +12,7 @@ import {
   prompt,
   promptForACRName,
   promptForApprovingHLDPullRequest,
-  promptForServicePrincipalCreation
+  promptForServicePrincipalCreation,
 } from "./prompt";
 import * as promptInstance from "./prompt";
 import * as gitService from "./gitService";
@@ -25,7 +25,7 @@ describe("test prompt function", () => {
       azdo_org_name: "org",
       azdo_pat: "pat",
       azdo_project_name: "project",
-      create_app_repo: false
+      create_app_repo: false,
     };
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce(answers);
     const ans = await prompt();
@@ -34,7 +34,7 @@ describe("test prompt function", () => {
       orgName: "org",
       projectName: "project",
       toCreateAppRepo: false,
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     });
   });
   it("positive test: create SP", async () => {
@@ -42,25 +42,25 @@ describe("test prompt function", () => {
       azdo_org_name: "org",
       azdo_pat: "pat",
       azdo_project_name: "project",
-      create_app_repo: true
+      create_app_repo: true,
     };
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce(answers);
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      create_service_principal: true
+      create_service_principal: true,
     });
 
     jest.spyOn(servicePrincipalService, "azCLILogin").mockResolvedValueOnce([
       {
         id: "72f988bf-86f1-41af-91ab-2d7cd011db48",
-        name: "subname"
-      }
+        name: "subname",
+      },
     ]);
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      az_subscription: "subname"
+      az_subscription: "subname",
     });
 
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      acr_name: "testACR"
+      acr_name: "testACR",
     });
 
     jest
@@ -68,7 +68,7 @@ describe("test prompt function", () => {
       .mockResolvedValueOnce({
         id: "b510c1ff-358c-4ed4-96c8-eb23f42bb65b",
         password: "a510c1ff-358c-4ed4-96c8-eb23f42bbc5b",
-        tenantId: "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        tenantId: "72f988bf-86f1-41af-91ab-2d7cd011db47",
       });
 
     const ans = await prompt();
@@ -84,7 +84,7 @@ describe("test prompt function", () => {
       subscriptionId: "72f988bf-86f1-41af-91ab-2d7cd011db48",
       toCreateAppRepo: true,
       toCreateSP: true,
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     });
   });
   it("positive test: no create SP", async () => {
@@ -92,25 +92,25 @@ describe("test prompt function", () => {
       azdo_org_name: "org",
       azdo_pat: "pat",
       azdo_project_name: "project",
-      create_app_repo: true
+      create_app_repo: true,
     };
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce(answers);
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      create_service_principal: false
+      create_service_principal: false,
     });
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
       az_sp_id: "b510c1ff-358c-4ed4-96c8-eb23f42bb65b",
       az_sp_password: "a510c1ff-358c-4ed4-96c8-eb23f42bbc5b",
-      az_sp_tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47"
+      az_sp_tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47",
     });
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      acr_name: "testACR"
+      acr_name: "testACR",
     });
     jest.spyOn(subscriptionService, "getSubscriptions").mockResolvedValueOnce([
       {
         id: "72f988bf-86f1-41af-91ab-2d7cd011db48",
-        name: "test"
-      }
+        name: "test",
+      },
     ]);
     const ans = await prompt();
     expect(ans).toStrictEqual({
@@ -124,7 +124,7 @@ describe("test prompt function", () => {
       subscriptionId: "72f988bf-86f1-41af-91ab-2d7cd011db48",
       toCreateAppRepo: true,
       toCreateSP: false,
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     });
   });
 });
@@ -136,7 +136,7 @@ describe("test getAnswerFromFile function", () => {
     const data = [
       "azdo_org_name=orgname",
       "azdo_pat=pat",
-      "azdo_project_name=project"
+      "azdo_project_name=project",
     ];
     fs.writeFileSync(file, data.join("\n"));
     const requestContext = getAnswerFromFile(file);
@@ -175,7 +175,7 @@ describe("test getAnswerFromFile function", () => {
     const data = [
       "azdo_org_name=orgname",
       "azdo_project_name=.project",
-      "azdo_pat=pat"
+      "azdo_pat=pat",
     ];
     fs.writeFileSync(file, data.join("\n"));
     expect(() => {
@@ -202,7 +202,7 @@ describe("test getAnswerFromFile function", () => {
       "az_sp_id=b510c1ff-358c-4ed4-96c8-eb23f42bb65b",
       "az_sp_password=a510c1ff-358c-4ed4-96c8-eb23f42bbc5b",
       "az_sp_tenant=72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "az_subscription_id=72f988bf-86f1-41af-91ab-2d7cd011db48"
+      "az_subscription_id=72f988bf-86f1-41af-91ab-2d7cd011db48",
     ];
     fs.writeFileSync(file, data.join("\n"));
     const requestContext = getAnswerFromFile(file);
@@ -232,7 +232,7 @@ describe("test getAnswerFromFile function", () => {
       "azdo_pat=pat",
       "azdo_project_name=project",
       "az_create_app=true",
-      "az_subscription_id=72f988bf-86f1-41af-91ab-2d7cd011db48"
+      "az_subscription_id=72f988bf-86f1-41af-91ab-2d7cd011db48",
     ];
     [".", ".##", ".abc"].forEach((v, i) => {
       if (i === 0) {
@@ -263,7 +263,7 @@ describe("test getAnswerFromFile function", () => {
       "az_sp_id=b510c1ff-358c-4ed4-96c8-eb23f42bb65b",
       "az_sp_password=a510c1ff-358c-4ed4-96c8-eb23f42bbc5b",
       "az_sp_tenant=72f988bf-86f1-41af-91ab-2d7cd011db47",
-      "az_subscription_id=xyz"
+      "az_subscription_id=xyz",
     ];
     fs.writeFileSync(file, data.join("\n"));
     expect(() => {
@@ -281,7 +281,7 @@ describe("test getSubscriptions function", () => {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     await expect(getSubscriptionId(mockRc)).rejects.toThrow();
   });
@@ -289,21 +289,21 @@ describe("test getSubscriptions function", () => {
     jest.spyOn(subscriptionService, "getSubscriptions").mockResolvedValueOnce([
       {
         id: "123345",
-        name: "subscription1"
+        name: "subscription1",
       },
       {
         id: "12334567890",
-        name: "subscription2"
-      }
+        name: "subscription2",
+      },
     ]);
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      az_subscription: "subscription2"
+      az_subscription: "subscription2",
     });
     const mockRc: RequestContext = {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     await getSubscriptionId(mockRc);
     expect(mockRc.subscriptionId).toBe("12334567890");
@@ -312,21 +312,21 @@ describe("test getSubscriptions function", () => {
     jest.spyOn(subscriptionService, "getSubscriptions").mockResolvedValueOnce([
       {
         id: "123345",
-        name: "subscription1"
+        name: "subscription1",
       },
       {
         id: "12334567890",
-        name: "subscription2"
-      }
+        name: "subscription2",
+      },
     ]);
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      az_subscription: "subscription3"
+      az_subscription: "subscription3",
     });
     const mockRc: RequestContext = {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     await expect(getSubscriptionId(mockRc)).rejects.toThrow();
   });
@@ -338,10 +338,10 @@ describe("test promptForACRName function", () => {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      acr_name: "testACR"
+      acr_name: "testACR",
     });
     await promptForACRName(mockRc);
     expect(mockRc.acrName).toBe("testACR");
@@ -351,13 +351,13 @@ describe("test promptForACRName function", () => {
 describe("test promptForServicePrincipalCreation function", () => {
   it("covering the test gap: negative test", async () => {
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      create_service_principal: true
+      create_service_principal: true,
     });
     jest.spyOn(servicePrincipalService, "azCLILogin").mockResolvedValueOnce([
       {
         id: "72f988bf-86f1-41af-91ab-2d7cd011db48",
-        name: "subname"
-      }
+        name: "subname",
+      },
     ]);
     jest
       .spyOn(promptInstance, "promptForSubscriptionId")
@@ -366,7 +366,7 @@ describe("test promptForServicePrincipalCreation function", () => {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     await expect(promptForServicePrincipalCreation(mockRc)).rejects.toThrow();
   });
@@ -378,13 +378,13 @@ describe("test promptForApprovingHLDPullRequest function", () => {
       .spyOn(gitService, "getAzureRepoUrl")
       .mockReturnValueOnce("https://sample/example");
     jest.spyOn(inquirer, "prompt").mockResolvedValueOnce({
-      approve_hld_pr: true
+      approve_hld_pr: true,
     });
     const mockRc: RequestContext = {
       accessToken: "pat",
       orgName: "org",
       projectName: "project",
-      workspace: WORKSPACE
+      workspace: WORKSPACE,
     };
     const ans = await promptForApprovingHLDPullRequest(mockRc);
     expect(ans).toBeTruthy();

--- a/src/lib/setup/prompt.ts
+++ b/src/lib/setup/prompt.ts
@@ -9,24 +9,24 @@ import {
   validateServicePrincipalId,
   validateServicePrincipalPassword,
   validateServicePrincipalTenantId,
-  validateSubscriptionId
+  validateSubscriptionId,
 } from "../validator";
 import {
   ACR_NAME,
   DEFAULT_PROJECT_NAME,
   HLD_REPO,
   RequestContext,
-  WORKSPACE
+  WORKSPACE,
 } from "./constants";
 import { getAzureRepoUrl } from "./gitService";
 import {
   azCLILogin,
   createWithAzCLI,
-  SubscriptionData
+  SubscriptionData,
 } from "../azure/servicePrincipalService";
 import {
   getSubscriptions,
-  SubscriptionItem
+  SubscriptionItem,
 } from "../azure/subscriptionService";
 
 export const promptForSubscriptionId = async (
@@ -34,15 +34,15 @@ export const promptForSubscriptionId = async (
 ): Promise<string | undefined> => {
   const questions = [
     {
-      choices: subscriptions.map(s => s.name),
+      choices: subscriptions.map((s) => s.name),
       message: "Select one of the subscriptions\n",
       name: "az_subscription",
-      type: "list"
-    }
+      type: "list",
+    },
   ];
   const ans = await inquirer.prompt(questions);
   const found = subscriptions.find(
-    s => s.name === (ans.az_subscription as string)
+    (s) => s.name === (ans.az_subscription as string)
   );
   return found ? found.id : undefined;
 };
@@ -99,8 +99,8 @@ export const promptForACRName = async (rc: RequestContext): Promise<void> => {
       message: `Enter Azure Container Register Name. The registry name must be unique within Azure\n`,
       name: "acr_name",
       type: "input",
-      validate: validateACRName
-    }
+      validate: validateACRName,
+    },
   ];
   const answers = await inquirer.prompt(questions);
   rc.acrName = answers.acr_name as string;
@@ -151,8 +151,8 @@ export const prompt = async (): Promise<RequestContext> => {
       default: true,
       message: "Would you like to create a sample application repository?",
       name: "create_app_repo",
-      type: "confirm"
-    }
+      type: "confirm",
+    },
   ];
   const answers = await inquirer.prompt(questions);
   const rc: RequestContext = {
@@ -160,7 +160,7 @@ export const prompt = async (): Promise<RequestContext> => {
     orgName: answers.azdo_org_name as string,
     projectName: answers.azdo_project_name as string,
     toCreateAppRepo: answers.create_app_repo as boolean,
-    workspace: WORKSPACE
+    workspace: WORKSPACE,
   };
 
   if (rc.toCreateAppRepo) {
@@ -212,9 +212,9 @@ const parseInformationFromFile = (file: string): { [key: string]: string } => {
     );
   }
 
-  const arr = content.split("\n").filter(s => s.trim().length > 0);
+  const arr = content.split("\n").filter((s) => s.trim().length > 0);
   const map: { [key: string]: string } = {};
-  arr.forEach(s => {
+  arr.forEach((s) => {
     const idx = s.indexOf("=");
     if (idx !== -1) {
       map[s.substring(0, idx).trim()] = s.substring(idx + 1).trim();
@@ -255,7 +255,7 @@ export const getAnswerFromFile = (file: string): RequestContext => {
     servicePrincipalPassword: map.az_sp_password,
     servicePrincipalTenantId: map.az_sp_tenant,
     acrName: map.az_acr_name || ACR_NAME,
-    workspace: WORKSPACE
+    workspace: WORKSPACE,
   };
 
   rc.toCreateAppRepo = map.az_create_app === "true";
@@ -277,8 +277,8 @@ export const promptForApprovingHLDPullRequest = async (
       default: true,
       message: `Please approve and merge the Pull Request at ${urlPR}? Refresh the page if you do not see an active Pull Request.`,
       name: "approve_hld_pr",
-      type: "confirm"
-    }
+      type: "confirm",
+    },
   ];
   const answers = await inquirer.prompt(questions);
   return !!answers.approve_hld_pr;

--- a/src/lib/setup/scaffold.test.ts
+++ b/src/lib/setup/scaffold.test.ts
@@ -12,7 +12,7 @@ import {
   HELM_REPO,
   HLD_REPO,
   MANIFEST_REPO,
-  RequestContext
+  RequestContext,
 } from "./constants";
 import * as gitService from "./gitService";
 import {
@@ -21,7 +21,7 @@ import {
   hldRepo,
   initService,
   manifestRepo,
-  setupVariableGroup
+  setupVariableGroup,
 } from "./scaffold";
 import * as scaffold from "./scaffold";
 
@@ -30,7 +30,7 @@ const createRequestContext = (workspace: string): RequestContext => {
     accessToken: "accessToken",
     orgName: "orgName",
     projectName: "projectName",
-    workspace
+    workspace,
   };
 };
 
@@ -84,7 +84,7 @@ describe("test hldRepo function", () => {
     expect(fs.existsSync(folder)).toBe(true);
     expect(fs.statSync(folder).isDirectory()).toBeTruthy();
 
-    ["component.yaml", "manifest-generation.yaml"].forEach(f => {
+    ["component.yaml", "manifest-generation.yaml"].forEach((f) => {
       const sPath = path.join(folder, f);
       expect(fs.existsSync(sPath)).toBe(true);
       expect(fs.statSync(sPath).isFile()).toBeTruthy();
@@ -119,13 +119,13 @@ describe("test helmRepo function", () => {
     expect(fs.statSync(folder).isDirectory()).toBeTruthy();
 
     const folderAppChart = path.join(folder, APP_REPO, "chart");
-    ["Chart.yaml", "values.yaml"].forEach(f => {
+    ["Chart.yaml", "values.yaml"].forEach((f) => {
       const sPath = path.join(folderAppChart, f);
       expect(fs.existsSync(sPath)).toBe(true);
       expect(fs.statSync(sPath).isFile()).toBeTruthy();
     });
     const folderAppChartTemplates = path.join(folderAppChart, "templates");
-    ["all-in-one.yaml"].forEach(f => {
+    ["all-in-one.yaml"].forEach((f) => {
       const sPath = path.join(folderAppChartTemplates, f);
       expect(fs.existsSync(sPath)).toBe(true);
       expect(fs.statSync(sPath).isFile()).toBeTruthy();

--- a/src/lib/setup/scaffold.ts
+++ b/src/lib/setup/scaffold.ts
@@ -6,7 +6,7 @@ import { initialize as hldInitialize } from "../../commands/hld/init";
 import {
   create as createVariableGroup,
   setVariableGroupInBedrockFile,
-  updateLifeCyclePipeline
+  updateLifeCyclePipeline,
 } from "../../commands/project/create-variable-group";
 import { initialize as projectInitialize } from "../../commands/project/init";
 import { createService } from "../../commands/service/create";
@@ -21,13 +21,13 @@ import {
   HLD_REPO,
   MANIFEST_REPO,
   RequestContext,
-  VARIABLE_GROUP
+  VARIABLE_GROUP,
 } from "./constants";
 import { createDirectory, moveToAbsPath, moveToRelativePath } from "./fsUtil";
 import {
   commitAndPushToRemote,
   createRepoInAzureOrg,
-  getAzureRepoUrl
+  getAzureRepoUrl,
 } from "./gitService";
 import { chartTemplate, mainTemplate, valuesTemplate } from "./helmTemplates";
 
@@ -184,7 +184,7 @@ export const setupVariableGroup = async (rc: RequestContext): Promise<void> => {
   const accessOpts: AzureDevOpsOpts = {
     orgName: rc.orgName,
     personalAccessToken: rc.accessToken,
-    project: rc.projectName
+    project: rc.projectName,
   };
 
   await deleteVariableGroup(accessOpts, VARIABLE_GROUP);
@@ -228,7 +228,7 @@ export const initService = async (
     pathPrefix: "",
     pathPrefixMajorVersion: "",
     ringNames: ["master"],
-    variableGroups: [VARIABLE_GROUP]
+    variableGroups: [VARIABLE_GROUP],
   });
 };
 

--- a/src/lib/setup/setupLog.test.ts
+++ b/src/lib/setup/setupLog.test.ts
@@ -27,7 +27,7 @@ const positiveTest = (logExist?: boolean, withAppCreation = false): void => {
     scaffoldHelm: true,
     scaffoldManifest: true,
     subscriptionId: "72f988bf-86f1-41af-91ab-2d7cd011db48",
-    workspace: "workspace"
+    workspace: "workspace",
   };
 
   if (withAppCreation) {
@@ -69,7 +69,7 @@ const positiveTest = (logExist?: boolean, withAppCreation = false): void => {
       "Lifecycle Pipeline Created: yes",
       "Build Pipeline Created: yes",
       "ACR Created: yes",
-      "Status: Completed"
+      "Status: Completed",
     ]);
   } else {
     expect(fs.readFileSync(file, "UTF-8").split("\n")).toStrictEqual([
@@ -95,7 +95,7 @@ const positiveTest = (logExist?: boolean, withAppCreation = false): void => {
       "Lifecycle Pipeline Created: no",
       "Build Pipeline Created: no",
       "ACR Created: no",
-      "Status: Completed"
+      "Status: Completed",
     ]);
   }
 };
@@ -132,7 +132,7 @@ describe("test create function", () => {
         scaffoldHLD: true,
         scaffoldHelm: true,
         scaffoldManifest: true,
-        workspace: "workspace"
+        workspace: "workspace",
       },
       file
     );
@@ -162,7 +162,7 @@ describe("test create function", () => {
       "Build Pipeline Created: no",
       "ACR Created: no",
       "Error: things broke",
-      "Status: Incomplete"
+      "Status: Incomplete",
     ]);
   });
 });

--- a/src/lib/setup/setupLog.ts
+++ b/src/lib/setup/setupLog.ts
@@ -37,7 +37,7 @@ export const create = (rc: RequestContext | undefined, file?: string): void => {
         rc.createdLifecyclePipeline
       )}`,
       `Build Pipeline Created: ${getBooleanVal(rc.createdBuildPipeline)}`,
-      `ACR Created: ${getBooleanVal(rc.createdACR)}`
+      `ACR Created: ${getBooleanVal(rc.createdACR)}`,
     ];
     if (rc.error) {
       buff.push(`Error: ${rc.error}`);

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -29,24 +29,24 @@ export const exec = async (
     let stderr = "";
 
     // Capture stdout/stderr as process runs
-    child.stdout?.on("data", data => {
+    child.stdout?.on("data", (data) => {
       logger.debug(`stdout -> '${cmdString}' -> ${data}`.trim());
       stdout = stdout + data;
     });
-    child.stderr?.on("data", data => {
+    child.stderr?.on("data", (data) => {
       logger.debug(`stderr -> '${cmdString}' -> ${data}`.trim());
       stderr = stderr + data;
     });
 
     // Reject on error
-    child.on("error", err => {
+    child.on("error", (err) => {
       logger.verbose(`'${cmdString}' encountered an error during execution`);
       logger.verbose(err);
       reject(err);
     });
 
     // Resolve promise on completion
-    child.on("exit", code => {
+    child.on("exit", (code) => {
       // Log completion of of command
       logger.verbose(`'${cmdString}' exited with code: ${code}`);
       if (stdout.length > 0) {

--- a/src/lib/traefik/ingress-route.test.ts
+++ b/src/lib/traefik/ingress-route.test.ts
@@ -30,7 +30,7 @@ describe("TraefikIngressRoute", () => {
       80,
       "/version/and/path",
       {
-        k8sBackend: "my-k8s-svc"
+        k8sBackend: "my-k8s-svc",
       }
     );
 
@@ -48,7 +48,7 @@ describe("TraefikIngressRoute", () => {
         80,
         "/version/and/Path",
         {
-          namespace
+          namespace,
         }
       );
       expect(withoutNamespace.metadata.namespace).toBe(namespace);
@@ -84,7 +84,7 @@ describe("TraefikIngressRoute", () => {
       80,
       "/version/and/Path",
       {
-        entryPoints: ["web"]
+        entryPoints: ["web"],
       }
     );
     expect(withJustWeb.spec.entryPoints).toStrictEqual(["web"]);
@@ -94,7 +94,7 @@ describe("TraefikIngressRoute", () => {
       80,
       "/version/and/Path",
       {
-        entryPoints: ["web-secure"]
+        entryPoints: ["web-secure"],
       }
     );
     expect(withJustWebSecure.spec.entryPoints).toStrictEqual(["web-secure"]);
@@ -104,7 +104,7 @@ describe("TraefikIngressRoute", () => {
       80,
       "/version/and/Path",
       {
-        entryPoints: ["web", "web-secure"]
+        entryPoints: ["web", "web-secure"],
       }
     );
     expect(withBoth.spec.entryPoints).toStrictEqual(["web", "web-secure"]);
@@ -113,7 +113,7 @@ describe("TraefikIngressRoute", () => {
   test("middleware gets added properly", () => {
     const middlewares = Array.from({ length: 10 }, () => "/" + uuid());
     const middlewaresNameArray = [
-      ...middlewares.map(middlewareName => ({ name: middlewareName }))
+      ...middlewares.map((middlewareName) => ({ name: middlewareName })),
     ];
 
     const withMiddlewares = TraefikIngressRoute(
@@ -122,7 +122,7 @@ describe("TraefikIngressRoute", () => {
       80,
       "/version/and/Path",
       {
-        middlewares
+        middlewares,
       }
     );
 
@@ -166,7 +166,7 @@ describe("TraefikIngressRoute", () => {
     ).not.toThrow();
     expect(() =>
       TraefikIngressRoute("valid-service", "valid-ring", 80, "v1", {
-        k8sBackend: "my.valid.service"
+        k8sBackend: "my.valid.service",
       })
     ).not.toThrow();
   });
@@ -186,7 +186,7 @@ describe("TraefikIngressRoute", () => {
     ).toThrow();
     expect(() =>
       TraefikIngressRoute("valid-service", "valid-ring", 80, "v1", {
-        k8sBackend: "-invalid"
+        k8sBackend: "-invalid",
       })
     ).toThrow();
   });

--- a/src/lib/traefik/ingress-route.ts
+++ b/src/lib/traefik/ingress-route.ts
@@ -73,7 +73,7 @@ export const TraefikIngressRoute = (
   const routeMatchPathPrefix = `PathPrefix(\`${versionAndPath}\`)`;
   const routeMatchHeaders = ringName && `Headers(\`Ring\`, \`${ringName}\`)`; // no 'X-' prefix for header: https://tools.ietf.org/html/rfc6648
   const routeMatch = [routeMatchPathPrefix, routeMatchHeaders]
-    .filter(matchRule => !!matchRule)
+    .filter((matchRule) => !!matchRule)
     .join(" && ");
 
   const backendService =
@@ -88,7 +88,7 @@ export const TraefikIngressRoute = (
     kind: "IngressRoute",
     metadata: {
       name,
-      ...(namespace ? { namespace } : {})
+      ...(namespace ? { namespace } : {}),
     },
     spec: {
       ...((entryPoints ?? []).length > 0 ? { entryPoints } : {}),
@@ -96,17 +96,17 @@ export const TraefikIngressRoute = (
         {
           kind: "Rule",
           match: routeMatch,
-          middlewares: middlewares.map(middlewareName => ({
-            name: middlewareName
+          middlewares: middlewares.map((middlewareName) => ({
+            name: middlewareName,
           })),
           services: [
             {
               name: backendService,
-              port: servicePort
-            }
-          ]
-        }
-      ]
-    }
+              port: servicePort,
+            },
+          ],
+        },
+      ],
+    },
   };
 };

--- a/src/lib/traefik/middleware.test.ts
+++ b/src/lib/traefik/middleware.test.ts
@@ -5,7 +5,7 @@ describe("TraefikIngressRoute", () => {
     const middlewareWithoutRing = TraefikMiddleware("my-service", "", [
       "/home",
       "/info",
-      "/data"
+      "/data",
     ]);
     expect(middlewareWithoutRing.metadata.name).toBe("my-service");
     expect(middlewareWithoutRing.metadata.namespace).toBe(undefined);
@@ -16,7 +16,7 @@ describe("TraefikIngressRoute", () => {
     expect(middlewareWithoutRing.spec.stripPrefix.prefixes[2]).toBe("/data");
 
     const middlewareWithRing = TraefikMiddleware("my-service", "prod", [
-      "/home"
+      "/home",
     ]);
     expect(middlewareWithRing.metadata.name).toBe("my-service-prod");
     expect(middlewareWithRing.spec.stripPrefix.prefixes.length).toBe(1);

--- a/src/lib/traefik/middleware.ts
+++ b/src/lib/traefik/middleware.ts
@@ -35,13 +35,13 @@ export const TraefikMiddleware = (
     kind: "Middleware",
     metadata: {
       name,
-      ...(namespace ? { namespace } : {})
+      ...(namespace ? { namespace } : {}),
     },
     spec: {
       stripPrefix: {
         forceSlash,
-        prefixes
-      }
-    }
+        prefixes,
+      },
+    },
   };
 };

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -6,14 +6,14 @@ describe("test deepClone function", () => {
       arrObjects: [
         {
           prop1: "prop1",
-          prop2: "prop2"
-        }
+          prop2: "prop2",
+        },
       ],
       arrString: ["item1", "item2"],
       attr: "hello",
       o: {
-        hello: "world"
-      }
+        hello: "world",
+      },
     };
     expect(deepClone(obj)).toStrictEqual(obj);
   });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -13,7 +13,7 @@ export function deepClone<T>(obj: T): T {
  * @param timeInSecond duration in millisecond
  */
 export const sleep = (timeInMs: number): Promise<unknown> => {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve();
     }, timeInMs);

--- a/src/lib/validator.test.ts
+++ b/src/lib/validator.test.ts
@@ -23,7 +23,7 @@ import {
   validateStorageKeyVaultName,
   validateStoragePartitionKey,
   validateStorageTableName,
-  validateSubscriptionId
+  validateSubscriptionId,
 } from "./validator";
 
 describe("Tests on validator helper functions", () => {
@@ -64,37 +64,37 @@ describe("Tests on validator helper functions", () => {
   });
   it("Test validateForNonEmptyValue function", () => {
     // expect "error" to be returned
-    ["", undefined, null].forEach(val => {
+    ["", undefined, null].forEach((val) => {
       expect(
         validateForNonEmptyValue({
           error: "error",
-          value: val
+          value: val,
         })
       ).toBe("error");
     });
     // expect "" to be returned
-    ["", undefined, null].forEach(val => {
+    ["", undefined, null].forEach((val) => {
       expect(
         validateForNonEmptyValue({
           error: "",
-          value: val
+          value: val,
         })
       ).toBe("");
     });
     // positive tests
-    [" c ", " b ", "a"].forEach(val => {
+    [" c ", " b ", "a"].forEach((val) => {
       expect(
         validateForNonEmptyValue({
           error: "",
-          value: val
+          value: val,
         })
       ).toBe("");
     });
-    [" b ", "a"].forEach(val => {
+    [" b ", "a"].forEach((val) => {
       expect(
         validateForNonEmptyValue({
           error: "",
-          value: val
+          value: val,
         })
       ).toBe("");
     });
@@ -208,17 +208,17 @@ describe("test validateServicePrincipal functions", () => {
     [
       {
         fn: validateServicePrincipalId,
-        prop: "Service Principal Id"
+        prop: "Service Principal Id",
       },
       {
         fn: validateServicePrincipalPassword,
-        prop: "Service Principal Password"
+        prop: "Service Principal Password",
       },
       {
         fn: validateServicePrincipalTenantId,
-        prop: "Service Principal Tenant Id"
-      }
-    ].forEach(item => {
+        prop: "Service Principal Tenant Id",
+      },
+    ].forEach((item) => {
       expect(item.fn("")).toBe(`Must enter a ${item.prop}.`);
       expect(item.fn("b510c1ff-358c-4ed4-96c8-eb23f42bb65b")).toBe(true);
       expect(item.fn(".eb23f42bb65b")).toBe(
@@ -295,7 +295,7 @@ describe("test validateStoragePartitionKey test", () => {
     expect(validateStoragePartitionKey("")).toBe(
       "Must enter a storage partition key."
     );
-    ["abc\\", "abc/", "abc?", "abc#"].forEach(s => {
+    ["abc\\", "abc/", "abc?", "abc#"].forEach((s) => {
       expect(validateStoragePartitionKey(s)).toBe(
         "The value for storage partition key is invalid. /, \\, # and ? characters are not allowed."
       );

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -182,9 +182,9 @@ export const validateProjectName = (value: string): string | boolean => {
     "+",
     "=",
     "[",
-    "]"
+    "]",
   ];
-  if (invalidChars.some(x => value.indexOf(x) !== -1)) {
+  if (invalidChars.some((x) => value.indexOf(x) !== -1)) {
     return `Project name can't contain special characters, such as / : \\ ~ & % ; @ ' " ? < > | # $ * } { , + = [ ]`;
   }
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -8,12 +8,12 @@ export const logger = createLogger({
   transports: [
     new transports.File({
       filename: "spk.log",
-      format: format.simple()
+      format: format.simple(),
     }),
     new transports.Console({
-      format: format.cli()
-    })
-  ]
+      format: format.cli(),
+    }),
+  ],
 });
 
 export const enableVerboseLogging = (): void => {

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -6,14 +6,14 @@ import {
   sanitizeTriggerPath,
   IMAGE_REPO,
   IMAGE_TAG,
-  SAFE_SOURCE_BRANCH
+  SAFE_SOURCE_BRANCH,
 } from "../lib/fileutils";
 import {
   AzurePipelinesYaml,
   BedrockFile,
   ComponentYaml,
   HelmConfig,
-  MaintainersFile
+  MaintainersFile,
 } from "../types";
 
 export const createTestServiceBuildAndUpdatePipelineYaml = (
@@ -32,9 +32,9 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
   const data: AzurePipelinesYaml = {
     trigger: {
       branches: { include: ringBranches },
-      paths: { include: [sanitizeTriggerPath(relativeServicePathFormatted)] } // Only building for a single service's path.
+      paths: { include: [sanitizeTriggerPath(relativeServicePathFormatted)] }, // Only building for a single service's path.
     },
-    variables: [...(variableGroups ?? []).map(group => ({ group }))],
+    variables: [...(variableGroups ?? []).map((group) => ({ group }))],
     stages: [
       {
         // Build stage
@@ -43,32 +43,32 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
           {
             job: "run_build_push_acr",
             pool: {
-              vmImage: VM_IMAGE
+              vmImage: VM_IMAGE,
             },
             steps: [
               {
                 task: "HelmInstaller@1",
                 inputs: {
-                  helmVersionToInstall: HELM_VERSION
-                }
+                  helmVersionToInstall: HELM_VERSION,
+                },
               },
               {
                 script: generateYamlScript([
                   `echo "az login --service-principal --username $(SP_APP_ID) --password $(SP_PASS) --tenant $(SP_TENANT)"`,
-                  `az login --service-principal --username "$(SP_APP_ID)" --password "$(SP_PASS)" --tenant "$(SP_TENANT)"`
+                  `az login --service-principal --username "$(SP_APP_ID)" --password "$(SP_PASS)" --tenant "$(SP_TENANT)"`,
                 ]),
-                displayName: "Azure Login"
+                displayName: "Azure Login",
               },
               {
                 script: generateYamlScript([
                   `# Download build.sh`,
                   `curl $BEDROCK_BUILD_SCRIPT > build.sh`,
-                  `chmod +x ./build.sh`
+                  `chmod +x ./build.sh`,
                 ]),
                 displayName: "Download bedrock bash scripts",
                 env: {
-                  BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)"
-                }
+                  BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)",
+                },
               },
               {
                 script: generateYamlScript([
@@ -83,12 +83,12 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
                   `. ./build.sh --source-only`,
                   `get_spk_version`,
                   `download_spk`,
-                  `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p1 $(Build.BuildId) --image-tag $tag_name --commit-id $commitId --service $service --repository $repourl`
+                  `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p1 $(Build.BuildId) --image-tag $tag_name --commit-id $commitId --service $service --repository $repourl`,
                 ]),
                 displayName:
                   "If configured, update Spektate storage with build pipeline",
                 condition:
-                  "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))"
+                  "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))",
               },
               {
                 script: generateYamlScript([
@@ -98,13 +98,13 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
                   `echo "Image Name: $IMAGE_NAME"`,
                   `cd ${relativeServiceForDockerfile}`,
                   `echo "az acr build -r $(ACR_NAME) --image $IMAGE_NAME ."`,
-                  `az acr build -r $(ACR_NAME) --image $IMAGE_NAME .`
+                  `az acr build -r $(ACR_NAME) --image $IMAGE_NAME .`,
                 ]),
-                displayName: "ACR Build and Publish"
-              }
-            ]
-          }
-        ]
+                displayName: "ACR Build and Publish",
+              },
+            ],
+          },
+        ],
       },
       {
         // Update HLD Stage
@@ -115,25 +115,25 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
           {
             job: "update_image_tag",
             pool: {
-              vmImage: VM_IMAGE
+              vmImage: VM_IMAGE,
             },
             steps: [
               {
                 task: "HelmInstaller@1",
                 inputs: {
-                  helmVersionToInstall: HELM_VERSION
-                }
+                  helmVersionToInstall: HELM_VERSION,
+                },
               },
               {
                 script: generateYamlScript([
                   `# Download build.sh`,
                   `curl $BEDROCK_BUILD_SCRIPT > build.sh`,
-                  `chmod +x ./build.sh`
+                  `chmod +x ./build.sh`,
                 ]),
                 displayName: "Download bedrock bash scripts",
                 env: {
-                  BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)"
-                }
+                  BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)",
+                },
               },
               {
                 script: generateYamlScript([
@@ -199,21 +199,21 @@ export const createTestServiceBuildAndUpdatePipelineYaml = (
                   `get_spk_version`,
                   `download_spk`,
                   `./spk/spk deployment create  -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p2 $(Build.BuildId) --hld-commit-id $latest_commit --env $BRANCH_NAME --image-tag $tag_name --pr $pr_id --repository $repourl`,
-                  `fi`
+                  `fi`,
                 ]),
                 displayName:
                   "Download Fabrikate, Update HLD, Push changes, Open PR, and if configured, push to Spektate storage",
                 env: {
                   ACCESS_TOKEN_SECRET: "$(PAT)",
                   AZURE_DEVOPS_EXT_PAT: "$(PAT)",
-                  REPO: "$(HLD_REPO)"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ]
+                  REPO: "$(HLD_REPO)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
   };
 
   return asString
@@ -230,19 +230,19 @@ export const createTestMaintainersYaml = (
         maintainers: [
           {
             email: "somegithubemailg@users.noreply.github.com",
-            name: "my name"
-          }
-        ]
+            name: "my name",
+          },
+        ],
       },
       "./packages/service1": {
         maintainers: [
           {
             email: "hello@users.noreply.github.com",
-            name: "testUser"
-          }
-        ]
-      }
-    }
+            name: "testUser",
+          },
+        ],
+      },
+    },
   };
 
   return asString ? yaml.dump(data) : data;
@@ -255,50 +255,50 @@ export const createTestBedrockYaml = (
     chart: {
       branch: "master",
       git: "https://github.com/catalystcode/spk-demo-repo.git",
-      path: ""
-    }
+      path: "",
+    },
   };
 
   const service2HelmConfig: HelmConfig = {
     chart: {
       branch: "master",
       git: "https://github.com/catalystcode/spk-demo-repo.git",
-      path: "/service1"
-    }
+      path: "/service1",
+    },
   };
 
   const zookeeperHelmConfig: HelmConfig = {
     chart: {
       chart: "zookeeper",
-      repository: "https://kubernetes-charts-incubator.storage.googleapis.com/"
-    }
+      repository: "https://kubernetes-charts-incubator.storage.googleapis.com/",
+    },
   };
 
   const data: BedrockFile = {
     rings: {
       develop: {},
       master: {
-        isDefault: true
+        isDefault: true,
       },
       qa: {},
-      testing: {}
+      testing: {},
     },
     services: {
       "./": {
         helm: service1HelmConfig,
-        k8sBackendPort: 80
+        k8sBackendPort: 80,
       },
       "./packages/service1": {
         helm: service2HelmConfig,
-        k8sBackendPort: 80
+        k8sBackendPort: 80,
       },
       "./zookeeper": {
         helm: zookeeperHelmConfig,
-        k8sBackendPort: 80
-      }
+        k8sBackendPort: 80,
+      },
     },
     variableGroups: [],
-    version: "1.0"
+    version: "1.0",
   };
 
   return asString ? yaml.dump(data) : data;
@@ -310,30 +310,30 @@ export const createTestHldLifecyclePipelineYaml = (
   const data: AzurePipelinesYaml = {
     trigger: {
       branches: {
-        include: ["master"]
-      }
+        include: ["master"],
+      },
     },
     variables: [],
     pool: {
-      vmImage: VM_IMAGE
+      vmImage: VM_IMAGE,
     },
     steps: [
       {
         task: "HelmInstaller@1",
         inputs: {
-          helmVersionToInstall: HELM_VERSION
-        }
+          helmVersionToInstall: HELM_VERSION,
+        },
       },
       {
         script: generateYamlScript([
           `# Download build.sh`,
           `curl $BEDROCK_BUILD_SCRIPT > build.sh`,
-          `chmod +x ./build.sh`
+          `chmod +x ./build.sh`,
         ]),
         displayName: "Download bedrock bash scripts",
         env: {
-          BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)"
-        }
+          BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)",
+        },
       },
       {
         script: generateYamlScript([
@@ -385,7 +385,7 @@ export const createTestHldLifecyclePipelineYaml = (
 
           ``,
           `echo 'az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"'`,
-          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"`
+          `az repos pr create --description "Reconciling HLD with $(Build.Repository.Name)-$(Build.BuildNumber)." "PR created by: $(Build.DefinitionName) with buildId: $(Build.BuildId) and buildNumber: $(Build.BuildNumber)"`,
         ]),
         displayName:
           "Download Fabrikate and SPK, Update HLD, Push changes, Open PR",
@@ -393,10 +393,10 @@ export const createTestHldLifecyclePipelineYaml = (
           ACCESS_TOKEN_SECRET: "$(PAT)",
           APP_REPO_URL: "$(Build.Repository.Uri)",
           AZURE_DEVOPS_EXT_PAT: "$(PAT)",
-          REPO: "$(HLD_REPO)"
-        }
-      }
-    ]
+          REPO: "$(HLD_REPO)",
+        },
+      },
+    ],
   };
 
   return asString
@@ -410,34 +410,34 @@ export const createTestHldAzurePipelinesYaml = (
   const data: AzurePipelinesYaml = {
     trigger: {
       branches: {
-        include: ["master"]
-      }
+        include: ["master"],
+      },
     },
     pool: {
-      vmImage: VM_IMAGE
+      vmImage: VM_IMAGE,
     },
     steps: [
       {
         checkout: "self",
         persistCredentials: true,
-        clean: true
+        clean: true,
       },
       {
         task: "HelmInstaller@1",
         inputs: {
-          helmVersionToInstall: HELM_VERSION
-        }
+          helmVersionToInstall: HELM_VERSION,
+        },
       },
       {
         script: generateYamlScript([
           `# Download build.sh`,
           `curl $BEDROCK_BUILD_SCRIPT > build.sh`,
-          `chmod +x ./build.sh`
+          `chmod +x ./build.sh`,
         ]),
         displayName: "Download bedrock bash scripts",
         env: {
-          BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)"
-        }
+          BEDROCK_BUILD_SCRIPT: "$(BUILD_SCRIPT_URL)",
+        },
       },
       {
         script: generateYamlScript([
@@ -452,38 +452,38 @@ export const createTestHldAzurePipelinesYaml = (
           `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p3 $(Build.BuildId) --hld-commit-id $commitId --pr $pr_id`,
           `else`,
           `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p3 $(Build.BuildId) --hld-commit-id $commitId`,
-          `fi`
+          `fi`,
         ]),
         displayName:
           "If configured, update manifest pipeline details in Spektate db before manifest generation",
         condition:
-          "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))"
+          "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))",
       },
       {
         task: "ShellScript@2",
         displayName: "Validate fabrikate definitions",
         inputs: {
-          scriptPath: "build.sh"
+          scriptPath: "build.sh",
         },
         condition: `eq(variables['Build.Reason'], 'PullRequest')`,
         env: {
-          VERIFY_ONLY: 1
-        }
+          VERIFY_ONLY: 1,
+        },
       },
       {
         task: "ShellScript@2",
         displayName:
           "Transform fabrikate definitions and publish to YAML manifests to repo",
         inputs: {
-          scriptPath: "build.sh"
+          scriptPath: "build.sh",
         },
         condition: `ne(variables['Build.Reason'], 'PullRequest')`,
         env: {
           ACCESS_TOKEN_SECRET: "$(PAT)",
           COMMIT_MESSAGE: "$(Build.SourceVersionMessage)",
           REPO: "$(MANIFEST_REPO)",
-          BRANCH_NAME: "$(Build.SourceBranchName)"
-        }
+          BRANCH_NAME: "$(Build.SourceBranchName)",
+        },
       },
       {
         script: generateYamlScript([
@@ -494,14 +494,14 @@ export const createTestHldAzurePipelinesYaml = (
           `repourl=\${url##*@}`,
           `get_spk_version`,
           `download_spk`,
-          `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p3 $(Build.BuildId) --manifest-commit-id $latest_commit --repository $repourl`
+          `./spk/spk deployment create -n $(INTROSPECTION_ACCOUNT_NAME) -k $(INTROSPECTION_ACCOUNT_KEY) -t $(INTROSPECTION_TABLE_NAME) -p $(INTROSPECTION_PARTITION_KEY) --p3 $(Build.BuildId) --manifest-commit-id $latest_commit --repository $repourl`,
         ]),
         displayName:
           "If configured, update manifest pipeline details in Spektate db after manifest generation",
         condition:
-          "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))"
-      }
-    ]
+          "and(ne(variables['INTROSPECTION_ACCOUNT_NAME'], ''), ne(variables['INTROSPECTION_ACCOUNT_KEY'], ''),ne(variables['INTROSPECTION_TABLE_NAME'], ''),ne(variables['INTROSPECTION_PARTITION_KEY'], ''))",
+      },
+    ],
   };
 
   return asString
@@ -519,9 +519,9 @@ export const createTestComponentYaml = (
         name: "traefik2",
         method: "git",
         source: "https://github.com/microsoft/fabrikate-definitions.git",
-        path: "definitions/traefik2"
-      }
-    ]
+        path: "definitions/traefik2",
+      },
+    ],
   };
 
   return asString ? yaml.dump(component) : component;

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,12 +234,44 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.7.5":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
+  integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helpers" "^7.9.0"
+    "@babel/parser" "^7.9.0"
+    "@babel/template" "^7.8.6"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.8.6", "@babel/generator@^7.8.7":
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.8.tgz#cdcd58caab730834cee9eeadb729e833b625da3e"
   integrity sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==
   dependencies:
     "@babel/types" "^7.8.7"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.3.tgz#7c8b2956c6f68b3ab732bd16305916fbba521d94"
+  integrity sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==
+  dependencies:
+    "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -260,10 +292,62 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
+  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-imports@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
+  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-transforms@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
+  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-simple-access" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/template" "^7.8.6"
+    "@babel/types" "^7.9.0"
+    lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
+  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
+"@babel/helper-replace-supers@^7.8.6":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
+  integrity sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/traverse" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
+"@babel/helper-simple-access@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
+  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
@@ -271,6 +355,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
 
 "@babel/helpers@^7.8.4":
   version "7.8.4"
@@ -280,6 +369,15 @@
     "@babel/template" "^7.8.3"
     "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
+
+"@babel/helpers@^7.9.0":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
+  integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.9.0"
+    "@babel/types" "^7.9.0"
 
 "@babel/highlight@^7.8.3":
   version "7.8.3"
@@ -295,6 +393,18 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.8.tgz#4c3b7ce36db37e0629be1f0d50a571d2f86f6cd4"
   integrity sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==
 
+"@babel/parser@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.3.tgz#043a5fc2ad8b7ea9facddc4e802a1f0f25da7255"
+  integrity sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==
+
+"@babel/plugin-syntax-bigint@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
@@ -309,7 +419,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+"@babel/template@^7.4.0", "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
   integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
@@ -333,6 +443,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.7.tgz#1fc9729e1acbb2337d5b6977a63979b4819f5d1d"
@@ -342,6 +467,20 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -350,7 +489,22 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@jest/console@^24.7.1", "@jest/console@^24.9.0":
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
+  integrity sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
+  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
   integrity sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
@@ -359,93 +513,119 @@
     chalk "^2.0.1"
     slash "^2.0.0"
 
-"@jest/core@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.9.0.tgz#2ceccd0b93181f9c4850e74f2a9ad43d351369c4"
-  integrity sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
+"@jest/console@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-25.1.0.tgz#1fc765d44a1e11aec5029c08e798246bd37075ab"
+  integrity sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/reporters" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
+    "@jest/source-map" "^25.1.0"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    slash "^3.0.0"
+
+"@jest/core@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.1.0.tgz#3d4634fc3348bb2d7532915d67781cdac0869e47"
+  integrity sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==
+  dependencies:
+    "@jest/console" "^25.1.0"
+    "@jest/reporters" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-changed-files "^24.9.0"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-resolve-dependencies "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    jest-watcher "^24.9.0"
-    micromatch "^3.1.10"
-    p-each-series "^1.0.0"
+    graceful-fs "^4.2.3"
+    jest-changed-files "^25.1.0"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-resolve-dependencies "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    jest-watcher "^25.1.0"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
     realpath-native "^1.1.0"
-    rimraf "^2.5.4"
-    slash "^2.0.0"
-    strip-ansi "^5.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
 
-"@jest/environment@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.9.0.tgz#21e3afa2d65c0586cbd6cbefe208bafade44ab18"
-  integrity sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
+"@jest/environment@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.1.0.tgz#4a97f64770c9d075f5d2b662b5169207f0a3f787"
+  integrity sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==
   dependencies:
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
 
-"@jest/fake-timers@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.9.0.tgz#ba3e6bf0eecd09a636049896434d306636540c93"
-  integrity sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
+"@jest/fake-timers@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.1.0.tgz#a1e0eff51ffdbb13ee81f35b52e0c1c11a350ce8"
+  integrity sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==
   dependencies:
-    "@jest/types" "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
+    "@jest/types" "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    lolex "^5.0.0"
 
-"@jest/reporters@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.9.0.tgz#86660eff8e2b9661d042a8e98a028b8d631a5b43"
-  integrity sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
+"@jest/reporters@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-25.1.0.tgz#9178ecf136c48f125674ac328f82ddea46e482b0"
+  integrity sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
     glob "^7.1.2"
-    istanbul-lib-coverage "^2.0.2"
-    istanbul-lib-instrument "^3.0.1"
-    istanbul-lib-report "^2.0.4"
-    istanbul-lib-source-maps "^3.0.1"
-    istanbul-reports "^2.2.6"
-    jest-haste-map "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
-    node-notifier "^5.4.2"
-    slash "^2.0.0"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    jest-haste-map "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    slash "^3.0.0"
     source-map "^0.6.0"
-    string-length "^2.0.0"
+    string-length "^3.1.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^4.0.1"
+  optionalDependencies:
+    node-notifier "^6.0.0"
 
-"@jest/source-map@^24.3.0", "@jest/source-map@^24.9.0":
+"@jest/source-map@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
   integrity sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
   dependencies:
     callsites "^3.0.0"
     graceful-fs "^4.1.15"
+    source-map "^0.6.0"
+
+"@jest/source-map@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-25.1.0.tgz#b012e6c469ccdbc379413f5c1b1ffb7ba7034fb0"
+  integrity sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.3"
     source-map "^0.6.0"
 
 "@jest/test-result@^24.9.0":
@@ -457,37 +637,48 @@
     "@jest/types" "^24.9.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
 
-"@jest/test-sequencer@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz#f8f334f35b625a4f2f355f2fe7e6036dad2e6b31"
-  integrity sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
+"@jest/test-result@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.1.0.tgz#847af2972c1df9822a8200457e64be4ff62821f7"
+  integrity sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==
   dependencies:
-    "@jest/test-result" "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
+    "@jest/console" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
 
-"@jest/transform@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.9.0.tgz#4ae2768b296553fadab09e9ec119543c90b16c56"
-  integrity sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
+"@jest/test-sequencer@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz#4df47208542f0065f356fcdb80026e3c042851ab"
+  integrity sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==
+  dependencies:
+    "@jest/test-result" "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-runner "^25.1.0"
+    jest-runtime "^25.1.0"
+
+"@jest/transform@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-25.1.0.tgz#221f354f512b4628d88ce776d5b9e601028ea9da"
+  integrity sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^24.9.0"
-    babel-plugin-istanbul "^5.1.0"
-    chalk "^2.0.1"
+    "@jest/types" "^25.1.0"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^3.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.15"
-    jest-haste-map "^24.9.0"
-    jest-regex-util "^24.9.0"
-    jest-util "^24.9.0"
-    micromatch "^3.1.10"
+    graceful-fs "^4.2.3"
+    jest-haste-map "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-util "^25.1.0"
+    micromatch "^4.0.2"
     pirates "^4.0.1"
     realpath-native "^1.1.0"
-    slash "^2.0.0"
+    slash "^3.0.0"
     source-map "^0.6.1"
-    write-file-atomic "2.4.1"
+    write-file-atomic "^3.0.0"
 
 "@jest/types@^24.9.0":
   version "24.9.0"
@@ -545,6 +736,13 @@
   integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
   dependencies:
     any-observable "^0.3.0"
+
+"@sinonjs/commons@^1.7.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
+  integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
+  dependencies:
+    type-detect "4.0.8"
 
 "@types/babel__core@^7.1.0":
   version "7.1.6"
@@ -645,7 +843,7 @@
   resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz#c1c0d402daac324582b6186b91f8905340ea3361"
   integrity sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
   integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
@@ -807,40 +1005,40 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz#aa7133bfb7b685379d9eafe4ae9e08b9037e129d"
-  integrity sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==
+"@typescript-eslint/eslint-plugin@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
+  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.23.0"
+    "@typescript-eslint/experimental-utils" "2.24.0"
     eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz#5d2261c8038ec1698ca4435a8da479c661dc9242"
-  integrity sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==
+"@typescript-eslint/experimental-utils@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
+  integrity sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.23.0.tgz#f3d4e2928ff647fe77fc2fcef1a3534fee6a3212"
-  integrity sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==
+"@typescript-eslint/parser@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.24.0.tgz#2cf0eae6e6dd44d162486ad949c126b887f11eb8"
+  integrity sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.23.0"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/experimental-utils" "2.24.0"
+    "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz#d355960fab96bd550855488dcc34b9a4acac8d36"
-  integrity sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==
+"@typescript-eslint/typescript-estree@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
+  integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -1018,7 +1216,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-acorn-globals@^4.1.0:
+acorn-globals@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
   integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
@@ -1036,17 +1234,12 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn@^5.5.3:
-  version "5.7.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
-  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
-
 acorn@^6.0.1, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -1151,6 +1344,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
@@ -1254,11 +1455,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
 async@>=0.6.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
@@ -1324,43 +1520,45 @@ azure-storage@^2.10.3:
     xml2js "0.2.8"
     xmlbuilder "^9.0.7"
 
-babel-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
-  integrity sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
+babel-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.1.0.tgz#206093ac380a4b78c4404a05b3277391278f80fb"
+  integrity sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==
   dependencies:
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
     "@types/babel__core" "^7.1.0"
-    babel-plugin-istanbul "^5.1.0"
-    babel-preset-jest "^24.9.0"
-    chalk "^2.4.2"
-    slash "^2.0.0"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^25.1.0"
+    chalk "^3.0.0"
+    slash "^3.0.0"
 
-babel-plugin-istanbul@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
-  integrity sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==
+babel-plugin-istanbul@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    find-up "^3.0.0"
-    istanbul-lib-instrument "^3.3.0"
-    test-exclude "^5.2.3"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^4.0.0"
+    test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz#4f837091eb407e01447c8843cbec546d0002d756"
-  integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
+babel-plugin-jest-hoist@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.1.0.tgz#fb62d7b3b53eb36c97d1bc7fec2072f9bd115981"
+  integrity sha512-oIsopO41vW4YFZ9yNYoLQATnnN46lp+MZ6H4VvPKFkcc2/fkl3CfE/NZZSmnEIEsJRmJAgkVEK0R7Zbl50CpTw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-preset-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
-  integrity sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
+babel-preset-jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz#d0aebfebb2177a21cde710996fce8486d34f1d33"
+  integrity sha512-eCGn64olaqwUMaugXsTtGAM2I0QTahjEtnRu0ql8Ie+gDWAc1N6wqN0k2NilnyTunM69Pad7gJY7LOtwLimoFQ==
   dependencies:
+    "@babel/plugin-syntax-bigint" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    babel-plugin-jest-hoist "^24.9.0"
+    babel-plugin-jest-hoist "^25.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1640,11 +1838,6 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1792,6 +1985,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1801,6 +2003,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collect-v8-coverage@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz#150ee634ac3650b71d9c985eb7f608942334feb1"
+  integrity sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2069,17 +2276,22 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+cssom@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@~0.3.6:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
-cssstyle@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.4.0.tgz#9d31328229d3c565c61e586b02041a28fccdccf1"
-  integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
+cssstyle@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
+  integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
   dependencies:
-    cssom "0.3.x"
+    cssom "~0.3.6"
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -2093,7 +2305,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-urls@^1.0.0:
+data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
   integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
@@ -2207,10 +2419,10 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-newline@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 diagnostics@^1.1.1:
   version "1.1.1"
@@ -2445,7 +2657,7 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.13.0, escodegen@^1.9.1:
+escodegen@^1.11.1, escodegen@^1.13.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
   integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
@@ -2456,6 +2668,13 @@ escodegen@^1.13.0, escodegen@^1.9.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-config-prettier@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
+  integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
+  dependencies:
+    get-stdin "^6.0.0"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -2602,7 +2821,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^3.4.0:
+execa@^3.2.0, execa@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
   integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
@@ -2648,7 +2867,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@^24.8.0, expect@^24.9.0:
+expect@^24.8.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
   integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
@@ -2659,6 +2878,18 @@ expect@^24.8.0, expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+expect@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.1.0.tgz#7e8d7b06a53f7d66ec927278db3304254ee683ee"
+  integrity sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-regex-util "^25.1.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -2841,7 +3072,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -2987,6 +3218,11 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
+fsevents@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
+  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -3011,6 +3247,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -3156,7 +3397,7 @@ globby@^11.0.0:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -3365,13 +3606,21 @@ import-fresh@^3.0.0, import-fresh@^3.1.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-local@2.0.0, import-local@^2.0.0:
+import-local@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
   integrity sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==
   dependencies:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
+
+import-local@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3447,13 +3696,6 @@ into-stream@^5.1.1:
   dependencies:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
-
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -3675,7 +3917,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -3689,6 +3931,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3725,10 +3972,15 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
+istanbul-lib-coverage@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
   integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
+
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
 istanbul-lib-hook@^2.0.7:
   version "2.0.7"
@@ -3737,7 +3989,7 @@ istanbul-lib-hook@^2.0.7:
   dependencies:
     append-transform "^1.0.0"
 
-istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
+istanbul-lib-instrument@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
   integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
@@ -3750,7 +4002,20 @@ istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
     istanbul-lib-coverage "^2.0.5"
     semver "^6.0.0"
 
-istanbul-lib-report@^2.0.4, istanbul-lib-report@^2.0.8:
+istanbul-lib-instrument@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz#61f13ac2c96cfefb076fe7131156cc05907874e6"
+  integrity sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/parser" "^7.7.5"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
+
+istanbul-lib-report@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
   integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
@@ -3759,7 +4024,16 @@ istanbul-lib-report@^2.0.4, istanbul-lib-report@^2.0.8:
     make-dir "^2.1.0"
     supports-color "^6.1.0"
 
-istanbul-lib-source-maps@^3.0.1, istanbul-lib-source-maps@^3.0.6:
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
   integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
@@ -3770,62 +4044,79 @@ istanbul-lib-source-maps@^3.0.1, istanbul-lib-source-maps@^3.0.6:
     rimraf "^2.6.3"
     source-map "^0.6.1"
 
-istanbul-reports@^2.2.4, istanbul-reports@^2.2.6:
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
+  integrity sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^2.2.4:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
   integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
     html-escaper "^2.0.0"
 
-jest-changed-files@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
-  integrity sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
+istanbul-reports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.0.tgz#d4d16d035db99581b6194e119bbf36c963c5eb70"
+  integrity sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==
   dependencies:
-    "@jest/types" "^24.9.0"
-    execa "^1.0.0"
-    throat "^4.0.0"
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
-jest-cli@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"
-  integrity sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
+jest-changed-files@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-25.1.0.tgz#73dae9a7d9949fdfa5c278438ce8f2ff3ec78131"
+  integrity sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==
   dependencies:
-    "@jest/core" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/types" "^25.1.0"
+    execa "^3.2.0"
+    throat "^5.0.0"
+
+jest-cli@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.1.0.tgz#75f0b09cf6c4f39360906bf78d580be1048e4372"
+  integrity sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==
+  dependencies:
+    "@jest/core" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    import-local "^2.0.0"
+    import-local "^3.0.2"
     is-ci "^2.0.0"
-    jest-config "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
+    jest-config "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
     prompts "^2.0.1"
     realpath-native "^1.1.0"
-    yargs "^13.3.0"
+    yargs "^15.0.0"
 
-jest-config@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.9.0.tgz#fb1bbc60c73a46af03590719efa4825e6e4dd1b5"
-  integrity sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
+jest-config@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.1.0.tgz#d114e4778c045d3ef239452213b7ad3ec1cbea90"
+  integrity sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    babel-jest "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/test-sequencer" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    babel-jest "^25.1.0"
+    chalk "^3.0.0"
     glob "^7.1.1"
-    jest-environment-jsdom "^24.9.0"
-    jest-environment-node "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    micromatch "^3.1.10"
-    pretty-format "^24.9.0"
+    jest-environment-jsdom "^25.1.0"
+    jest-environment-node "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
+    micromatch "^4.0.2"
+    pretty-format "^25.1.0"
     realpath-native "^1.1.0"
 
 jest-diff@^24.3.0, jest-diff@^24.9.0:
@@ -3848,46 +4139,46 @@ jest-diff@^25.1.0:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
 
-jest-docblock@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
-  integrity sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==
+jest-docblock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.1.0.tgz#0f44bea3d6ca6dfc38373d465b347c8818eccb64"
+  integrity sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==
   dependencies:
-    detect-newline "^2.1.0"
+    detect-newline "^3.0.0"
 
-jest-each@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
-  integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
+jest-each@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-25.1.0.tgz#a6b260992bdf451c2d64a0ccbb3ac25e9b44c26a"
+  integrity sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==
   dependencies:
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    jest-get-type "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
 
-jest-environment-jsdom@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"
-  integrity sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
+jest-environment-jsdom@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz#6777ab8b3e90fd076801efd3bff8e98694ab43c3"
+  integrity sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
-    jsdom "^11.5.1"
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    jsdom "^15.1.1"
 
-jest-environment-node@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
-  integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
+jest-environment-node@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.1.0.tgz#797bd89b378cf0bd794dc8e3dca6ef21126776db"
+  integrity sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==
   dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/fake-timers" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
 
 jest-get-type@^24.9.0:
   version "24.9.0"
@@ -3899,51 +4190,51 @@ jest-get-type@^25.1.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
   integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
 
-jest-haste-map@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
-  integrity sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
+jest-haste-map@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-25.1.0.tgz#ae12163d284f19906260aa51fd405b5b2e5a4ad3"
+  integrity sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==
   dependencies:
-    "@jest/types" "^24.9.0"
-    anymatch "^2.0.0"
+    "@jest/types" "^25.1.0"
+    anymatch "^3.0.3"
     fb-watchman "^2.0.0"
-    graceful-fs "^4.1.15"
-    invariant "^2.2.4"
-    jest-serializer "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.9.0"
-    micromatch "^3.1.10"
+    graceful-fs "^4.2.3"
+    jest-serializer "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
+    micromatch "^4.0.2"
     sane "^4.0.3"
     walker "^1.0.7"
   optionalDependencies:
-    fsevents "^1.2.7"
+    fsevents "^2.1.2"
 
-jest-jasmine2@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz#1f7b1bd3242c1774e62acabb3646d96afc3be6a0"
-  integrity sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
+jest-jasmine2@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz#681b59158a430f08d5d0c1cce4f01353e4b48137"
+  integrity sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==
   dependencies:
     "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     co "^4.6.0"
-    expect "^24.9.0"
+    expect "^25.1.0"
     is-generator-fn "^2.0.0"
-    jest-each "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
-    throat "^4.0.0"
+    jest-each "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
+    throat "^5.0.0"
 
-jest-junit@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-9.0.0.tgz#9eb247dda7a8d2e1647a92f58a03a1490c74aea5"
-  integrity sha512-jnABGjL5pd2lhE1w3RIslZSufFbWQZGx8O3eluDES7qKxQuonXMtsPIi+4AKl4rtjb4DvMAjwLi4eHukc2FP/Q==
+jest-junit@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-10.0.0.tgz#c94b91c24920a327c9d2a075e897b2dba4af494b"
+  integrity sha512-dbOVRyxHprdSpwSAR9/YshLwmnwf+RSl5hf0kCGlhAcEeZY9aRqo4oNmaT0tLC16Zy9D0zekDjWkjHGjXlglaQ==
   dependencies:
     jest-validate "^24.9.0"
     mkdirp "^0.5.1"
@@ -3951,13 +4242,13 @@ jest-junit@^9.0.0:
     uuid "^3.3.3"
     xml "^1.0.1"
 
-jest-leak-detector@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
-  integrity sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
+jest-leak-detector@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz#ed6872d15aa1c72c0732d01bd073dacc7c38b5c6"
+  integrity sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==
   dependencies:
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
 jest-matcher-utils@^24.9.0:
   version "24.9.0"
@@ -3968,6 +4259,16 @@ jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
+  integrity sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -3983,138 +4284,151 @@ jest-message-util@^24.9.0:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
-  integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
+jest-message-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.1.0.tgz#702a9a5cb05c144b9aa73f06e17faa219389845e"
+  integrity sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==
   dependencies:
-    "@jest/types" "^24.9.0"
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.1.0.tgz#411d549e1b326b7350b2e97303a64715c28615fd"
+  integrity sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==
+  dependencies:
+    "@jest/types" "^25.1.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
-jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
+jest-regex-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
   integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
 
-jest-resolve-dependencies@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz#ad055198959c4cfba8a4f066c673a3f0786507ab"
-  integrity sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-snapshot "^24.9.0"
+jest-regex-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.1.0.tgz#efaf75914267741838e01de24da07b2192d16d87"
+  integrity sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==
 
-jest-resolve@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.9.0.tgz#dff04c7687af34c4dd7e524892d9cf77e5d17321"
-  integrity sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
+jest-resolve-dependencies@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz#8a1789ec64eb6aaa77fd579a1066a783437e70d2"
+  integrity sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==
   dependencies:
-    "@jest/types" "^24.9.0"
+    "@jest/types" "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-snapshot "^25.1.0"
+
+jest-resolve@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.1.0.tgz#23d8b6a4892362baf2662877c66aa241fa2eaea3"
+  integrity sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
     browser-resolve "^1.11.3"
-    chalk "^2.0.1"
+    chalk "^3.0.0"
     jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
 
-jest-runner@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.9.0.tgz#574fafdbd54455c2b34b4bdf4365a23857fcdf42"
-  integrity sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
+jest-runner@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.1.0.tgz#fef433a4d42c89ab0a6b6b268e4a4fbe6b26e812"
+  integrity sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.4.2"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-docblock "^24.3.0"
-    jest-haste-map "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-leak-detector "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-docblock "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-jasmine2 "^25.1.0"
+    jest-leak-detector "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-runtime "^25.1.0"
+    jest-util "^25.1.0"
+    jest-worker "^25.1.0"
     source-map-support "^0.5.6"
-    throat "^4.0.0"
+    throat "^5.0.0"
 
-jest-runtime@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.9.0.tgz#9f14583af6a4f7314a6a9d9f0226e1a781c8e4ac"
-  integrity sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
+jest-runtime@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.1.0.tgz#02683218f2f95aad0f2ec1c9cdb28c1dc0ec0314"
+  integrity sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==
   dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/source-map" "^24.3.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    chalk "^2.0.1"
+    "@jest/console" "^25.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/source-map" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/transform" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
     glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
+    graceful-fs "^4.2.3"
+    jest-config "^25.1.0"
+    jest-haste-map "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-regex-util "^25.1.0"
+    jest-resolve "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    jest-validate "^25.1.0"
     realpath-native "^1.1.0"
-    slash "^2.0.0"
-    strip-bom "^3.0.0"
-    yargs "^13.3.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.0.0"
 
-jest-serializer@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.9.0.tgz#e6d7d7ef96d31e8b9079a714754c5d5c58288e73"
-  integrity sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
+jest-serializer@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.1.0.tgz#73096ba90e07d19dec4a0c1dd89c355e2f129e5d"
+  integrity sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==
 
-jest-snapshot@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.9.0.tgz#ec8e9ca4f2ec0c5c87ae8f925cf97497b0e951ba"
-  integrity sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
+jest-snapshot@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.1.0.tgz#d5880bd4b31faea100454608e15f8d77b9d221d9"
+  integrity sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==
   dependencies:
     "@babel/types" "^7.0.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    expect "^24.9.0"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    expect "^25.1.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-resolve "^25.1.0"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^24.9.0"
-    semver "^6.2.0"
+    pretty-format "^25.1.0"
+    semver "^7.1.1"
 
-jest-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"
-  integrity sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==
+jest-util@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.1.0.tgz#7bc56f7b2abd534910e9fa252692f50624c897d9"
+  integrity sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==
   dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/source-map" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    callsites "^3.0.0"
-    chalk "^2.0.1"
-    graceful-fs "^4.1.15"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
     is-ci "^2.0.0"
     mkdirp "^0.5.1"
-    slash "^2.0.0"
-    source-map "^0.6.0"
 
 jest-validate@^24.9.0:
   version "24.9.0"
@@ -4128,18 +4442,29 @@ jest-validate@^24.9.0:
     leven "^3.1.0"
     pretty-format "^24.9.0"
 
-jest-watcher@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.9.0.tgz#4b56e5d1ceff005f5b88e528dc9afc8dd4ed2b3b"
-  integrity sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
+jest-validate@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.1.0.tgz#1469fa19f627bb0a9a98e289f3e9ab6a668c732a"
+  integrity sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==
   dependencies:
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    jest-util "^24.9.0"
-    string-length "^2.0.0"
+    "@jest/types" "^25.1.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    jest-get-type "^25.1.0"
+    leven "^3.1.0"
+    pretty-format "^25.1.0"
+
+jest-watcher@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.1.0.tgz#97cb4a937f676f64c9fad2d07b824c56808e9806"
+  integrity sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==
+  dependencies:
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    jest-util "^25.1.0"
+    string-length "^3.1.0"
 
 jest-when@^2.7.0:
   version "2.7.0"
@@ -4149,23 +4474,24 @@ jest-when@^2.7.0:
     bunyan "^1.8.12"
     expect "^24.8.0"
 
-jest-worker@^24.6.0, jest-worker@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
-  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
+jest-worker@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.1.0.tgz#75d038bad6fdf58eba0d2ec1835856c497e3907a"
+  integrity sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==
   dependencies:
     merge-stream "^2.0.0"
-    supports-color "^6.1.0"
+    supports-color "^7.0.0"
 
-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
-  integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
+jest@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.1.0.tgz#b85ef1ddba2fdb00d295deebbd13567106d35be9"
+  integrity sha512-FV6jEruneBhokkt9MQk0WUFoNTwnF76CLXtwNMfsc0um0TlB/LG2yxUd0KqaFjEJ9laQmVWQWS0sG/t2GsuI0w==
   dependencies:
-    import-local "^2.0.0"
-    jest-cli "^24.9.0"
+    "@jest/core" "^25.1.0"
+    import-local "^3.0.2"
+    jest-cli "^25.1.0"
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -4183,36 +4509,36 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^11.5.1:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
-  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
+jsdom@^15.1.1:
+  version "15.2.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
+  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
   dependencies:
     abab "^2.0.0"
-    acorn "^5.5.3"
-    acorn-globals "^4.1.0"
+    acorn "^7.1.0"
+    acorn-globals "^4.3.2"
     array-equal "^1.0.0"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle "^1.0.0"
-    data-urls "^1.0.0"
+    cssom "^0.4.1"
+    cssstyle "^2.0.0"
+    data-urls "^1.1.0"
     domexception "^1.0.1"
-    escodegen "^1.9.1"
+    escodegen "^1.11.1"
     html-encoding-sniffer "^1.0.2"
-    left-pad "^1.3.0"
-    nwsapi "^2.0.7"
-    parse5 "4.0.0"
+    nwsapi "^2.2.0"
+    parse5 "5.1.0"
     pn "^1.1.0"
-    request "^2.87.0"
-    request-promise-native "^1.0.5"
-    sax "^1.2.4"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
     symbol-tree "^3.2.2"
-    tough-cookie "^2.3.4"
+    tough-cookie "^3.0.1"
     w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
     webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
-    whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.1"
-    ws "^5.2.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -4265,6 +4591,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
+  integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -4348,11 +4681,6 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -4371,7 +4699,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@>=8:
+lint-staged@>=10:
   version "10.0.8"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.0.8.tgz#0f7849cdc336061f25f5d4fcbcfa385701ff4739"
   integrity sha512-Oa9eS4DJqvQMVdywXfEor6F4vP+21fPHF8LUXgBbVWUSWBddjqsvO6Bv1LwMChmgQZZqwUvgJSHlu8HFHAPZmA==
@@ -4541,12 +4869,12 @@ logform@^2.1.1:
     ms "^2.1.1"
     triple-beam "^1.3.0"
 
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
+    "@sinonjs/commons" "^1.7.0"
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -4570,6 +4898,13 @@ make-dir@^2.0.0, make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
+  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
+  dependencies:
+    semver "^6.0.0"
 
 make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
@@ -4750,7 +5085,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -4953,16 +5288,16 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^5.4.2:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.3.tgz#cb72daf94c93904098e28b9c590fd866e464bd50"
-  integrity sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==
+node-notifier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-6.0.0.tgz#cea319e06baa16deec8ce5cd7f133c4a46b68e12"
+  integrity sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
   dependencies:
     growly "^1.3.0"
-    is-wsl "^1.1.0"
-    semver "^5.5.0"
+    is-wsl "^2.1.1"
+    semver "^6.3.0"
     shellwords "^0.1.1"
-    which "^1.3.0"
+    which "^1.3.1"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -5010,7 +5345,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7:
+nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
@@ -5186,12 +5521,10 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
-p-each-series@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
-  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
-  dependencies:
-    p-reduce "^1.0.0"
+p-each-series@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
+  integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -5238,11 +5571,6 @@ p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
-
-p-reduce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
-  integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -5333,10 +5661,10 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
-parse5@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+parse5@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -5410,6 +5738,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.4:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.1"
@@ -5505,10 +5838,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -5808,7 +6141,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.5:
+request-promise-native@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
@@ -5817,7 +6150,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-"request@>= 2.52.0", request@^2.86.0, request@^2.87.0, request@^2.88.0:
+"request@>= 2.52.0", request@^2.86.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -5860,6 +6193,13 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -5877,6 +6217,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -5932,6 +6277,13 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -6028,10 +6380,17 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+saxes@^3.1.9:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
+  integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
+  dependencies:
+    xmlchars "^2.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -6065,10 +6424,15 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
+  integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
 serialize-javascript@^2.1.2:
   version "2.1.2"
@@ -6267,6 +6631,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 spawn-wrap@^1.4.2:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.3.tgz#81b7670e170cca247d80bf5faf0cfb713bdcf848"
@@ -6419,13 +6788,13 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-string-length@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
-  integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
   dependencies:
     astral-regex "^1.0.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.2.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -6453,7 +6822,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -6539,6 +6908,11 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -6573,12 +6947,20 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-hyperlinks@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
+  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -6604,6 +6986,14 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+
+terminal-link@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@^1.4.2, terser-webpack-plugin@^1.4.3:
   version "1.4.3"
@@ -6639,6 +7029,15 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
 text-hex@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
@@ -6649,10 +7048,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-throat@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
-  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+throat@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
+  integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
 throttleit@^1.0.0:
   version "1.0.0"
@@ -6733,7 +7132,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
+tough-cookie@^2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -6762,10 +7161,10 @@ triple-beam@^1.2.0, triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
-ts-jest@^24.2.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
-  integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
+ts-jest@^25.2.1:
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.1.tgz#49bf05da26a8b7fbfbc36b4ae2fcdc2fef35c85d"
+  integrity sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -6776,12 +7175,12 @@ ts-jest@^24.2.0:
     mkdirp "0.x"
     resolve "1.x"
     semver "^5.5"
-    yargs-parser "10.x"
+    yargs-parser "^16.1.0"
 
-ts-loader@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.1.tgz#67939d5772e8a8c6bdaf6277ca023a4812da02ef"
-  integrity sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==
+ts-loader@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.2.tgz#dffa3879b01a1a1e0a4b85e2b8421dc0dfff1c58"
+  integrity sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"
@@ -6789,10 +7188,10 @@ ts-loader@^6.2.1:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-node@^8.5.4:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+ts-node@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.1.tgz#7c4d3e9ed33aa703b64b28d7f9d194768be5064d"
+  integrity sha512-10DE9ONho06QORKAaCBpPiFCdW+tZJuY/84tyypGtl6r+/C7Asq0dhqbRZURuUlLQtZxxDvT8eoj8cGW0ha6Bg==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -6851,6 +7250,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
@@ -6869,12 +7273,19 @@ typed-rest-client@1.2.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4:
+typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
@@ -7023,6 +7434,15 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
+v8-to-istanbul@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz#387d173be5383dbec209d21af033dcb892e3ac82"
+  integrity sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -7056,6 +7476,15 @@ w3c-hr-time@^1.0.1:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+w3c-xmlserializer@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
+  integrity sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+  dependencies:
+    domexception "^1.0.1"
+    webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
@@ -7132,7 +7561,7 @@ webpack@^4.41.2:
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
@@ -7144,19 +7573,10 @@ whatwg-fetch@>=0.10.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
-whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
 
 whatwg-url@^7.0.0:
   version "7.1.0"
@@ -7243,19 +7663,19 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
-write-file-atomic@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
-  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
 
 write-file-atomic@^2.4.2:
   version "2.4.3"
@@ -7266,6 +7686,16 @@ write-file-atomic@^2.4.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 write@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
@@ -7273,12 +7703,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
-  dependencies:
-    async-limiter "~1.0.0"
+ws@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -7314,6 +7742,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlchars@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 "xmldom@>= 0.1.x":
   version "0.3.0"
@@ -7352,17 +7785,26 @@ yaml@^1.7.2:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-yargs-parser@10.x:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^13.0.0, yargs-parser@^13.1.0, yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -7384,7 +7826,7 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
-yargs@^13.2.2, yargs@^13.3.0:
+yargs@^13.2.2:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
@@ -7399,6 +7841,23 @@ yargs@^13.2.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^15.0.0:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Dev Tools Upgrades

- Changed azure pipeline build/tests to support Node 12 (LTS) and 13 (current)
  - Dropped Node 10
  - Added Node 13
- Added ESLint pre-commit hook
  - `eslint --fix` now runs for JS/TS files before being committed. If any
    staged files fail linting, commit will fail.
- Added `eslint-config-prettier`
  - Helps minimize conflicts between eslint and prettier configurations.
- Upgrade to TypeScript 3.8.
  - No breaking changes.
  - View changes here:
    <https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/>
- Upgrade to Jest 25
  - No breaking changes.
  - View changes here: <https://jestjs.io/blog/2020/01/21/jest-25>
- Upgrade to Prettier 2
  - No Breaking changes.
  - Default of `trailingComma`, `arrowParens`, and `endOfLine` have been
    changed. Prettier has been run on the codebase to adjust for these changes.
  - View changes here: <https://prettier.io/blog/2020/03/21/2.0.0.html>
