### PR TITLE
Modify how pipelines are verified in the integration tests 

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -301,6 +301,55 @@ function verify_pipeline_with_poll () {
     fi
 }
 
+function verify_pipeline_with_poll_and_source_version () {
+    local pipeline_name=$3
+    poll_timeout=$4
+    poll_interval=$5
+    source_version=$6
+    end=$((SECONDS+$poll_timeout))
+    loop_result="unknown"
+
+    echo "Attempting to verify that the pipeline build for $pipeline_name is successful..."
+    pipeline_result=$(az pipelines build definition show --name $pipeline_name --org $AZDO_ORG_URL --p $AZDO_PROJECT)
+    pipeline_id=$(tr '"\""' '"\\"' <<< "$pipeline_result" | jq .id)
+    echo "$pipeline_name has pipeline id of $pipeline_id"
+
+    build_run_exists=$(az pipelines build list --definition-ids $pipeline_id --org https://dev.azure.com/edaenasj --p spkintegrationtests | jq -r --arg source_version "$source_version" '.[].sourceVersion | select(. == $source_version) != null')
+
+    if [ "$build_run_exists" != "true" ]; then
+        echo "Commit ID $source_version was nof found in pipeline run $pipeline_name."
+        exit 1
+    fi
+
+    while [ $SECONDS -lt $end ]; do
+        pipeline_builds=$(az pipelines build list --definition-ids $pipeline_id --org $1 --p $2)
+
+        # We use grep because of string matching issues
+        echo "Get the build status for build..."
+        pipeline_status=$(tr '"\""' '"\\"' <<< "$pipeline_builds" | jq .[0].status)
+        echo "pipeline: $pipeline_name-$pipeline_id:"
+        echo "pipeline_status this iteration --> $pipeline_status"
+        if [ "$(echo $pipeline_status | grep 'completed')" != "" ]; then
+            pipeline_result=$(tr '"\""' '"\\"' <<< "$pipeline_builds" | jq .[0].result)
+            if [ "$(echo $pipeline_result | grep 'succeeded')" != "" ]; then
+                echo "Successful build for pipeline: $pipeline_name-$pipeline_id!"
+                loop_result=$pipeline_result
+                break
+            else
+                echo "Expected successful build for pipeline: $pipeline_name-$pipeline_id but result is $pipeline_result"
+                exit 1
+            fi
+        else
+        echo "pipeline: $pipeline_name-$pipeline_id status is $pipeline_status. Sleeping for $poll_interval seconds"
+        sleep $poll_interval
+        fi
+    done
+    if [ "$loop_result" = "unknown" ]; then
+        echo "Polling pipeline: $pipeline_name-$pipeline_id timed out after $poll_timeout seconds!"
+        exit 1
+    fi
+}
+
 function validate_file () {
     echo "Validating file $1"
     if grep -q "$2" "$1";

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -314,10 +314,10 @@ function verify_pipeline_with_poll_and_source_version () {
     pipeline_id=$(tr '"\""' '"\\"' <<< "$pipeline_result" | jq .id)
     echo "$pipeline_name has pipeline id of $pipeline_id"
 
-    build_run_exists=$(az pipelines build list --definition-ids $pipeline_id --org https://dev.azure.com/edaenasj --p spkintegrationtests | jq -r --arg source_version "$source_version" '.[].sourceVersion | select(. == $source_version) != null')
+    build_run_exists=$(az pipelines build list --definition-ids $pipeline_id --org $AZDO_ORG_URL --p $AZDO_PROJECT | jq -r --arg source_version "$source_version" '.[].sourceVersion | select(. == $source_version) != null')
 
     if [ "$build_run_exists" != "true" ]; then
-        echo "Commit ID $source_version was nof found in pipeline run $pipeline_name."
+        echo "Commit ID $source_version was not found in pipeline run $pipeline_name."
         exit 1
     fi
 

--- a/tests/validations.sh
+++ b/tests/validations.sh
@@ -364,7 +364,10 @@ verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $lifecycle_pipeline_name 4
 
 # Wait for fabrikam-hld-to-fabrikam-manifests pipeline to finish
 echo "Wait for fabrikam-hld-to-fabrikam-manifests pipeline"
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 500 15 3
+cd $TEST_WORKSPACE/$hld_dir
+git pull
+hld_repo_commit_id=$(git log --format="%H" -n 1)
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 500 15 $hld_repo_commit_id
 ring_name=qa-ring
 
 cd $TEST_WORKSPACE
@@ -379,12 +382,16 @@ git commit -m "Adding test ring"
 git push -u origin --all
 
 # Wait for the lifecycle pipeline to finish and approve the pull request
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $lifecycle_pipeline_name 300 15 2
+mono_repo_commit_id=$(git log --format="%H" -n 1)
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $lifecycle_pipeline_name 300 15 $mono_repo_commit_id
 echo "Finding pull request that $lifecycle_pipeline_name pipeline created..."
 approve_pull_request $AZDO_ORG_URL $AZDO_PROJECT "Reconciling HLD"
 
 # Wait for fabrikam-hld-to-fabrikam-manifests pipeline to finish
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 300 15 4
+cd $TEST_WORKSPACE/$hld_dir
+git pull
+hld_repo_commit_id=$(git log --format="%H" -n 1)
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 300 15 $hld_repo_commit_id
 
 # Verify the file was added in the manifest repository
 cd $TEST_WORKSPACE
@@ -417,16 +424,20 @@ echo "Ring doc" >> ringDoc.md
 git add ringDoc.md
 git commit -m "Adding ring doc file"
 git push --set-upstream origin $ring_name
+mono_repo_commit_id=$(git log --format="%H" -n 1)
 
 # Verify frontend service pipeline run was successful
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $frontend_pipeline_name 300 15 3
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $frontend_pipeline_name 300 15 $mono_repo_commit_id
 #complete merge
 echo "Finding pull request that $frontend_pipeline_name pipeline created..."
 approve_pull_request $AZDO_ORG_URL $AZDO_PROJECT "Updating fabrikam.acme.frontend image tag to qa-ring"
 
 # Wait for fabrikam-hld-to-fabrikam-manifests pipeline to finish
 echo "Wait for hld to fabrikam manifests"
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 400 15 5
+cd $TEST_WORKSPACE/$hld_dir
+git pull
+hld_repo_commit_id=$(git log --format="%H" -n 1)
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 400 15 $hld_repo_commit_id
 
 echo "Validating ring image tag in manifest repo"
 cd $TEST_WORKSPACE/$hld_dir
@@ -451,7 +462,10 @@ echo "Successfully reached the end of the service validations scripts."
 
 # Verify hld to manifest pipeline run was successful, to verify the full end-end capture of
 # introspection data
-verify_pipeline_with_poll $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 300 15 5
+cd $TEST_WORKSPACE/$hld_dir
+git pull
+hld_repo_commit_id=$(git log --format="%H" -n 1)
+verify_pipeline_with_poll_and_source_version $AZDO_ORG_URL $AZDO_PROJECT $hld_to_manifest_pipeline_name 300 15 $hld_repo_commit_id
 
 cd $TEST_WORKSPACE
 cd ..


### PR DESCRIPTION
Use the commit ID instead of the build count to verify if a pipeline was successful