### PR TITLE
[FEATURE] add exception chain to hld add variable group command

### DIFF
--- a/src/lib/errorStatusCode.ts
+++ b/src/lib/errorStatusCode.ts
@@ -6,5 +6,6 @@ export enum errorStatusCode {
   VALIDATION_ERR = 1001,
   EXE_FLOW_ERR = 1002,
   ENV_SETTING_ERR = 1010,
+  FILE_IO_ERR = 1011,
   GIT_OPS_ERR = 1100,
 }

--- a/src/lib/i18n.json
+++ b/src/lib/i18n.json
@@ -25,6 +25,11 @@
     "infra-err-tf-path-not-found": "Provided Terraform {0} path is invalid or cannot be found: {1}",
     "infra-err-create-scaffold": "Could not create scaffold",
     "infra-err-git-clone-failed": "Could not clone the source remote repository. The remote repo might not exist or you did not have the rights to access it",
-    "infra-git-source-no-exist": "Source path, {0} did not exist."
+    "infra-git-source-no-exist": "Source path, {0} did not exist.",
+
+    "hld-append-var-group-cmd-failed": "HLD Append Variable Group Command was not successfully executed.",
+    "hld-append-var-group-name-missing": "Variable group name was not provided. Provide variable group.",
+
+    "fileutils-append-variable-group-to-pipeline-yaml": "Could not append variable group name to manifest-generation.yaml file in HLD repo. Check this is file exist and if it is YAML format."
   }
 }


### PR DESCRIPTION
closes https://github.com/microsoft/bedrock/issues/1265

also fixed eslint-disable error
also added code to make sure that empty string with spaces are not allowed as variable group name

```
$ ts-node src/index.ts hld avg " "
error:   
code: 1000
message: hld-append-var-group-cmd-failed: HLD Append Variable Group Command was not successfully executed.
  code: 1001
  message: hld-append-var-group-name-missing: Variable group name was not provided. Provide variable group.

$ ts-node src/index.ts hld avg "a"
error:   
code: 1000
message: hld-append-var-group-cmd-failed: HLD Append Variable Group Command was not successfully executed.
  code: 1011
  message: fileutils-append-variable-group-to-pipeline-yaml: Could not append variable group name to manifest-generation.yaml file in HLD repo. Check this is file exist and if it is YAML format.
  details: Unable to load file '/Users/veseah/git/spk/manifest-generation.yaml'
```