### PR TITLE
Adding https:// to repoUrl in rings tests

### DIFF
--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -268,7 +268,7 @@ lifecycle_pipeline_name="$mono_repo_dir-lifecycle"
 pipeline_exists $AZDO_ORG_URL $AZDO_PROJECT $lifecycle_pipeline_name
 
 # Deploy lifecycle pipeline and verify it runs.
-spk project install-lifecycle-pipeline --org-name $AZDO_ORG --devops-project $AZDO_PROJECT --repo-url $repo_url --pipeline-name $lifecycle_pipeline_name --personal-access-token $ACCESS_TOKEN_SECRET  >> $TEST_WORKSPACE/log.txt
+spk project install-lifecycle-pipeline --org-name $AZDO_ORG --devops-project $AZDO_PROJECT --repo-url "https://$repo_url" --pipeline-name $lifecycle_pipeline_name --personal-access-token $ACCESS_TOKEN_SECRET  >> $TEST_WORKSPACE/log.txt
 
 # TODO: Verify the lifecycle pipeline sucessfully runs
 # Verify lifecycle pipeline was created


### PR DESCRIPTION
Fixing an issue caused by changes in https://github.com/CatalystCode/spk/pull/440 that caused `spk project install-lifecycle-pipeline` to fail when the --repo-url value does not have "https://" prepended to the url.

The error message was 
```
Error occurred installing pipeline for project hld lifecycle.
Could not determine origin repository, or it is not a supported type.
```

We should have better error messages. This is a great opportunity to implement more solutions like https://github.com/CatalystCode/spk/pull/446