### PR TITLE
Fix: Race condition in getRemoteUrl test

### DIFF
--- a/src/commands/service/create-revision.test.ts
+++ b/src/commands/service/create-revision.test.ts
@@ -250,14 +250,11 @@ describe("Create pull request", () => {
 });
 
 describe("test getRemoteUrl function", () => {
-  it("sanity test: get original url", async (done) => {
-    const res = await getRemoteUrl(undefined);
-    expect(!!res.match(/(.*?)\/spk/i)).toBe(true);
-    done();
+  it("sanity test: get original url", () => {
+    expect(getRemoteUrl(undefined)).resolves.toMatch(/(.*?)\/spk/i);
   });
-  it("sanity test", async (done) => {
-    const res = await getRemoteUrl("https://github.com/CatalystCode/spk1");
-    expect(res).toBe("https://github.com/CatalystCode/spk1");
-    done();
+  it("sanity test", () => {
+    const url = "https://github.com/CatalystCode/spk1";
+    expect(getRemoteUrl(url)).resolves.toBe(url);
   });
 });


### PR DESCRIPTION
- Removed a race condition for the `getRemoteUrl` tests caused by the test
  functions being both `async` as well as using a `done` callback.