### PR TITLE
[BUG-FIX] added validation to create function

### DIFF
--- a/src/commands/project/create-variable-group.test.ts
+++ b/src/commands/project/create-variable-group.test.ts
@@ -147,7 +147,14 @@ describe("create", () => {
       personalAccessToken,
       project: devopsProject,
     };
-    await expect(create("", "", "", "", "", "", accessOpts)).rejects.toThrow();
+
+    // for some reasons, cannot get the await expect(...).rejects.toThrow() to work
+    try {
+      await create("", "", "", "", "", "", accessOpts);
+      expect(true).toBeFalsy();
+    } catch (e) {
+      expect(e.message).toBe("Required values were missing");
+    }
   });
 
   test("Should pass with variable group arguments", async () => {

--- a/src/commands/project/create-variable-group.ts
+++ b/src/commands/project/create-variable-group.ts
@@ -191,6 +191,16 @@ export const create = (
     `Creating Variable Group from group definition '${variableGroupName}'`
   );
 
+  if (
+    !registryName ||
+    !hldRepoUrl ||
+    !servicePrincipalId ||
+    !servicePrincipalPassword ||
+    !tenantId
+  ) {
+    throw Error("Required values were missing");
+  }
+
   const vars: VariableGroupDataVariable = {
     ACR_NAME: {
       value: registryName,


### PR DESCRIPTION

closes https://github.com/microsoft/bedrock/issues/1256

since validation is missing in the create function, this test triggers api calls to the azdo server which results in timeout.