### PR TITLE
Disable camelCase ESLint Rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,4 +12,7 @@ module.exports = {
     "prettier",
     "prettier/@typescript-eslint",
   ],
+  rules: {
+    "@typescript-eslint/camelcase": "off",
+  },
 };

--- a/src/commands/deployment/dashboard.test.ts
+++ b/src/commands/deployment/dashboard.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 jest.mock("open");
 import open from "open";
 jest.mock("../../config");

--- a/src/commands/deployment/onboard.test.ts
+++ b/src/commands/deployment/onboard.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import fs from "fs";
 import yaml from "js-yaml";
 import * as path from "path";

--- a/src/commands/deployment/onboard.ts
+++ b/src/commands/deployment/onboard.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { StorageAccount } from "@azure/arm-storage/esm/models";
 import commander from "commander";
 import fs from "fs";

--- a/src/commands/deployment/validate.test.ts
+++ b/src/commands/deployment/validate.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import uuid from "uuid/v4";
 import * as deploymenttable from "../../lib/azure/deploymenttable";
 import {

--- a/src/commands/hld/pipeline.test.ts
+++ b/src/commands/hld/pipeline.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import * as config from "../../config";
 import * as azdo from "../../lib/azdoClient";
 import { BUILD_SCRIPT_URL } from "../../lib/constants";

--- a/src/commands/hld/pipeline.ts
+++ b/src/commands/hld/pipeline.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   BuildDefinition,

--- a/src/commands/infra/scaffold.test.ts
+++ b/src/commands/infra/scaffold.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 jest.mock("./generate");
 
 import fs from "fs";

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import axios from "axios";
 import fs from "fs";
 import inquirer from "inquirer";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import axios from "axios";
 import commander from "commander";
 import fs from "fs";

--- a/src/commands/project/create-variable-group.ts
+++ b/src/commands/project/create-variable-group.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable @typescript-eslint/camelcase */
+
 import { VariableGroup } from "azure-devops-node-api/interfaces/ReleaseInterfaces";
 import commander from "commander";
 import path from "path";

--- a/src/commands/project/pipeline.test.ts
+++ b/src/commands/project/pipeline.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import * as azdo from "../../lib/azdoClient";
 import { create as createBedrockYaml } from "../../lib/bedrockYaml";
 import { createTempDir } from "../../lib/ioUtil";

--- a/src/commands/service/create-revision.ts
+++ b/src/commands/service/create-revision.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/camelcase */
+
 import commander from "commander";
 import { join } from "path";
 import { Bedrock, Config } from "../../config";

--- a/src/commands/service/pipeline.ts
+++ b/src/commands/service/pipeline.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable @typescript-eslint/camelcase */
+
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import {
   BuildDefinition,

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import path from "path";
 import { readYaml } from "../config";
 import * as config from "../config";

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { IBuildApi } from "azure-devops-node-api/BuildApi";
 import { IGitApi } from "azure-devops-node-api/GitApi";
 import commander from "commander";

--- a/src/lib/azdoClient.test.ts
+++ b/src/lib/azdoClient.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 jest.mock("azure-devops-node-api");
 jest.mock("../config");
 

--- a/src/lib/azure/azurecredentials.test.ts
+++ b/src/lib/azure/azurecredentials.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import * as config from "../../config";
 import { ConfigYaml } from "../../types";

--- a/src/lib/azure/storage.test.ts
+++ b/src/lib/azure/storage.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 // Mocks
 jest.mock("@azure/arm-storage");
 jest.mock("azure-storage");

--- a/src/lib/git/azure.test.ts
+++ b/src/lib/git/azure.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/camelcase */
+
 import { WebApi } from "azure-devops-node-api";
 import uuid from "uuid/v4";
 import { Config } from "../../config";

--- a/src/lib/pipelines/serviceEndpoint.test.ts
+++ b/src/lib/pipelines/serviceEndpoint.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { IRestResponse } from "typed-rest-client";
 import uuid from "uuid/v4";
 import { Config, readYaml } from "../../config";

--- a/src/lib/pipelines/variableGroup.test.ts
+++ b/src/lib/pipelines/variableGroup.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { VariableGroupParameters } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 import uuid from "uuid/v4";
 import * as azdoClient from "../azdoClient";

--- a/src/lib/setup/prompt.test.ts
+++ b/src/lib/setup/prompt.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import fs from "fs";
 import inquirer from "inquirer";
 import os from "os";

--- a/src/lib/validator.test.ts
+++ b/src/lib/validator.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/camelcase */
+
 import path from "path";
 import { Config, loadConfiguration } from "../config";
 import {


### PR DESCRIPTION
Disabling the `@typescript-eslint/camelcase` ESLint rule because we store a lot
of config level objects use underscore case and we are most likely not going to
get away from that.

- Disabled the ESLint `@typescript-eslint/camelcase` rule in `.eslintrc.js`.
- Removed all page-level `@typescript-eslint/camelcase` disable flags.