### PR TITLE
[FEATURE] Add specific error code for spk init command

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,12 @@ import {
   saveConfiguration,
 } from "../config";
 import { build as buildCmd, exit as exitCmd } from "../lib/commandBuilder";
+import {
+  build as buildError,
+  log as logError,
+  build,
+} from "../lib/errorBuilder";
+import { errorStatusCode } from "../lib/errorStatusCode";
 import * as promptBuilder from "../lib/promptBuilder";
 import { deepClone } from "../lib/util";
 import { hasValue } from "../lib/validator";
@@ -93,8 +99,9 @@ export const validatePersonalAccessToken = async (
   azure: ConfigYaml["azure_devops"]
 ): Promise<boolean> => {
   if (!azure || !azure.org || !azure.project || !azure.access_token) {
-    throw Error(
-      "Unable to validate personal access token because organization, project or access token information were missing"
+    throw buildError(
+      errorStatusCode.ENV_SETTING_ERR,
+      "init_cmd_unable_validate_pat"
     );
   }
   try {
@@ -109,6 +116,7 @@ export const validatePersonalAccessToken = async (
     );
     return res.status === 200;
   } catch (_) {
+    // command does not terminate if pat cannot be verified.
     return false;
   }
 };
@@ -194,13 +202,12 @@ export const execute = async (
 ): Promise<void> => {
   try {
     if (!hasValue(opts.file) && !opts.interactive) {
-      throw new Error(
-        "File that stores configuration is not provided and interactive mode is not turn on"
-      );
+      throw buildError(errorStatusCode.VALIDATION_ERR, "init_cmd_missing_opts");
     }
     if (hasValue(opts.file) && opts.interactive) {
-      throw new Error(
-        "Not supported option while configuration file is provided and interactive mode is turn on"
+      throw buildError(
+        errorStatusCode.VALIDATION_ERR,
+        "init_cmd_both_opts_err"
       );
     }
 
@@ -212,8 +219,7 @@ export const execute = async (
 
     await exitFn(0);
   } catch (err) {
-    logger.error(`Error occurred while initializing`);
-    logger.error(err);
+    logError(buildError(errorStatusCode.CMD_EXE_ERR, "init_cmd_failed", err));
     await exitFn(1);
   }
 };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,11 +10,7 @@ import {
   saveConfiguration,
 } from "../config";
 import { build as buildCmd, exit as exitCmd } from "../lib/commandBuilder";
-import {
-  build as buildError,
-  log as logError,
-  build,
-} from "../lib/errorBuilder";
+import { build as buildError, log as logError } from "../lib/errorBuilder";
 import { errorStatusCode } from "../lib/errorStatusCode";
 import * as promptBuilder from "../lib/promptBuilder";
 import { deepClone } from "../lib/util";

--- a/src/lib/i18n.json
+++ b/src/lib/i18n.json
@@ -17,7 +17,7 @@
   },
   "errors": {
     "init_cmd_failed": "Init command was not successfully executed.",
-    "init_cmd_unable_validate_pat": "Could not validation personal access token because organization, project or access token information were missing. Provide them in config.yaml.",
+    "init_cmd_unable_validate_pat": "Could not validate personal access token because organization, project or access token information were missing. Provide them in config.yaml.",
     "init_cmd_missing_opts": "Could not execute this command because file that stores configuration was not provided and interactive mode was not set. Provide file name or enable interactive mode.",
     "init_cmd_both_opts_err": "Could not execute this command because file that stores configuration was provided and interactive mode was set. Provide file name or enable interactive mode.",
 

--- a/src/lib/i18n.json
+++ b/src/lib/i18n.json
@@ -16,6 +16,11 @@
     "storageKeVaultName": "Enter key vault name (have the value as empty and hit enter key to skip)"
   },
   "errors": {
+    "init_cmd_failed": "Init command was not successfully executed.",
+    "init_cmd_unable_validate_pat": "Could not validation personal access token because organization, project or access token information were missing. Provide them in config.yaml.",
+    "init_cmd_missing_opts": "Could not execute this command because file that stores configuration was not provided and interactive mode was not set. Provide file name or enable interactive mode.",
+    "init_cmd_both_opts_err": "Could not execute this command because file that stores configuration was provided and interactive mode was set. Provide file name or enable interactive mode.",
+
     "setup-cmd-failed": "Setup command was not successfully executed.",
     "setup-cmd-prompt-err-no-subscriptions": "No subscriptions found.",
     "setup-cmd-prompt-err-subscription-missing": "Subscription Identifier was missing.",


### PR DESCRIPTION
closes https://github.com/microsoft/bedrock/issues/1310

e.g.
```
$ spk init 
error:   
code: 1000
message: init_cmd_failed: Init command was not successfully executed.
  code: 1001
  message: init_cmd_missing_opts: Could not execute this command because file that stores configuration was not provided and interactive mode was not set. Provide file name or enable interactive mode.
```